### PR TITLE
Reimplemented union on dictionaries and maps for performance improvem…

### DIFF
--- a/src/FSharpPlus/Extensions.fs
+++ b/src/FSharpPlus/Extensions.fs
@@ -378,14 +378,7 @@ module Map =
 
     /// Returns the union of two maps, preferring values from the first in case of duplicate keys.
     let union (source: Map<'Key, 'T>) (altSource: Map<'Key, 'T>) = 
-        Enumerable
-          .Union(
-            source, 
-            altSource,
-            { new IEqualityComparer<KeyValuePair<'Key,'T>> with 
-                      member __.Equals ((a:KeyValuePair<'Key,'T>),(b:KeyValuePair<'Key,'T>)) : bool = a.Key = b.Key
-                      member __.GetHashCode (a:KeyValuePair<'Key,'T>) = a.Key.GetHashCode () })
-          .ToDictionary((fun x -> x.Key), (fun y -> y.Value)) 
+        unionWith (fun x _ -> x) source altSource
 
 /// Additional operations on IDictionary<'Key, 'Value>
 [<RequireQualifiedAccess>]
@@ -458,7 +451,7 @@ module Dict =
             { new IEqualityComparer<KeyValuePair<'Key,'T>> with 
                       member __.Equals ((a:KeyValuePair<'Key,'T>),(b:KeyValuePair<'Key,'T>)) : bool = a.Key = b.Key
                       member __.GetHashCode (a:KeyValuePair<'Key,'T>) = a.Key.GetHashCode () })
-          .ToDictionary((fun x -> x.Key), (fun y -> y.Value)) 
+          .ToDictionary((fun x -> x.Key), (fun y -> y.Value)) :> IDictionary<'Key, 'T>
 
 /// Additional operations on IReadOnlyDictionary<'Key, 'Value>
 [<RequireQualifiedAccess>]

--- a/src/FSharpPlus/Extensions.fs
+++ b/src/FSharpPlus/Extensions.fs
@@ -1,8 +1,6 @@
 namespace FSharpPlus
 
 open System
-open System.Collections.Generic
-open System.Linq
 
 /// Additional operations on Option
 [<RequireQualifiedAccess>]
@@ -332,6 +330,8 @@ module IReadOnlyList =
 /// Additional operations on Map<'Key, 'Value>
 [<RequireQualifiedAccess>]
 module Map =
+    open System.Collections.Generic
+    open System.Linq
 
     let keys   (source: Map<_,_>) = Seq.map (fun (KeyValue(k, _)) -> k) source
     let values (source: Map<_,_>) = Seq.map (fun (KeyValue(_, v)) -> v) source
@@ -387,27 +387,12 @@ module Map =
                       member __.GetHashCode (a:KeyValuePair<'Key,'T>) = a.Key.GetHashCode () })
           .ToDictionary((fun x -> x.Key), (fun y -> y.Value)) 
 
-    /// Returns the intersection of two maps, using the combiner function for duplicate keys.
-    let intersectWith combiner (source1:Map<'Key, 'T>) (source2:Map<'Key, 'T>) =
-        Enumerable
-          .Join(
-            source1, 
-            source2, 
-            (fun (x:KeyValuePair<'Key, 'T>) -> x.Key), 
-            (fun (y:KeyValuePair<'Key, 'T>) -> y.Key), 
-            (fun (x:KeyValuePair<'Key, 'T>) (y:KeyValuePair<'Key, 'T>) -> 
-              KeyValuePair<'Key, 'Value>(x.Key, combiner (x.Value) (y.Value))))
-          .ToDictionary((fun x -> x.Key), (fun y -> y.Value))  
-
-    // Returns the intersection of two maps, preferring values from the first in case of duplicate keys.
-    let intersect (source1:Map<'Key, 'T>) (source2:Map<'Key, 'T>) = 
-        intersectWith (fun a _ -> a) source1 source2
-
 /// Additional operations on IDictionary<'Key, 'Value>
 [<RequireQualifiedAccess>]
 module Dict =
     open System.Collections.Generic
     open System.Collections.ObjectModel
+    open System.Linq
 
     let toIReadOnlyDictionary source = ReadOnlyDictionary source :> IReadOnlyDictionary<_,_>
 
