### PR TITLE
Polyvariadic parsing functions

### DIFF
--- a/src/FSharpPlus/FSharpPlus.fsproj
+++ b/src/FSharpPlus/FSharpPlus.fsproj
@@ -72,6 +72,7 @@
     <Compile Include="Validations.fs" />
     <Compile Include="Kleisli.fs" />
     <Compile Include="Memoization.fs" />
+    <Compile Include="Parsing.fs" />
     <None Include="Samples\Collections.fsx" />
     <None Include="Samples\Split-Join.fsx" />
     <None Include="Samples\Conversions.fsx" />

--- a/src/FSharpPlus/Parsing.fs
+++ b/src/FSharpPlus/Parsing.fs
@@ -1,0 +1,118 @@
+﻿namespace FSharpPlus
+
+open FSharpPlus.Internals
+
+
+[<AutoOpen>]
+module Parsing =
+
+    // From https://gist.github.com/gusty/2810b0cc7f8bf89f614facaf121fcaa4
+
+    /// [omit]
+    module Internals =
+
+        open System
+        open System.Text.RegularExpressions
+        open FSharpPlus
+        open FSharpPlus.Internals.Prelude
+
+        let formatters = [|"%b"; "%d"; "%i"; "%s"; "%u"; "%x"; "%X"; "%o"; "%e"; "%E"; "%f"; "%F"; "%g"; "%G"; "%M"; "%c"; "%A"|]
+
+        let getGroups (pf: PrintfFormat<_,_,_,_,_>) s =
+          let formatStr = replace "%%" "%" pf.Value
+          let constants = split formatters formatStr
+          let regex = Regex ("^" + String.Join ("(.*?)", constants |> Array.map Regex.Escape) + "$")
+          let groups = 
+            regex.Match(s).Groups 
+            |> Seq.cast<Group> 
+            |> Seq.skip 1
+          groups
+            |> Seq.map (fun g  -> g.Value)
+            |> Seq.toArray
+
+        type ParseArray =
+            static member inline ParseArray (_: 't  , _: obj) = fun (g: string []) -> (parse (g.[0])) : 't
+
+            static member inline Invoke (g: string []) =
+                let inline call_2 (a: ^a, b: ^b) = ((^a or ^b) : (static member ParseArray: _*_ -> _) b, a) g
+                let inline call (a: 'a) = call_2 (a, Unchecked.defaultof<'r>) : 'r
+                call Unchecked.defaultof<ParseArray>
+
+            static member inline ParseArray (t: 't, _: ParseArray) = fun (g: string [])  ->
+                let (t1: 't1) = if false then (^t : (member Item1 : 't1) t) else parse (g.[0])
+                let (t2: 't2) = if false then (^t : (member Item2 : 't2) t) else parse (g.[1])
+                let (t3: 't3) = if false then (^t : (member Item3 : 't3) t) else parse (g.[2])
+                let (t4: 't4) = if false then (^t : (member Item4 : 't4) t) else parse (g.[3])
+                let (t5: 't5) = if false then (^t : (member Item5 : 't5) t) else parse (g.[4])
+                let (t6: 't6) = if false then (^t : (member Item6 : 't6) t) else parse (g.[5])
+                let (t7: 't7) = if false then (^t : (member Item7 : 't7) t) else parse (g.[6])
+                let (tr: 'tr) = if false then (^t : (member Rest  : 'tr) t) else ParseArray.Invoke (g.[7..])
+                Tuple<_,_,_,_,_,_,_,_>(t1, t2, t3, t4, t5, t6, t7, tr) |> retype : 't
+
+            static member inline ParseArray (_: unit                        , _: ParseArray) = fun (_: string []) -> ()
+            static member inline ParseArray (_: Tuple<'t1>                  , _: ParseArray) = fun (g: string []) -> Tuple<_> (parse g.[0]) : Tuple<'t1>
+            static member inline ParseArray (_: Id<'t1>                     , _: ParseArray) = fun (g: string []) -> Id<_> (parse g.[0])
+            static member inline ParseArray (_: 't1*'t2                     , _: ParseArray) = fun (g: string []) -> parse g.[0], parse g.[1]
+            static member inline ParseArray (_: 't1*'t2'*'t3                , _: ParseArray) = fun (g: string []) -> parse g.[0], parse g.[1], parse g.[2]
+            static member inline ParseArray (_: 't1*'t2'*'t3*'t4            , _: ParseArray) = fun (g: string []) -> parse g.[0], parse g.[1], parse g.[2], parse g.[3]
+            static member inline ParseArray (_: 't1*'t2'*'t3*'t4*'t5        , _: ParseArray) = fun (g: string []) -> parse g.[0], parse g.[1], parse g.[2], parse g.[3], parse g.[4]
+            static member inline ParseArray (_: 't1*'t2'*'t3*'t4*'t5*'t6    , _: ParseArray) = fun (g: string []) -> parse g.[0], parse g.[1], parse g.[2], parse g.[3], parse g.[4], parse g.[5]
+            static member inline ParseArray (_: 't1*'t2'*'t3*'t4*'t5*'t6*'t7, _: ParseArray) = fun (g: string []) -> parse g.[0], parse g.[1], parse g.[2], parse g.[3], parse g.[4], parse g.[5], parse g.[6]
+
+        let inline tryParseElemAt i (g: string []) =
+            if i < Array.length g then tryParse (g.[i])
+            else None
+
+        type TryParseArray =
+            static member inline TryParseArray (_:'t, _:obj) = fun (g: string []) -> tryParseElemAt 0 g : 't option
+
+            static member inline Invoke (g: string []) =
+                let inline call_2 (a: ^a, b: ^b) = ((^a or ^b) : (static member TryParseArray: _*_ -> _) b, a) g
+                let inline call (a: 'a) = call_2 (a, Unchecked.defaultof<'r>) : 'r option
+                call Unchecked.defaultof<TryParseArray>
+
+            static member inline TryParseArray (t: 't, _: TryParseArray) = fun (g: string [])  ->
+                let (t1: 't1 option) = if false then Some (^t : (member Item1 : 't1) t) else tryParseElemAt 0 g
+                let (t2: 't2 option) = if false then Some (^t : (member Item2 : 't2) t) else tryParseElemAt 1 g
+                let (t3: 't3 option) = if false then Some (^t : (member Item3 : 't3) t) else tryParseElemAt 2 g
+                let (t4: 't4 option) = if false then Some (^t : (member Item4 : 't4) t) else tryParseElemAt 3 g
+                let (t5: 't5 option) = if false then Some (^t : (member Item5 : 't5) t) else tryParseElemAt 4 g
+                let (t6: 't6 option) = if false then Some (^t : (member Item6 : 't6) t) else tryParseElemAt 5 g
+                let (t7: 't7 option) = if false then Some (^t : (member Item7 : 't7) t) else tryParseElemAt 6 g
+                let (tr: 'tr option) = if false then Some (^t : (member Rest  : 'tr) t) elif g.Length > 7 then TryParseArray.Invoke (g.[7..]) else None
+                match t1, t2, t3, t4, t5, t6, t7, tr with
+                |  Some t1, Some t2, Some t3, Some t4, Some t5, Some t6, Some t7, Some tr -> Some (Tuple<_,_,_,_,_,_,_,_>(t1, t2, t3, t4, t5, t6, t7, tr) |> retype : 't)
+                | _ -> None
+
+            static member inline TryParseArray (_: unit                        , _: TryParseArray) = fun (_: string []) -> ()
+            static member inline TryParseArray (_: Tuple<'t1>                  , _: TryParseArray) = fun (g: string []) -> Tuple<_> <!> tryParseElemAt 0 g : Tuple<'t1> option
+            static member inline TryParseArray (_: Id<'t1>                     , _: TryParseArray) = fun (g: string []) -> Id<_>    <!> tryParseElemAt 0 g
+            static member inline TryParseArray (_: 't1*'t2                     , _: TryParseArray) = fun (g: string []) -> tuple2 <!> tryParseElemAt 0 g <*> tryParseElemAt 1 g
+            static member inline TryParseArray (_: 't1*'t2'*'t3                , _: TryParseArray) = fun (g: string []) -> tuple3 <!> tryParseElemAt 0 g <*> tryParseElemAt 1 g <*> tryParseElemAt 2 g
+            static member inline TryParseArray (_: 't1*'t2'*'t3*'t4            , _: TryParseArray) = fun (g: string []) -> tuple4 <!> tryParseElemAt 0 g <*> tryParseElemAt 1 g <*> tryParseElemAt 2 g <*> tryParseElemAt 3 g
+            static member inline TryParseArray (_: 't1*'t2'*'t3*'t4*'t5        , _: TryParseArray) = fun (g: string []) -> tuple5 <!> tryParseElemAt 0 g <*> tryParseElemAt 1 g <*> tryParseElemAt 2 g <*> tryParseElemAt 3 g <*> tryParseElemAt 4 g
+            static member inline TryParseArray (_: 't1*'t2'*'t3*'t4*'t5*'t6    , _: TryParseArray) = fun (g: string []) -> tuple6 <!> tryParseElemAt 0 g <*> tryParseElemAt 1 g <*> tryParseElemAt 2 g <*> tryParseElemAt 3 g <*> tryParseElemAt 4 g <*> tryParseElemAt 5 g
+            static member inline TryParseArray (_: 't1*'t2'*'t3*'t4*'t5*'t6*'t7, _: TryParseArray) = fun (g: string []) -> tuple7 <!> tryParseElemAt 0 g <*> tryParseElemAt 1 g <*> tryParseElemAt 2 g <*> tryParseElemAt 3 g <*> tryParseElemAt 4 g <*> tryParseElemAt 5 g <*> tryParseElemAt 6 g
+
+
+    open Internals
+    open System
+
+    /// Gets a tuple with the result of parsing each element of a string array.
+    let inline parseArray (source: string[]) : '``(T1 * T2 * ... * Tn)`` = ParseArray.Invoke source
+
+    /// Gets a tuple with the result of parsing each element of a formatted text.
+    let inline sscanf (pf: PrintfFormat<_,_,_,_,'``(T1 * T2 * ... * Tn)``>) s : '``(T1 * T2 * ... * Tn)`` = getGroups pf s |> parseArray
+
+    /// Gets a tuple with the result of parsing each element of a formatted text from the Console.
+    let inline scanfn pf : '``(T1 * T2 * ... * Tn)`` = sscanf pf (Console.ReadLine ())
+
+
+    /// Gets a tuple with the result of parsing each element of a string array. Returns None in case of failure.
+    let inline tryParseArray g : '``(T1 * T2 * ... * Tn)`` option = TryParseArray.Invoke g
+
+    /// Gets a tuple with the result of parsing each element of a formatted text. Returns None in case of failure.
+    let inline trySscanf (pf: PrintfFormat<_,_,_,_,'``(T1 * T2 * ... * Tn)``>) s : '``(T1 * T2 * ... * Tn)`` option = getGroups pf s |> tryParseArray
+
+    /// Gets a tuple with the result of parsing each element of a formatted text from the Console. Returns None in case of failure.
+    let inline tryScanfn pf : '``(T1 * T2 * ... * Tn)`` option = trySscanf pf (Console.ReadLine ())

--- a/tests/FSharpPlus.Tests/General.fs
+++ b/tests/FSharpPlus.Tests/General.fs
@@ -1402,6 +1402,40 @@ module Parsing =
 
         let (r123: WrappedListA<int> option) = tryParse "[1;2;3]"
         Assert.IsTrue ((r123 = Some (WrappedListA [1; 2; 3])))
+        
+    [<Test>]
+    let scanfParsing () =
+        let (ccx : int * uint32 * float * float32 * int * uint32 * float * float32 * int * uint32 * float * float32 * int * uint32 * float * float32 * int) = parseArray [|"34"; "24"; "34"; "4"; "5"; "6"; "7"; "8"; "9"; "10"; "11"; "12"; "13"; "14"; "15"; "16"; "17"|]
+        
+        let t = sscanf "(%i-%i-%f-%i-%i-%i-%i-%i-%i)" "(32-66-888-4-5-6-7-8-9)"
+        let (a,b) = sscanf "(%%%s,%M)" "(%hello, 4.53)"
+        let (x,y,z) = sscanf "%s-%s-%s" "test-this-string"
+        let (j,k,l,m,n,o,p) = sscanf "%f %F %g %G %e %E %c" "1 2.1 3.4 .3 43.2e32 0 f"
+        
+        let (r1,r2,r3,r4,r5,r6,r7,r8)        = sscanf "%f %F %g %G %e %E %c %c"    "1 2.1 3.4 .3 43.2e32 0 f f"
+        let (s1,s2,s3,s4,s5,s6,s7,s8,s9)     = sscanf "%f %F %g %G %e %E %c %c %c" "1 2.1 3.4 .3 43.2e32 0 f f f"
+        let (t1,t2,t3,t4,t5,t6,t7,t8,t9,t10) = sscanf "%f %F %g %G %e %E %c %c %c %c" "1 2.1 3.4 .3 43.2e32 0 f f f f"
+        let (u1,u2,u3,u4,u5,u6,u7,u8,u9,u10,u11,u12,u13,u14,u15)         = sscanf "%f %F %g %G %e %E %c %c %c %c %c %c %c %c %c"       "1 2.1 3.4 .3 43.2e32 0 f f f f f f f f f"
+        let (v1,v2,v3,v4,v5,v6,v7,v8,v9,v10,v11,v12,v13,v14,v15,v16)     = sscanf "%f %F %g %G %e %E %c %c %c %c %c %c %c %c %c %i"    "1 2.1 3.4 .3 43.2e32 0 f f f f f f f f f 16"
+        let (w1,w2,w3,w4,w5,w6,w7,w8,w9,w10,w11,w12,w13,w14,w15,w16,w17) = sscanf "%f %F %g %G %e %E %c %c %c %c %c %c %c %c %c %i %f" "1 2.1 3.4 .3 43.2e32 0 f f f f f f f f f 16 17"
+        
+        
+        let (zzz) = sscanf "(%%%s)" "(%hello)"
+        let (x1,y1,z1) = sscanf "%s--%s-%s" "test--this-string"
+        
+        
+        let f1 = trySscanf "(%%%s)" "(%hello)"
+        let f2 = trySscanf "%s--%s-%s" "test--this-gg"
+        let f3 = trySscanf "%f %F %g %G %e %E %c %c"    "1 2.1 3.4 .3 43.2e32 0 f f"
+        let f4 = trySscanf "%f %F %g %G %e %E %c %c %c" "1 2.1 3.4 .3 43.2e32 0 f f f"
+        let f5 = trySscanf "%f %F %g %G %e %E %c %c %c %c" "1 2.1 3.4 .3 43.2e32 0 f f f f"
+        let f6 = trySscanf "%f %F %g %G %e %E %c %c %c %c %c %c %c %c %c"       "1 2.1 3.4 .3 43.2e32 0 f f f f f f f f"
+        let f7 = trySscanf "%f %F %g %G %e %E %c %c %c %c %c %c %c %c %c %i"    "1 2.1 3.4 .3 43.2e32 0 f f f f f f f f f 16"
+        let f8 = trySscanf "%f %F %g %G %e %E %c %c %c %c %c %c %c %c %c %i %f" "1 2.1 3.4 .3 43.2e32 0 f f f f f f f f f 16 17"
+        
+        let (date : (DayOfWeek * string * uint16 * int) option) = trySscanf "%A %A %A %A" "Saturday March 25 1989"
+
+        ()
 
 
 module Conversions =


### PR DESCRIPTION
This will add the `scanf` family of functions, strong typed and working with tuples of any size.

They return a tuple whose type should be known at compile-time.

These new functions are:
 - scanf
 - sscanf
 - parseArray

And the `try...`version of each of them.

Probably the most interesting one is `sscanf` which will simplify extraction data from strings, and its trySscanf variant.

Internally they use the `parse` function, from this library.