### PR TITLE
Add polyvariadic memoization

### DIFF
--- a/src/FSharpPlus/FSharpPlus.fsproj
+++ b/src/FSharpPlus/FSharpPlus.fsproj
@@ -67,6 +67,7 @@
     <Compile Include="DList.fs" />
     <Compile Include="Validations.fs" />
     <Compile Include="Kleisli.fs" />
+    <Compile Include="Memoization.fs" />
     <None Include="Samples\Collections.fsx" />
     <None Include="Samples\Split-Join.fsx" />
     <None Include="Samples\Conversions.fsx" />

--- a/src/FSharpPlus/Memoization.fs
+++ b/src/FSharpPlus/Memoization.fs
@@ -7,16 +7,20 @@ module Memoization =
     // From https://gist.github.com/gusty/70e5af737f2f6aed2bc0303a2e17c7d7
 
     open System.Collections.Concurrent
-  
+
     // Key wrapper to allow null values, since dict keys can't be null
     [<Struct>]
     type MemoizationKeyWrapper<'a> = MemoizationKeyWrapper of 'a
 
-    type T = T with static member getOrAdd (cd:ConcurrentDictionary<MemoizationKeyWrapper<'a>,'b>) (f:'a -> 'b) k = 
-      cd.GetOrAdd (MemoizationKeyWrapper k, (fun (MemoizationKeyWrapper x) -> x) >> f)
+    type MemoizeConcurrentHelper = MemoizeConcurrentHelper with
+        static member getOrAdd (cd:ConcurrentDictionary<MemoizationKeyWrapper<'a>,'b>) (f:'a -> 'b) k =
+            cd.GetOrAdd (MemoizationKeyWrapper k, (fun (MemoizationKeyWrapper x) -> x) >> f)
 