@@ -474,22 +459,6 @@ module Dict =
                       member __.Equals ((a:KeyValuePair<'Key,'T>),(b:KeyValuePair<'Key,'T>)) : bool = a.Key = b.Key
                       member __.GetHashCode (a:KeyValuePair<'Key,'T>) = a.Key.GetHashCode () })
           .ToDictionary((fun x -> x.Key), (fun y -> y.Value)) 
-
-    /// Returns the intersection of two maps, using the combiner function for duplicate keys.
-    let intersectWith combiner (source1:IDictionary<'Key, 'T>) (source2:IDictionary<'Key, 'T>) =
-        Enumerable
-          .Join(
-            source1, 
-            source2, 
-            (fun (x:KeyValuePair<'Key, 'T>) -> x.Key), 
-            (fun (y:KeyValuePair<'Key, 'T>) -> y.Key), 
-            (fun (x:KeyValuePair<'Key, 'T>) (y:KeyValuePair<'Key, 'T>) -> 
-              KeyValuePair<'Key, 'Value>(x.Key, combiner (x.Value) (y.Value))))
-          .ToDictionary((fun x -> x.Key), (fun y -> y.Value))  
-
-    // Returns the intersection of two maps, preferring values from the first in case of duplicate keys.
-    let intersect (source1:IDictionary<'Key, 'T>) (source2:IDictionary<'Key, 'T>) = 
-        intersectWith (fun a _ -> a) source1 source2
 
 /// Additional operations on IReadOnlyDictionary<'Key, 'Value>
 [<RequireQualifiedAccess>]

--- a/src/FSharpPlus/Extensions.fs
+++ b/src/FSharpPlus/Extensions.fs
@@ -377,8 +377,7 @@ module Map =
         Map.fold (fun m k v' -> Map.add k (match Map.tryFind k m with Some v -> combiner v v' | None -> v') m) source1 source2
 
     /// Returns the union of two maps, preferring values from the first in case of duplicate keys.
-    let union (source: Map<'Key, 'T>) (altSource: Map<'Key, 'T>) = 
-        unionWith (fun x _ -> x) source altSource
+    let union (source: Map<'Key, 'T>) (altSource: Map<'Key, 'T>) = unionWith (fun x _ -> x) source altSource
 
 /// Additional operations on IDictionary<'Key, 'Value>
 [<RequireQualifiedAccess>]

--- a/tests/FSharpPlus.Tests/Extensions.fs
+++ b/tests/FSharpPlus.Tests/Extensions.fs
@@ -1,0 +1,24 @@
+module Extensions
+
+open FSharpPlus
+open NUnit.Framework
+open Validations
+
+[<Test>]
+let ``Dict.union gives empty dictionary when two empty dictionaries are joined`` () =
+  let m1 = dict []
+  let m2 = dict []
+  let r1 = m1 |> Dict.union m2 |> Seq.toList
+
+  areEqual [] r1
+
+[<Test>]
+let ``Dict.union provides same end result as Dict.unionWith picking the first source value for dupes`` () =
+  let m1 = dict [1, "2"; 2,"4"; 4,"8"]
+  let m2 = dict [1, "4"; 2,"8"; 4,"16"]
+
+  let r1 = m1 |> Dict.union m2 |> Seq.toList
+  let r2 = m1 |> Dict.unionWith konst m2 |> Seq.toList
+
+  areEqual r1 r2
+

--- a/tests/FSharpPlus.Tests/FSharpPlus.Tests.fsproj
+++ b/tests/FSharpPlus.Tests/FSharpPlus.Tests.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="Validations.fs" />
     <Compile Include="ComputationExpressions.fs" />
     <Compile Include="Lens.fs" />
+    <Compile Include="Extensions.fs" />
     <None Include="paket.references" />
     <Content Include="App.config" />
   </ItemGroup>


### PR DESCRIPTION
- Reimplemented union on dictionaries and maps using Linq which carries some performance improvements over the current implementation. unionWith will stay as is, because of the combiner function.
- Implemented intersect and intersectWith (preferred intersect instead of join to follow the naming on F# Set).
