### PR TITLE
- Tuple size limitation

### DIFF
--- a/docsrc/content/abstraction-monoid.fsx
+++ b/docsrc/content/abstraction-monoid.fsx
@@ -57,10 +57,8 @@ From .Net/F#
  -  ``Set<'T>``
  -  ``Map<'T,'U>``
  -  ``TimeSpan`` 
- -  ``'T*'U``
- -  ``'T*'U*'V``
- -  ``'T*'U*'V*'W``
- -  ``'T*'U*'V*'W*'X``
+ -  ``Tuple<*>``
+ -  ``'T1* ... *'Tn``
  -  ``Task<'T>``
  -  ``'T->'Monoid``
  -  ``Async<'T>``

--- a/docsrc/content/abstraction-semigroup.fsx
+++ b/docsrc/content/abstraction-semigroup.fsx
@@ -42,10 +42,8 @@ From .Net/F#
  -  ``Set<'T>``
  -  ``Map<'T,'U>``
  -  ``TimeSpan`` 
- -  ``'T*'U``
- -  ``'T*'U*'V``
- -  ``'T*'U*'V*'W``
- -  ``'T*'U*'V*'W*'X``
+ -  ``Tuple<*>``
+ -  ``'T1* ... *'Tn``
  -  ``Task<'T>``
  -  ``'T->'Semigroup``
  -  ``Async<'T>``

--- a/src/FSharpPlus/Internals.fs
+++ b/src/FSharpPlus/Internals.fs
@@ -7,10 +7,13 @@ type Default3 = class inherit Default4 end
 type Default2 = class inherit Default3 end
 type Default1 = class inherit Default2 end
 
+#nowarn "0042" // retype
+
 module internal Prelude =
     let inline flip f x y = f y x
     let inline const' k _ = k
     let inline tupleToOption x = match x with true, value -> Some value | _ -> None