-    let inline memoize (f:'``(T1 -> T2 -> ... -> Tn)``): '``(T1 -> T2 -> ... -> Tn)`` = (T $ Unchecked.defaultof<'``(T1 -> T2 -> ... -> Tn)``>) f
+    let inline memoize (f:'``(T1 -> T2 -> ... -> Tn)``): '``(T1 -> T2 -> ... -> Tn)`` =
+        (MemoizeConcurrentHelper $ Unchecked.defaultof<'``(T1 -> T2 -> ... -> Tn)``>) f
 
-    type T with     
-        static member        ($) (_:obj,  _: 'a -> 'b) = T.getOrAdd (ConcurrentDictionary ())
-        static member inline ($) (T, _:'t -> 'a -> 'b) = T.getOrAdd (ConcurrentDictionary ()) << (<<) memoize
+    type MemoizeConcurrentHelper with
+        static member ($) (_:obj,  _: 'a -> 'b) =
+            MemoizeConcurrentHelper.getOrAdd (ConcurrentDictionary ())
+        static member inline ($) (MemoizeConcurrentHelper, _:'t -> 'a -> 'b) =
+            MemoizeConcurrentHelper.getOrAdd (ConcurrentDictionary ()) << (<<) memoize

--- a/src/FSharpPlus/Memoization.fs
+++ b/src/FSharpPlus/Memoization.fs
@@ -8,10 +8,15 @@ module Memoization =
 
     open System.Collections.Concurrent
   
-    type T = T with static member getOrAdd (cd:ConcurrentDictionary<_,'t>) (f:_ -> _) k = cd.GetOrAdd (k, f)
-  
+    // Key wrapper to allow null values, since dict keys can't be null
+    [<Struct>]
+    type MemoizationKeyWrapper<'a> = MemoizationKeyWrapper of 'a
+
+    type T = T with static member getOrAdd (cd:ConcurrentDictionary<MemoizationKeyWrapper<'a>,'b>) (f:'a -> 'b) k = 
+      cd.GetOrAdd (MemoizationKeyWrapper k, (fun (MemoizationKeyWrapper x) -> x) >> f)
+
     let inline memoize (f:'``(T1 -> T2 -> ... -> Tn)``): '``(T1 -> T2 -> ... -> Tn)`` = (T $ Unchecked.defaultof<'``(T1 -> T2 -> ... -> Tn)``>) f
-  
+
     type T with     
         static member        ($) (_:obj,  _: 'a -> 'b) = T.getOrAdd (ConcurrentDictionary ())
         static member inline ($) (T, _:'t -> 'a -> 'b) = T.getOrAdd (ConcurrentDictionary ()) << (<<) memoize

--- a/src/FSharpPlus/Memoization.fs
+++ b/src/FSharpPlus/Memoization.fs
@@ -1,0 +1,17 @@
+﻿namespace FSharpPlus
+
+
+[<AutoOpen>]
+module Memoization =
+
+    // From https://gist.github.com/gusty/70e5af737f2f6aed2bc0303a2e17c7d7
+
+    open System.Collections.Concurrent
+  
+    type T = T with static member getOrAdd (cd:ConcurrentDictionary<_,'t>) (f:_ -> _) k = cd.GetOrAdd (k, f)
+  
+    let inline memoize (f:'``(T1 -> T2 -> ... -> Tn)``): '``(T1 -> T2 -> ... -> Tn)`` = (T $ Unchecked.defaultof<'``(T1 -> T2 -> ... -> Tn)``>) f
+  
+    type T with     
+        static member        ($) (_:obj,  _: 'a -> 'b) = T.getOrAdd (ConcurrentDictionary ())
+        static member inline ($) (T, _:'t -> 'a -> 'b) = T.getOrAdd (ConcurrentDictionary ()) << (<<) memoize

--- a/tests/FSharpPlus.Tests/General.fs
+++ b/tests/FSharpPlus.Tests/General.fs
@@ -1584,6 +1584,49 @@ module ApplicativeInference =
 
 
 
+
+
+module Memoization =
+
+    [<Test>]
+    let memoization () =
+        let effs = ResizeArray ()
+
+        let f x                       = printfn "calculating"; effs.Add "f"; string x
+        let g x (y:string) z : uint32 = printfn "calculating"; effs.Add "g"; uint32 (x * int y + int z)
+        let h x y z                   = printfn "calculating"; effs.Add "h"; new System.DateTime (x, y, z)
+        let sum2 (a:int)       = printfn "calculating"; effs.Add "sum2"; (+) a
+        let sum3 a (b:int) c   = printfn "calculating"; effs.Add "sum3"; a + b + c
+        let sum4 a b c d : int = printfn "calculating"; effs.Add "sum4"; a + b + c + d
+
+        // memoize them
+        let msum2 = memoize sum2
+        let msum3 = memoize sum3
+        let msum4 = memoize sum4
+        let mf    = memoize f
+        let mg    = memoize g
+        let mh    = memoize h
+
+        // check memoization really happens
+        let v1  = msum2 1 1
+        let v2  = msum2 1 1
+        let v3  = msum2 2 1
+        let v4  = msum3 1 2 3
+        let v5  = msum3 1 2 3
+        let v6  = msum4 3 1 2 3
+        let v7  = msum4 3 1 2 3
+        let v8  = msum4 3 5 2 3
+        let v9  = mf 3M
+        let v10 = mf 3M
+        let v11 = mg 4 "2" 3M
+        let v12 = mg 4 "2" 3M
+        let v13 = mh 2010 1 1
+        let v14 = mh 2010 1 1
+
+        Assert.AreEqual(effs.ToArray(), [|"sum2"; "sum2"; "sum3"; "sum4"; "sum4"; "f"; "g"; "h"|])
+
+
+
 // Old code, no longer used but still interesting to see if it still compiles
 
 module Ratio =

--- a/tests/FSharpPlus.Tests/General.fs
+++ b/tests/FSharpPlus.Tests/General.fs
@@ -1626,6 +1626,14 @@ module Memoization =
         Assert.AreEqual(effs.ToArray(), [|"sum2"; "sum2"; "sum3"; "sum4"; "sum4"; "f"; "g"; "h"|])
 
 
+    [<Test>]
+    let memoizeAcceptsNullArgument () =
+        let f x y = ""
+        let mf = memoize f
+        let _ = mf null null  // should not throw
+        ()
+
+
 
 // Old code, no longer used but still interesting to see if it still compiles
 


### PR DESCRIPTION
Fixes #88 

Note that I tried making the helper type `T` private, but found no way to make it compile. We might consider giving it an awful name that is less likely to collide with anything user-defined.