### PR TITLE
Fix AppVeyor build, add tests results uploading and build version patching.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,8 @@ image: Visual Studio 2017
 init:
   - git config --global core.autocrlf input
 build_script:
-  - cmd: build.cmd All
+  - cmd: build.cmd RunTests
 test: off
-version: 0.0.1.{build}
 artifacts:
   - path: bin
     name: bin

--- a/build.fsx
+++ b/build.fsx
@@ -68,6 +68,10 @@ let gitRaw = environVarOrDefault "gitRaw" "https://raw.github.com/fsprojects"
 // Read additional information from the release notes document
 let release = LoadReleaseNotes "RELEASE_NOTES.md"
 
+// Patch build version if on AppVeyor
+if BuildServerHelper.buildServer = AppVeyor then
+    AppVeyor.UpdateBuildVersion  (release.AssemblyVersion + "." + AppVeyor.AppVeyorEnvironment.BuildNumber)
+
 // Helper active pattern for project types
 let (|Fsproj|Csproj|Vbproj|Shproj|) (projFileName:string) =
     match projFileName with
@@ -164,6 +168,10 @@ Target "RunTests" (fun _ ->
             DisableShadowCopy = true
             TimeOut = TimeSpan.FromMinutes 20.
             OutputFile = "TestResults.xml" })
+
+    // Import test result file if on AppVeyor
+    if BuildServerHelper.buildServer = AppVeyor then
+        AppVeyor.UploadTestResultsFile AppVeyor.TestResultsType.NUnit "TestResults.xml"
 )
 
 


### PR DESCRIPTION
I didn't manage to make the documentation generation run on AppVeyor, but even building and running tests on a Windows box seems beneficial.

@gusty , if you decide to merge that can you take care of turning on the AppVeyor build and adding the badge to the readme?

Link to passing build on my AppVeyor account:
https://ci.appveyor.com/project/gdziadkiewicz/fsharpplus/builds/19799286