### PR TITLE
Update travis yml and paket restore targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ before_install:
   - chmod +x build.sh
  
 script: 
-  - ./build.sh All
+  - ./build.sh GenerateDocs # this will run 'RunTests' as well


### PR DESCRIPTION
Issue with using pack on travis due to paket. Since the main source of packages is Appveyor, there is little need to generate package on Travis.