### PR TITLE
Preparing for compiler test suite

### DIFF
--- a/src/FSharpPlus.Samples/FSharpPlus.Samples.fsproj
+++ b/src/FSharpPlus.Samples/FSharpPlus.Samples.fsproj
@@ -1,4 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup Condition="'$(CompilerTest)' == 'true'">
+    <FscToolPath>$(FSC_ToolPathCompilerBuild)</FscToolPath>
+    <FscToolExe>$(FSC_ExePathCompilerBuild)</FscToolExe>
+  </PropertyGroup>
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/FSharpPlus/FSharpPlus.fsproj
+++ b/src/FSharpPlus/FSharpPlus.fsproj
@@ -1,5 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup Condition="'$(CompilerTest)' == 'true'">
+    <FscToolPath>$(FSC_ToolPathCompilerBuild)</FscToolPath>
+    <FscToolExe>$(FSC_ExePathCompilerBuild)</FscToolExe>
+  </PropertyGroup>
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     <Title>FSharpPlus</Title>

--- a/tests/FSharpPlus.Tests/FSharpPlus.Tests.fsproj
+++ b/tests/FSharpPlus.Tests/FSharpPlus.Tests.fsproj
@@ -1,5 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup Condition="'$(CompilerTest)' == 'true'">
+    <FscToolPath>$(FSC_ToolPathCompilerBuild)</FscToolPath>
+    <FscToolExe>$(FSC_ExePathCompilerBuild)</FscToolExe>
+  </PropertyGroup>
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>


### PR DESCRIPTION
This allows overriding the paths for locating F# compiler, SDK mainly used for the F# compiler to build F#+ with a freshly built "experimental" compiler (with overriding the used msbuild properties here).