+    let inline retype (x: 'T) : 'U = (# "" x : 'U #)
 
 
 

--- a/src/FSharpPlus/Monoid.fs
+++ b/src/FSharpPlus/Monoid.fs
@@ -12,6 +12,7 @@ open System.Threading.Tasks
 #endif
 open FSharpPlus
 open FSharpPlus.Internals
+open FSharpPlus.Internals.Prelude
 
 
 [<Extension; Sealed>]
@@ -60,6 +61,19 @@ type Plus with
                     | Choice2Of2 a, Choice2Of2 b -> Choice2Of2 (Plus.Invoke a b)
 
 type Plus with 
+    static member inline ``+`` (x, y, _mthd: Plus)  :'t =
+        let xr, yr = (^t : (member Rest : 'tr) x), (^t : (member Rest : 'tr) y)
+        let x7, y7 = (^t : (member Item7: 't7) x), (^t : (member Item7: 't7) y)
+        let x6, y6 = (^t : (member Item6: 't6) x), (^t : (member Item6: 't6) y)
+        let x5, y5 = (^t : (member Item5: 't5) x), (^t : (member Item5: 't5) y)
+        let x4, y4 = (^t : (member Item4: 't4) x), (^t : (member Item4: 't4) y)
+        let x3, y3 = (^t : (member Item3: 't3) x), (^t : (member Item3: 't3) y)
+        let x2, y2 = (^t : (member Item2: 't2) x), (^t : (member Item2: 't2) y)
+        let x1, y1 = (^t : (member Item1: 't1) x), (^t : (member Item1: 't1) y)
+        Tuple<_,_,_,_,_,_,_,_>(Plus.Invoke x1 y1, Plus.Invoke x2 y2, Plus.Invoke x3 y3, Plus.Invoke x4 y4, Plus.Invoke x5 y5, Plus.Invoke x6 y6, Plus.Invoke x7 y7, Plus.Invoke xr yr) |> retype : 't
+
+    static member inline ``+`` (x1: Tuple<'a>, y1: Tuple<'a>, _mthd: Plus) = Tuple<'a> (Plus.Invoke x1.Item1 y1.Item1) : Tuple<'a>
+type Plus with 
     static member inline ``+`` ((x1,x2         ), (y1,y2         ), [<Optional>]_mthd: Plus) = (Plus.Invoke x1 y1, Plus.Invoke x2 y2                                                         ) :'a*'b
 type Plus with 
     static member inline ``+`` ((x1,x2,x3      ), (y1,y2,y3      ), [<Optional>]_mthd: Plus) = (Plus.Invoke x1 y1, Plus.Invoke x2 y2, Plus.Invoke x3 y3                                      ) :'a*'b*'c
@@ -67,7 +81,12 @@ type Plus with
     static member inline ``+`` ((x1,x2,x3,x4   ), (y1,y2,y3,y4   ), [<Optional>]_mthd: Plus) = (Plus.Invoke x1 y1, Plus.Invoke x2 y2, Plus.Invoke x3 y3, Plus.Invoke x4 y4                   ) :'a*'b*'c*'d
 type Plus with 
     static member inline ``+`` ((x1,x2,x3,x4,x5), (y1,y2,y3,y4,y5), [<Optional>]_mthd: Plus) = (Plus.Invoke x1 y1, Plus.Invoke x2 y2, Plus.Invoke x3 y3, Plus.Invoke x4 y4, Plus.Invoke x5 y5) :'a*'b*'c*'d*'e
-    
+type Plus with 
+    static member inline ``+`` ((x1,x2,x3,x4,x5,x6)   , (y1,y2,y3,y4,y5,y6)   , [<Optional>]_mthd: Plus) = (Plus.Invoke x1 y1, Plus.Invoke x2 y2, Plus.Invoke x3 y3, Plus.Invoke x4 y4, Plus.Invoke x5 y5, Plus.Invoke x6 y6)                    :'a*'b*'c*'d*'e*'f
+type Plus with 
+    static member inline ``+`` ((x1,x2,x3,x4,x5,x6,x7), (y1,y2,y3,y4,y5,y6,y7), [<Optional>]_mthd: Plus) = (Plus.Invoke x1 y1, Plus.Invoke x2 y2, Plus.Invoke x3 y3, Plus.Invoke x4 y4, Plus.Invoke x5 y5, Plus.Invoke x6 y6, Plus.Invoke x7 y7) :'a*'b*'c*'d*'e*'f*'g
+
+
 type Plus with    
     
 #if NET35

--- a/src/FSharpPlus/Numeric.fs
+++ b/src/FSharpPlus/Numeric.fs
@@ -134,7 +134,7 @@ open System.Threading.Tasks
 #endif
 open System.Collections.Generic
 open Microsoft.FSharp.Quotations
-
+open FSharpPlus.Internals.Prelude
 
 
 type Zero =
@@ -161,10 +161,28 @@ type Zero =
         let inline call (a:'a) = call_2 (a, Unchecked.defaultof<'r>) :'r
         call Unchecked.defaultof<Zero>
 
+type Zero with
+    static member inline Zero (t: 't, _:Zero)  :'t =
+        let (tr: 'tr) = if false then (^t : (member Rest : 'tr) t) else Zero.Invoke ()
+        let (t7: 't7) = if false then (^t : (member Item7: 't7) t) else Zero.Invoke ()
+        let (t6: 't6) = if false then (^t : (member Item6: 't6) t) else Zero.Invoke ()
+        let (t5: 't5) = if false then (^t : (member Item5: 't5) t) else Zero.Invoke ()
+        let (t4: 't4) = if false then (^t : (member Item4: 't4) t) else Zero.Invoke ()
+        let (t3: 't3) = if false then (^t : (member Item3: 't3) t) else Zero.Invoke ()
+        let (t2: 't2) = if false then (^t : (member Item2: 't2) t) else Zero.Invoke ()
+        let (t1: 't1) = if false then (^t : (member Item1: 't1) t) else Zero.Invoke ()
+        Tuple<_,_,_,_,_,_,_,_>(t1, t2, t3, t4, t5, t6, t7, tr) |> retype : 't
+
+type Zero with
+    static member inline Zero (_: Tuple<'a>, _:Zero) = Tuple<_> (Zero.Invoke ()) : Tuple<'a>
+    static member inline Zero (_: Id<'a>   , _:Zero) = Id<_>    (Zero.Invoke ())
+    
 type Zero with static member inline Zero (_ : 'a*'b         , _:Zero) = (Zero.Invoke(), Zero.Invoke()                                             ): 'a*'b
 type Zero with static member inline Zero (_ : 'a*'b*'c      , _:Zero) = (Zero.Invoke(), Zero.Invoke(), Zero.Invoke()                              ): 'a*'b*'c
 type Zero with static member inline Zero (_ : 'a*'b*'c*'d   , _:Zero) = (Zero.Invoke(), Zero.Invoke(), Zero.Invoke(), Zero.Invoke()               ): 'a*'b*'c*'d
 type Zero with static member inline Zero (_ : 'a*'b*'c*'d*'e, _:Zero) = (Zero.Invoke(), Zero.Invoke(), Zero.Invoke(), Zero.Invoke(), Zero.Invoke()): 'a*'b*'c*'d*'e
+type Zero with static member inline Zero (_: 'a*'b*'c*'d*'e*'f   , _:Zero) = (Zero.Invoke (), Zero.Invoke (), Zero.Invoke (), Zero.Invoke (), Zero.Invoke (), Zero.Invoke ()                ): 'a*'b*'c*'d*'e*'f
+type Zero with static member inline Zero (_: 'a*'b*'c*'d*'e*'f*'g, _:Zero) = (Zero.Invoke (), Zero.Invoke (), Zero.Invoke (), Zero.Invoke (), Zero.Invoke (), Zero.Invoke (), Zero.Invoke ()): 'a*'b*'c*'d*'e*'f*'g
 
 #if NET35
 #else
@@ -479,6 +497,7 @@ type Sqrt with
 // Bounded class ----------------------------------------------------------
 
 open System
+open FSharpPlus.Internals.Prelude
 // TODO: can we have a (working) default ? It's a field, maybe we should call to a property.
 
 type MinValue =
@@ -505,13 +524,26 @@ type MinValue =
         let inline call (a:'a) = call_2 (a, Unchecked.defaultof<'r>) :'r
         call Unchecked.defaultof<MinValue>
 
+    static member inline MinValue (t: 't, _:MinValue) :'t =
+        let (tr: 'tr) = if false then (^t : (member Rest : 'tr) t) else MinValue.Invoke ()
+        let (t7: 't7) = if false then (^t : (member Item7: 't7) t) else MinValue.Invoke ()
+        let (t6: 't6) = if false then (^t : (member Item6: 't6) t) else MinValue.Invoke ()
+        let (t5: 't5) = if false then (^t : (member Item5: 't5) t) else MinValue.Invoke ()
+        let (t4: 't4) = if false then (^t : (member Item4: 't4) t) else MinValue.Invoke ()
+        let (t3: 't3) = if false then (^t : (member Item3: 't3) t) else MinValue.Invoke ()
+        let (t2: 't2) = if false then (^t : (member Item2: 't2) t) else MinValue.Invoke ()
+        let (t1: 't1) = if false then (^t : (member Item1: 't1) t) else MinValue.Invoke ()
+        Tuple<_,_,_,_,_,_,_,_>(t1, t2, t3, t4, t5, t6, t7, tr) |> retype : 't
+
+    static member inline MinValue (_: Tuple<'a>, _:MinValue) = Tuple<_> (MinValue.Invoke ()) : Tuple<'a>
+    static member inline MinValue (_: Id<'a>   , _:MinValue) = Id<_>    (MinValue.Invoke ())
+
     static member inline MinValue ((_:'a*'b                  ), _:MinValue) = (MinValue.Invoke(), MinValue.Invoke())
     static member inline MinValue ((_:'a*'b*'c               ), _:MinValue) = (MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke())
     static member inline MinValue ((_:'a*'b*'c*'d            ), _:MinValue) = (MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke())
     static member inline MinValue ((_:'a*'b*'c*'d*'e         ), _:MinValue) = (MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke())
     static member inline MinValue ((_:'a*'b*'c*'d*'e*'f      ), _:MinValue) = (MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke())
     static member inline MinValue ((_:'a*'b*'c*'d*'e*'f*'g   ), _:MinValue) = (MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke())
-    static member inline MinValue ((_:'a*'b*'c*'d*'e*'f*'g*'h), _:MinValue) = (MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke())
 
 type MaxValue =
     static member MaxValue (_:unit          , _:MaxValue) = ()
@@ -537,10 +569,23 @@ type MaxValue =
         let inline call (a:'a) = call_2 (a, Unchecked.defaultof<'r>) :'r
         call Unchecked.defaultof<MaxValue>
 
+    static member inline MaxValue (t: 't, _:MaxValue) :'t =
+        let (tr: 'tr) = if false then (^t : (member Rest : 'tr) t) else MaxValue.Invoke ()
+        let (t7: 't7) = if false then (^t : (member Item7: 't7) t) else MaxValue.Invoke ()
+        let (t6: 't6) = if false then (^t : (member Item6: 't6) t) else MaxValue.Invoke ()
+        let (t5: 't5) = if false then (^t : (member Item5: 't5) t) else MaxValue.Invoke ()
+        let (t4: 't4) = if false then (^t : (member Item4: 't4) t) else MaxValue.Invoke ()
+        let (t3: 't3) = if false then (^t : (member Item3: 't3) t) else MaxValue.Invoke ()
+        let (t2: 't2) = if false then (^t : (member Item2: 't2) t) else MaxValue.Invoke ()
+        let (t1: 't1) = if false then (^t : (member Item1: 't1) t) else MaxValue.Invoke ()
+        Tuple<_,_,_,_,_,_,_,_>(t1, t2, t3, t4, t5, t6, t7, tr) |> retype : 't
+
+    static member inline MaxValue (_: Tuple<'a>, _:MaxValue) = Tuple<_> (MaxValue.Invoke ()) : Tuple<'a>
+    static member inline MaxValue (_: Id<'a>   , _:MaxValue) = Id<_>    (MaxValue.Invoke ())
+
     static member inline MaxValue ((_:'a*'b                  ), _:MaxValue) = (MaxValue.Invoke(), MaxValue.Invoke())
     static member inline MaxValue ((_:'a*'b*'c               ), _:MaxValue) = (MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke())
     static member inline MaxValue ((_:'a*'b*'c*'d            ), _:MaxValue) = (MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke())
     static member inline MaxValue ((_:'a*'b*'c*'d*'e         ), _:MaxValue) = (MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke())
     static member inline MaxValue ((_:'a*'b*'c*'d*'e*'f      ), _:MaxValue) = (MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke())
     static member inline MaxValue ((_:'a*'b*'c*'d*'e*'f*'g   ), _:MaxValue) = (MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke())
-    static member inline MaxValue ((_:'a*'b*'c*'d*'e*'f*'g*'h), _:MaxValue) = (MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke())

--- a/src/FSharpPlus/Operators.fs
+++ b/src/FSharpPlus/Operators.fs
@@ -452,7 +452,7 @@ module Operators =
     let inline mapItem2 mapping tuple = MapItem2.Invoke mapping tuple
     let inline mapItem3 mapping tuple = MapItem3.Invoke mapping tuple
     let inline mapItem4 mapping tuple = MapItem4.Invoke mapping tuple
-    let        mapItem5 mapping tuple = MapItem5.MapItem5 (tuple, mapping)
+    let inline mapItem5 mapping tuple = MapItem5.Invoke mapping tuple
     
     
     

--- a/src/FSharpPlus/Tuple.fs
+++ b/src/FSharpPlus/Tuple.fs
@@ -8,95 +8,132 @@ open FSharpPlus.Internals
 
 
 type Item1 =
-    static member Item1 ((a, _, _, _, _)) = a
-    static member Item1 ((a, _, _, _)   ) = a
-    static member Item1 ((a, _, _)      ) = a
-    static member Item1 ((a, _)         ) = a
-
-    static member inline Invoke value = 
-        let inline call_2 (_:^a, b:^b) = ((^a or ^b) : (static member Item1: _ -> _) b)
-        let inline call (a:'a, b:'b) = call_2 (a, b)
-        call (Unchecked.defaultof<Item1> , value)
+    static member inline Invoke value = (^t : (member Item1: _) value)
 
 type Item2 =
-    static member Item2 ((_, b, _, _, _)) = b
-    static member Item2 ((_, b, _, _)   ) = b
-    static member Item2 ((_, b, _)      ) = b
-    static member Item2 ((_, b)         ) = b
-
-    static member inline Invoke value = 
-        let inline call_2 (_:^a, b:^b) = ((^a or ^b) : (static member Item2: _ -> _) b)
-        let inline call (a:'a, b:'b) = call_2 (a, b)
-        call (Unchecked.defaultof<Item2> , value)
+    static member inline Invoke value = (^t : (member Item2: _) value)
 
 type Item3 =
-    static member Item3 ((_, _, c, _, _)) = c
-    static member Item3 ((_, _, c, _)   ) = c
-    static member Item3 ((_, _, c)      ) = c
-
-    static member inline Invoke value = 
-        let inline call_2 (_:^a, b:^b) = ((^a or ^b) : (static member Item3: _ -> _) b)
-        let inline call (a:'a, b:'b) = call_2 (a, b)
-        call (Unchecked.defaultof<Item3> , value)
+    static member inline Invoke value = (^t : (member Item3: _) value)
 
 type Item4 =
-    static member Item4 ((_, _, _, d, _)) = d
-    static member Item4 ((_, _, _, d)   ) = d
-
-    static member inline Invoke value = 
-        let inline call_2 (_:^a, b:^b) = ((^a or ^b) : (static member Item4: _ -> _) b)
-        let inline call (a:'a, b:'b) = call_2 (a, b)
-        call (Unchecked.defaultof<Item4> , value)
+    static member inline Invoke value = (^t : (member Item4: _) value)
 
 type Item5 =
-    static member Item5 ((_, _, _, _, e)) = e
-
-    static member inline Invoke value = 
-        let inline call_2 (_:^a, b:^b) = ((^a or ^b) : (static member Item5: _ -> _) b)
-        let inline call (a:'a, b:'b) = call_2 (a, b)
-        call (Unchecked.defaultof<Item5> , value)
+    static member inline Invoke value = (^t : (member Item5: _) value)
 
 
 type MapItem1 =   
-    static member MapItem1 ((a, b, c, d, e)         , fn) = (fn a, b, c, d, e)
-    static member MapItem1 ((a, b, c, d)            , fn) = (fn a, b, c, d)      
-    static member MapItem1 ((a, b, c)               , fn) = (fn a, b, c)         
-    static member MapItem1 ((a, b)                  , fn) = (fn a, b)
+    static member inline MapItem1 (t: 't, fn) =
+        let xr = (^t : (member Rest : 'tr) t)
+        let x7 = (^t : (member Item7: 't7) t)
+        let x6 = (^t : (member Item6: 't6) t)
+        let x5 = (^t : (member Item5: 't5) t)
+        let x4 = (^t : (member Item4: 't4) t)
+        let x3 = (^t : (member Item3: 't3) t)
+        let x2 = (^t : (member Item2: 't2) t)
+        let x1 = (^t : (member Item1: 't1) t)
+        Tuple<_,_,_,_,_,_,_,_> (fn x1, x2, x3, x4, x5, x6, x7, xr)
+
+    static member MapItem1 (a: Tuple<_>          , fn) = Tuple<_> (fn a.Item1)
+    static member MapItem1 ((a, b)               , fn) = (fn a, b)
+    static member MapItem1 ((a, b, c)            , fn) = (fn a, b, c)
+    static member MapItem1 ((a, b, c, d)         , fn) = (fn a, b, c, d)
+    static member MapItem1 ((a, b, c, d, e)      , fn) = (fn a, b, c, d, e)
+    static member MapItem1 ((a, b, c, d, e, f)   , fn) = (fn a, b, c, d, e, f)
+    static member MapItem1 ((a, b, c, d, e, f, g), fn) = (fn a, b, c, d, e, f, g)
 
     static member inline Invoke f value = 
         let inline call_2 (_:^a, b:^b) = ((^a or ^b) : (static member MapItem1: _ * _ -> _) b, f)
         let inline call   (a:'a, b:'b) = call_2 (a, b)
         call (Unchecked.defaultof<MapItem1> , value)
 
-type MapItem2 =
-    static member MapItem2 ((a, b, c, d, e)         , fn) = (a, fn b, c, d, e)
-    static member MapItem2 ((a, b, c, d)            , fn) = (a, fn b, c, d)      
-    static member MapItem2 ((a, b, c)               , fn) = (a, fn b, c)         
-    static member MapItem2 ((a, b)                  , fn) = (a, fn b)            
+type MapItem2 =   
+    static member inline MapItem2 (t: 't, fn) =
+        let xr = (^t : (member Rest : 'tr) t)
+        let x7 = (^t : (member Item7: 't7) t)
+        let x6 = (^t : (member Item6: 't6) t)
+        let x5 = (^t : (member Item5: 't5) t)
+        let x4 = (^t : (member Item4: 't4) t)
+        let x3 = (^t : (member Item3: 't3) t)
+        let x2 = (^t : (member Item2: 't2) t)
+        let x1 = (^t : (member Item1: 't1) t)
+        Tuple<_,_,_,_,_,_,_,_> (x1, fn x2, x3, x4, x5, x6, x7, xr)
+
+    static member MapItem2 ((a, b)               , fn) = (a, fn b)
+    static member MapItem2 ((a, b, c)            , fn) = (a, fn b, c)
+    static member MapItem2 ((a, b, c, d)         , fn) = (a, fn b, c, d)
+    static member MapItem2 ((a, b, c, d, e)      , fn) = (a, fn b, c, d, e)
+    static member MapItem2 ((a, b, c, d, e, f)   , fn) = (a, fn b, c, d, e, f)
+    static member MapItem2 ((a, b, c, d, e, f, g), fn) = (a, fn b, c, d, e, f, g)
 
     static member inline Invoke f value = 
         let inline call_2 (_:^a, b:^b) = ((^a or ^b) : (static member MapItem2: _ * _ -> _) b, f)
         let inline call   (a:'a, b:'b) = call_2 (a, b)
         call (Unchecked.defaultof<MapItem2> , value)
 
-type MapItem3 =
-    static member MapItem3 ((a, b, c, d, e)         , fn) = (a, b, fn c, d, e)
-    static member MapItem3 ((a, b, c, d)            , fn) = (a, b, fn c, d)      
-    static member MapItem3 ((a, b, c)               , fn) = (a, b, fn c)
+type MapItem3 =   
+    static member inline MapItem3 (t: 't, fn) =
+        let xr = (^t : (member Rest : 'tr) t)
+        let x7 = (^t : (member Item7: 't7) t)
+        let x6 = (^t : (member Item6: 't6) t)
+        let x5 = (^t : (member Item5: 't5) t)
+        let x4 = (^t : (member Item4: 't4) t)
+        let x3 = (^t : (member Item3: 't3) t)
+        let x2 = (^t : (member Item2: 't2) t)
+        let x1 = (^t : (member Item1: 't1) t)
+        Tuple<_,_,_,_,_,_,_,_>(x1, x2, fn x3, x4, x5, x6, x7, xr)
+
+    static member MapItem3 ((a, b, c)            , fn) = (a, b, fn c)
+    static member MapItem3 ((a, b, c, d)         , fn) = (a, b, fn c, d)
+    static member MapItem3 ((a, b, c, d, e)      , fn) = (a, b, fn c, d, e)
+    static member MapItem3 ((a, b, c, d, e, f)   , fn) = (a, b, fn c, d, e, f)
+    static member MapItem3 ((a, b, c, d, e, f, g), fn) = (a, b, fn c, d, e, f, g)
 
     static member inline Invoke f value = 
         let inline call_2 (_:^a, b:^b) = ((^a or ^b) : (static member MapItem3: _ * _ -> _) b, f)
         let inline call   (a:'a, b:'b) = call_2 (a, b)
         call (Unchecked.defaultof<MapItem3> , value)
 
-type MapItem4 =  
-    static member MapItem4 ((a, b, c, d, e), fn) = (a, b, c, fn d, e)
-    static member MapItem4 ((a, b, c, d)   , fn) = (a, b, c, fn d)
+type MapItem4 =   
+    static member inline MapItem4 (t: 't, fn) =
+        let xr = (^t : (member Rest : 'tr) t)
+        let x7 = (^t : (member Item7: 't7) t)
+        let x6 = (^t : (member Item6: 't6) t)
+        let x5 = (^t : (member Item5: 't5) t)
+        let x4 = (^t : (member Item4: 't4) t)
+        let x3 = (^t : (member Item3: 't3) t)
+        let x2 = (^t : (member Item2: 't2) t)
+        let x1 = (^t : (member Item1: 't1) t)
+        Tuple<_,_,_,_,_,_,_,_>(x1, x2, x3, fn x4, x5, x6, x7, xr)
 
-    static member inline Invoke f value =
+    static member MapItem4 ((a, b, c, d)         , fn) = (a, b, c, fn d)
+    static member MapItem4 ((a, b, c, d, e)      , fn) = (a, b, c, fn d, e)
+    static member MapItem4 ((a, b, c, d, e, f)   , fn) = (a, b, c, fn d, e, f)
+    static member MapItem4 ((a, b, c, d, e, f, g), fn) = (a, b, c, fn d, e, f, g)
+
+    static member inline Invoke f value = 
         let inline call_2 (_:^a, b:^b) = ((^a or ^b) : (static member MapItem4: _ * _ -> _) b, f)
         let inline call   (a:'a, b:'b) = call_2 (a, b)
         call (Unchecked.defaultof<MapItem4> , value)
 
-type MapItem5 =
-    static member MapItem5 ((a, b, c, d, e), fn) = (a, b, c, d, fn e)
+type MapItem5 =   
+    static member inline MapItem5 (t: 't, fn) =
+        let xr = (^t : (member Rest : 'tr) t)
+        let x7 = (^t : (member Item7: 't7) t)
+        let x6 = (^t : (member Item6: 't6) t)
+        let x5 = (^t : (member Item5: 't5) t)
+        let x4 = (^t : (member Item4: 't4) t)
+        let x3 = (^t : (member Item3: 't3) t)
+        let x2 = (^t : (member Item2: 't2) t)
+        let x1 = (^t : (member Item1: 't1) t)
+        Tuple<_,_,_,_,_,_,_,_>(x1, x2, x3, x4, fn x5, x6, x7, xr)
+
+    static member MapItem5 ((a, b, c, d, e)      , fn) = (a, b, c, d, fn e)
+    static member MapItem5 ((a, b, c, d, e, f)   , fn) = (a, b, c, d, fn e, f)
+    static member MapItem5 ((a, b, c, d, e, f, g), fn) = (a, b, c, d, fn e, f, g)
+
+    static member inline Invoke f value = 
+        let inline call_2 (_:^a, b:^b) = ((^a or ^b) : (static member MapItem5: _ * _ -> _) b, f)
+        let inline call   (a:'a, b:'b) = call_2 (a, b)
+        call (Unchecked.defaultof<MapItem5> , value)

--- a/tests/FSharpPlus.Tests/General.fs
+++ b/tests/FSharpPlus.Tests/General.fs
@@ -234,6 +234,8 @@ module Monoid =
         let lzy2 = plus (zero) lzy1
         let asy1 = plus (async.Return [1]) (async.Return [2;3])
         let asy2 = plus (zero) asy1
+        let bigNestedTuple1 = (1, System.Tuple (8, "ff",3,4,5,6,7,8,9,10,11,12,(),14,15,16,17,18,19,20)) ++ (2, System.Tuple (8, "ff",3,4,5,6,7,8,9,10,11,12,(),14,15,16,17,18,19,20)) ++ (3, System.Tuple (8, "ff",3,4,5,6,7,8,9,10,11,12,(),14,15,16,17,18,19,20))
+        let bigNestedTuple2 = (1, System.Tuple (8, "ff",3,4,5,6,7,8,9,10,11,12,(),14,15,16,17,18,19,20)) ++ (zero, System.Tuple (8, "ff",3,4,5,6,7,8,9,10,11,12,(),14,15,16,17,18,19,20)) ++ zero
 
         let mapA = Map.empty 
                     |> Map.add 1 (async.Return "Hey")
@@ -1222,6 +1224,8 @@ module Numerics =
         let res17 = abs' argComplex    
         let res18 = abs' argComplex32  
         let res19 = abs' argBigRational
+
+        let (res20: int * char * int * char * int * char * int * char * int * char) = maxValue
 
         Assert.AreEqual(res09 * res19, argBigRational)
 

--- a/tests/FSharpPlus.Tests/Lens.fs
+++ b/tests/FSharpPlus.Tests/Lens.fs
@@ -6,6 +6,13 @@ open FSharpPlus.Lens
 open NUnit.Framework
 open FsCheck
 open Helpers
+
+
+[<Test>]
+let simple_lens() =
+  areEqual 1 (view _1 (1, '2'))
+  areEqual 2 (view _2 ('1', 2))
+
 [<Test>]
 let ok_prism() =
   areEqual (None) (preview _Ok (Error 1))


### PR DESCRIPTION
This removes tuple size limitation.
It also makes available the overloads for both syntactic and system tuples.

The only limitation is for lenses, because MapItemX functions will start returning system tuples for tuples of size greater than 7, when writing.

This is due a wart in the current design of the F# compiler, which only converts tuples when size is less than 8.