### PR TITLE
Extend string module - Part 1

### DIFF
--- a/src/FSharpPlus/Collection.fs
+++ b/src/FSharpPlus/Collection.fs
@@ -34,7 +34,7 @@ type OfSeq =
     static member inline OfSeq (x: seq<'t>                 , _: 'UserType                       , _: OfSeq   ) = (^UserType : (static member OfSeq : seq<'t> -> ^UserType) x)
     static member        OfSeq (x                          , _: 't []                           , _: OfSeq   ) = Array.ofSeq<'t> x
     static member        OfSeq (x                          , _: 't list                         , _: OfSeq   ) = List.ofSeq<'t> x
-    static member        OfSeq (x: seq<char>               , _: string                          , _: OfSeq   ) = String.Join ("", Array.ofSeq x)
+    static member        OfSeq (x: seq<char>               , _: string                          , _: OfSeq   ) = String.ofSeq x
     static member        OfSeq (x: seq<char>               , _: Text.StringBuilder              , _: OfSeq   ) = (StringBuilder (), x) ||> Seq.fold (fun x -> x.Append)
     static member        OfSeq (x: seq<'t>                 , _: Stack<'t>                       , _: OfSeq   ) = Generic.Stack x
 
@@ -68,7 +68,7 @@ type OfList =
     static member inline OfList (x: list<'t>                 , _: 'UserType                       , _: OfList  ) = (^UserType : (static member OfList : list<'t> -> ^UserType) x)
     static member        OfList (x                           , _: 't []                           , _: OfList  ) = Array.ofList<'t> x
     static member        OfList (x                           , _: 't list                         , _: OfList  ) = x
-    static member        OfList (x: list<char>               , _: string                          , _: OfList  ) = String.Join ("", Array.ofList x)
+    static member        OfList (x: list<char>               , _: string                          , _: OfList  ) = String.ofList x
     static member        OfList (x: list<char>               , _: Text.StringBuilder              , _: OfList  ) = (StringBuilder (), x) ||> List.fold (fun x -> x.Append)
     static member        OfList (x: list<'t>                 , _: Stack<'t>                       , _: OfList  ) = Generic.Stack x
 
@@ -104,7 +104,7 @@ type Filter with
 type Skip =
     inherit Default1
     static member inline Skip (x: '``Foldable<'T>``, n, [<Optional>]_impl: Default1) = x |> ToSeq.Invoke |> Seq.skip n |> OfSeq.Invoke : '``Foldable<'T>``
-    static member        Skip (x: string           , n, [<Optional>]_impl: Skip    ) = x.[n..]
+    static member        Skip (x: string           , n, [<Optional>]_impl: Skip    ) = String.skip n x
     static member        Skip (x: StringBuilder    , n, [<Optional>]_impl: Skip    ) = new StringBuilder(x.ToString().[n..])
     static member        Skip (x: 'a []            , n, [<Optional>]_impl: Skip    ) = x.[n..] : 'a []
     static member        Skip (x: 'a ResizeArray   , n, [<Optional>]_impl: Skip    ) = ResizeArray<'a> (Seq.skip n x)
@@ -120,7 +120,7 @@ type Skip =
 type Take =
     inherit Default1
     static member inline Take (x: '``Foldable<'T>``, n, [<Optional>]_impl: Default1) = x |> ToSeq.Invoke |> Seq.take n |> OfSeq.Invoke : '``Foldable<'T>``
-    static member        Take (x: string           , n, [<Optional>]_impl: Take    ) = x.[..n-1]
+    static member        Take (x: string           , n, [<Optional>]_impl: Take    ) = String.take n x
     static member        Take (x: StringBuilder    , n, [<Optional>]_impl: Take    ) = new StringBuilder(x.ToString().[..n-1])
     static member        Take (x: 'a []            , n, [<Optional>]_impl: Take    ) = x.[..n-1] : 'a []
     static member        Take (x: 'a ResizeArray   , n, [<Optional>]_impl: Take    ) = ResizeArray<'a> (Seq.take n x)
@@ -135,6 +135,7 @@ type Take =
 type TakeWhile =
     inherit Default1
     static member inline TakeWhile (x: '``Foldable<'T>``, p, [<Optional>]_impl: Default1 ) = x |> ToSeq.Invoke |> Seq.takeWhile p |> OfSeq.Invoke : '``Foldable<'T>``
+    static member        TakeWhile (x: string           , p, [<Optional>]_impl: TakeWhile) = String.takeWhile p x
     static member        TakeWhile (x: 'a []            , p, [<Optional>]_impl: TakeWhile) = Array.takeWhile p x
     static member        TakeWhile (x: 'a ResizeArray   , p, [<Optional>]_impl: TakeWhile) = ResizeArray<'a> (Seq.takeWhile p x)
     static member        TakeWhile (x: list<'a>         , p, [<Optional>]_impl: TakeWhile) = List.takeWhile p x
@@ -148,6 +149,7 @@ type TakeWhile =
 type SkipWhile =
     inherit Default1
     static member inline SkipWhile (x: '``Foldable<'T>``, p, [<Optional>]_impl: Default1 ) = x |> ToSeq.Invoke |> Seq.skipWhile p |> OfSeq.Invoke : '``Foldable<'T>``
+    static member        SkipWhile (x: string           , p, [<Optional>]_impl: SkipWhile) = String.skipWhile p x
     static member        SkipWhile (x: 'a []            , p, [<Optional>]_impl: SkipWhile) = Array.skipWhile p x
     static member        SkipWhile (x: 'a ResizeArray   , p, [<Optional>]_impl: SkipWhile) = ResizeArray<'a> (Seq.skipWhile p x)
     static member        SkipWhile (x: list<'a>         , p, [<Optional>]_impl: SkipWhile) = List.skipWhile p x
@@ -161,7 +163,7 @@ type SkipWhile =
 type Drop =
     inherit Default1
     static member inline Drop (x: '``Foldable<'T>``, n, [<Optional>]_impl: Default1) = x |> ToSeq.Invoke |> Seq.drop n |> OfSeq.Invoke : '``Foldable<'T>``
-    static member        Drop (x: string           , n, [<Optional>]_impl: Drop    ) = if n > 0 then (if x.Length > n then x.[n..] else "") else x
+    static member        Drop (x: string           , n, [<Optional>]_impl: Drop    ) = String.drop n x
     static member        Drop (x: StringBuilder    , n, [<Optional>]_impl: Drop    ) = if n > 0 then (if x.Length > n then new StringBuilder(x.ToString().[n..]) else new StringBuilder ()) else new StringBuilder (string x)
     static member        Drop (x: 'a []            , n, [<Optional>]_impl: Drop    ) = if n > 0 then (if x.Length > n then x.[n..] else [||]) else x : 'a []
     static member        Drop (x: 'a ResizeArray   , n, [<Optional>]_impl: Drop    ) = ResizeArray<'a> (Seq.drop n x)
@@ -177,7 +179,7 @@ type Drop =
 type Limit =
     inherit Default1
     static member inline Limit (x: '``Foldable<'T>``, n, [<Optional>]_impl: Default1) = x |> ToSeq.Invoke |> Seq.truncate n |> OfSeq.Invoke : '``Foldable<'T>``
-    static member        Limit (x: string           , n, [<Optional>]_impl: Limit   ) = if n < 1 then  ""  elif n < x.Length then x.[..n-1] else x
+    static member        Limit (x: string           , n, [<Optional>]_impl: Limit   ) = String.truncate n x
     static member        Limit (x: StringBuilder    , n, [<Optional>]_impl: Limit   ) = new StringBuilder(x.ToString().[..n-1])
     static member        Limit (x: 'a []            , n, [<Optional>]_impl: Limit   ) = if n < 1 then [||] elif n < x.Length then x.[..n-1] else x : 'a []
     static member        Limit (x: 'a ResizeArray   , n, [<Optional>]_impl: Limit   ) = ResizeArray<'a> (Seq.truncate n x)

--- a/src/FSharpPlus/Extensions.fs
+++ b/src/FSharpPlus/Extensions.fs
@@ -348,11 +348,15 @@ module String =
     /// Returns a string that have at most N characters from the beginning of the original string.
     /// It returns the original string if it is shorter than count.
     let truncate count (source: string) =
-        if String.length source <= count then source else take count source
+        if count < 1 then String.Empty
+        else if String.length source <= count then source
+        else take count source
     /// Returns a string that drops first N characters of the original string.
     /// When count exceeds the length of the string it returns an empty string.
     let drop     count (source: string) =
-        if String.length source >= count then String.Empty else skip count source
+        if count < 1 then source
+        else if String.length source >= count then String.Empty
+        else skip count source
 
     let findIndex    (char: char) (source: string) = source.IndexOf char
     let tryFindIndex (char: char) (source: string) =
@@ -365,7 +369,7 @@ module String =
         if index = -1 then None else Some index
 
     /// Converts the string to an array of Int32 code-points (the actual Unicode Code Point number).
-    let toCodePoints (encoding : System.Text.Encoding option) (source : string) : seq<int> =
+    let toCodePoints (source : string) : seq<int> =
         let mapper i c =
             // Ignore the low-surrogate because it's already been converted
             if c |> Char.IsLowSurrogate then None

--- a/src/FSharpPlus/Extensions.fs
+++ b/src/FSharpPlus/Extensions.fs
@@ -345,6 +345,24 @@ module String =
                 i <- i + 1
             if i = 0 then ""
             else source |> skip i
+    /// Returns a string that have at most N characters from the beginning of the original string.
+    /// It returns the original string if it is shorter than count.
+    let truncate count (source: string) =
+        if String.length source <= count then source else take count source
+    /// Returns a string that drops first N characters of the original string.
+    /// When count exceeds the length of the string it returns an empty string.
+    let drop     count (source: string) =
+        if String.length source >= count then String.Empty else skip count source
+
+    let findIndex    (char: char) (source: string) = source.IndexOf char
+    let tryFindIndex (char: char) (source: string) =
+        let index = findIndex char source
+        if index = -1 then None else Some index
+
+    let findSliceIndex    (slice: string) (source: string) = source.IndexOf slice
+    let tryFindSliceIndex (slice: string) (source: string) =
+        let index = findSliceIndex slice source
+        if index = -1 then None else Some index
 
     /// Converts the string to an array of Int32 code-points (the actual Unicode Code Point number).
     let toCodePoints (encoding : System.Text.Encoding option) (source : string) : seq<int> =

--- a/src/FSharpPlus/Extensions.fs
+++ b/src/FSharpPlus/Extensions.fs
@@ -295,6 +295,57 @@ module String =
             |> String.filter (fun ch -> CharUnicodeInfo.GetUnicodeCategory ch <> UnicodeCategory.NonSpacingMark)
             |> normalize NormalizationForm.FormC
 
+    /// Pads the beginning of the given string with spaces so that it has a specified total length.
+    let padLeft totalLength (source: string) = source.PadLeft totalLength
+    /// Pads the beginning of the given string with a specified character so that it has a specified total length.
+    let padLeftWith totalLength paddingChar (source: string) = source.PadLeft (totalLength, paddingChar)
+    /// Pads the end of the given string with spaces so that it has a specified total length.
+    let padRight totalLength (source: string) = source.PadRight totalLength
+    /// Pads the end of the given string with a specified character so that it has a specified total length.
+    let padRightWith totalLength paddingChar (source: string) = source.PadRight (totalLength, paddingChar)
+
+    /// Removes all leading and trailing occurrences of specified characters from the given string.
+    let trim      (trimChars: char seq) (source: string) = source.Trim (Seq.toArray trimChars)
+    /// Removes all leading occurrences of specified characters from the given string.
+    let trimStart (trimChars: char seq) (source: string) = source.TrimStart (Seq.toArray trimChars)
+    /// Removes all trailing occurrences of specified characters from the given string.
+    let trimEnd   (trimChars: char seq) (source: string) = source.TrimEnd (Seq.toArray trimChars)
+
+    let toArray (source: string)    = source.ToCharArray ()
+    let ofArray (source: char [])   = new String (source)
+    let toList  (source: string)    = toArray source |> List.ofArray
+    let ofList  (source: char list) = new String (source |> Array.ofList)
+    let toSeq   (source: string)    = source :> seq<char>
+    let ofSeq   (source: seq<char>) = String.Join (String.Empty, source)
+
+    let item    (index: int) (source: string) = source.[index]
+    let tryItem (index: int) (source: string) = if index >= 0 && index < source.Length then Some source.[index] else None
+
+    let rev (source: string) = new String (source.ToCharArray () |> Array.rev)
+
+    let take count (source: string) = source.[..count-1]
+    let skip count (source: string) = source.[count..]
+    let takeWhile (predicate: char -> bool) (source: string) =
+        if String.IsNullOrEmpty source then
+            String.Empty
+        else
+            let mutable i = 0
+            let length = String.length source
+            while i < length && predicate source.[i] do
+                i <- i + 1
+            if i = 0 then ""
+            else source |> take i
+    let skipWhile (predicate: char -> bool) (source: string) =
+        if String.IsNullOrEmpty source then
+            String.Empty
+        else
+            let mutable i = 0
+            let length = String.length source
+            while i < length && predicate source.[i] do
+                i <- i + 1
+            if i = 0 then ""
+            else source |> skip i
+
 
 /// Additional operations on IReadOnlyCollection<'T>
 [<RequireQualifiedAccess>]

--- a/src/FSharpPlus/Extensions.fs
+++ b/src/FSharpPlus/Extensions.fs
@@ -346,6 +346,20 @@ module String =
             if i = 0 then ""
             else source |> skip i
 
+    /// Converts the string to an array of Int32 code-points (the actual Unicode Code Point number).
+    let toCodePoints (encoding : System.Text.Encoding option) (source : string) : seq<int> =
+        let mapper i c =
+            // Ignore the low-surrogate because it's already been converted
+            if c |> Char.IsLowSurrogate then None
+            else Char.ConvertToUtf32 (source, i) |> Some
+        source |> Seq.mapi mapper |> Seq.choose id
+    /// Converts the array of Int32 code-points (the actual Unicode Code Point number) to a string.
+    let fromCodePoints (source: seq<int>) : string =
+        source |> Seq.map Char.ConvertFromUtf32 |> String.concat String.Empty
+
+    /// Converts a string to a byte-array using the specified encoding.
+    let getBytes (encoding: System.Text.Encoding) (source: string) : byte [] = encoding.GetBytes source
+
 
 /// Additional operations on IReadOnlyCollection<'T>
 [<RequireQualifiedAccess>]

--- a/src/FSharpPlus/Extensions.fs
+++ b/src/FSharpPlus/Extensions.fs
@@ -358,14 +358,24 @@ module String =
         else if String.length source >= count then String.Empty
         else skip count source
 
-    let findIndex    (char: char) (source: string) = source.IndexOf char
+    let findIndex    (char: char) (source: string) =
+        let index = source.IndexOf char
+        if index = -1 then
+            ArgumentException("An index satisfying the predicate was not found in the string.") |> raise
+        else
+            index
     let tryFindIndex (char: char) (source: string) =
-        let index = findIndex char source
+        let index = source.IndexOf char
         if index = -1 then None else Some index
 
-    let findSliceIndex    (slice: string) (source: string) = source.IndexOf slice
+    let findSliceIndex    (slice: string) (source: string) =
+        let index = source.IndexOf slice
+        if index = -1 then
+            ArgumentException("An index satisfying the predicate was not found in the string.") |> raise
+        else
+            index
     let tryFindSliceIndex (slice: string) (source: string) =
-        let index = findSliceIndex slice source
+        let index = source.IndexOf slice
         if index = -1 then None else Some index
 
     /// Converts the string to an array of Int32 code-points (the actual Unicode Code Point number).

--- a/src/FSharpPlus/Extensions.fs
+++ b/src/FSharpPlus/Extensions.fs
@@ -386,7 +386,7 @@ module String =
             else Char.ConvertToUtf32 (source, i) |> Some
         source |> Seq.mapi mapper |> Seq.choose id
     /// Converts the array of Int32 code-points (the actual Unicode Code Point number) to a string.
-    let fromCodePoints (source: seq<int>) : string =
+    let ofCodePoints (source: seq<int>) : string =
         source |> Seq.map Char.ConvertFromUtf32 |> String.concat String.Empty
 
     /// Converts a string to a byte-array using the specified encoding.

--- a/src/FSharpPlus/Foldable.fs
+++ b/src/FSharpPlus/Foldable.fs
@@ -42,7 +42,7 @@ type ToSeq =
     inherit Default1
     static member ToSeq (x: seq<'T>   , [<Optional>]_impl: ToSeq) = x
     static member ToSeq (x: Text.StringBuilder,         _: ToSeq) = string x :> seq<char>
-    static member ToSeq (x: string    ,                 _: ToSeq) = x        :> seq<char>
+    static member ToSeq (x: string    ,                 _: ToSeq) = String.toSeq x
     static member ToSeq (x: option<'T>, [<Optional>]_impl: ToSeq) = match x with Some x -> Seq.singleton x | _ -> Seq.empty
     static member ToSeq (x: Id<'T>    , [<Optional>]_impl: ToSeq) = Seq.singleton x.getValue
 
@@ -65,7 +65,7 @@ type ToList =
     static member        ToList (x: seq<'a>       , [<Optional>]_impl: Default2) = Seq.toList x
     static member inline ToList (x                , [<Optional>]_impl: Default1) = (^Foldable : (static member ToList : 'Foldable->list<_>) x)
     static member        ToList (x: Set<'a>       , [<Optional>]_impl: ToList  ) = Set.toList x
-    static member        ToList (x: string        , [<Optional>]_impl: ToList  ) = x.ToCharArray () |> Array.toList
+    static member        ToList (x: string        , [<Optional>]_impl: ToList  ) = String.toList x
     static member        ToList (x: StringBuilder , [<Optional>]_impl: ToList  ) = x.ToString().ToCharArray() |> Array.toList
     static member        ToList (x: 'a []         , [<Optional>]_impl: ToList  ) = Array.toList x
     static member        ToList (x: 'a ResizeArray, [<Optional>]_impl: ToList  ) = Seq.toList x
@@ -83,7 +83,7 @@ type ToArray =
     static member        ToArray (x: seq<'a>       , [<Optional>]_impl: Default2) = Seq.toArray x
     static member inline ToArray (x                , [<Optional>]_impl: Default1) = (^Foldable : (static member ToArray : 'Foldable->array<_>) x)
     static member        ToArray (x: Set<'a>       , [<Optional>]_impl: ToArray ) = Set.toArray x
-    static member        ToArray (x: string        , [<Optional>]_impl: ToArray ) = x.ToCharArray ()
+    static member        ToArray (x: string        , [<Optional>]_impl: ToArray ) = String.toArray x
     static member        ToArray (x: StringBuilder , [<Optional>]_impl: ToArray ) = x.ToString().ToCharArray ()
     static member        ToArray (x: 'a []         , [<Optional>]_impl: ToArray ) = x
     static member        ToArray (x: 'a ResizeArray, [<Optional>]_impl: ToArray ) = Seq.toArray x

--- a/src/FSharpPlus/Indexable.fs
+++ b/src/FSharpPlus/Indexable.fs
@@ -5,6 +5,7 @@ open System.Runtime.CompilerServices
 open System.Runtime.InteropServices
 open System.Text
 open System.Collections.Generic
+open FSharpPlus
 open FSharpPlus.Internals
 open FSharpPlus.Internals.Prelude
 
@@ -16,7 +17,7 @@ type Item =
     inherit Default1
     static member inline Item (x: '``Indexable<'T>`` , k        , [<Optional>]_impl: Default1) = (^``Indexable<'T>`` : (member get_Item : _ -> 'T) x, k) : 'T
     static member inline Item (_: 'T when 'T: null and 'T: struct, _,         _impl: Default1) = ()
-    static member        Item (x: string             , n        , [<Optional>]_impl: Item    ) = x.[n]
+    static member        Item (x: string             , n        , [<Optional>]_impl: Item    ) = String.item n x
     static member        Item (x: StringBuilder      , n        , [<Optional>]_impl: Item    ) = x.ToString().[n]
     static member        Item (x: 'T []              , n        , [<Optional>]_impl: Item    ) = x.[n]       : 'T
     static member        Item (x: 'T [,]             , (i,j)    , [<Optional>]_impl: Item    ) = x.[i,j]     : 'T
@@ -36,7 +37,7 @@ type TryItem =
         if (^``Indexable<'T>``: (member TryGetValue: _ * _ -> _) (x, k, &r)) then Some r else None
     static member inline TryItem (x: '``Indexable<'T>``, k        , [<Optional>]_impl: Default1) = (^``Indexable<'T>`` : (static member TryItem : _ * _ -> _) k, x) : 'T option
     static member inline TryItem (_: 'T when 'T: null and 'T: struct, _       , _impl: Default1) = ()
-    static member        TryItem (x: string            , n        , [<Optional>]_impl: TryItem ) = if n >= 0 && n < x.Length then Some (x.[n]) else None
+    static member        TryItem (x: string            , n        , [<Optional>]_impl: TryItem ) = String.tryItem n x
     static member        TryItem (x: StringBuilder     , n        , [<Optional>]_impl: TryItem ) = if n >= 0 && n < x.Length then Some ((string x).[n]) else None
     static member        TryItem (x: 'a []             , n        , [<Optional>]_impl: TryItem ) = if n >= x.GetLowerBound 0 && n <= x.GetUpperBound 0 then Some x.[n] else None : 'a option
     static member        TryItem (x: 'a [,]            , (i,j)    , [<Optional>]_impl: TryItem ) = if (i, j)       >= (x.GetLowerBound 0, x.GetLowerBound 1                                      ) && (i, j)       <= (x.GetUpperBound 0, x.GetUpperBound 1                                      ) then Some x.[i,j]     else None : 'a option

--- a/tests/FSharpPlus.Tests/Extensions.fs
+++ b/tests/FSharpPlus.Tests/Extensions.fs
@@ -231,3 +231,35 @@ let ``IReadOnlyDictionary.union provides same end result as Dict.unionWith picki
   let r2 = m1 |> IReadOnlyDictionary.unionWith konst m2 |> Seq.toList
 
   areEqual r1 r2
+
+[<Test>]
+let ``String.toCodePoints >> String.ofCodePoints should preserve the original string`` () =
+  // some naughty strings adopted from https://github.com/minimaxir/big-list-of-naughty-strings
+  // The MIT License (MIT), Copyright (c) 2015 Max Woolf
+  let testStrings = [
+    "田中さんにあげて下さい"
+    "パーティーへ行かないか"
+    "和製漢語"
+    "部落格"
+    "사회과학원 어학연구소"
+    "찦차를 타고 온 펲시맨과 쑛다리 똠방각하"
+    "社會科學院語學研究所"
+    "울란바토르"
+    "𠜎𠜱𠝹𠱓𠱸𠲖𠳏"
+    "ヽ༼ຈل͜ຈ༽ﾉ ヽ༼ຈل͜ຈ༽ﾉ"
+    "(｡◕ ∀ ◕｡)"
+    "｀ｨ(´∀｀∩"
+    "__ﾛ(_*)"
+    "・(￣∀￣)・:*:"
+    "ﾟ･✿ヾ╲(｡◕‿◕｡)╱✿･ﾟ"
+    "表ポあA鷗ŒéＢ逍Üßªąñ丂㐀𠀀"
+    "0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣ 🔟"
+    "🇺🇸🇷🇺🇸 🇦🇫🇦🇲🇸"
+    "🇺🇸🇷🇺🇸🇦🇫🇦🇲"
+    "🇺🇸🇷🇺🇸🇦"
+    "If you're reading this, you've been in a coma for almost 20 years now. We're trying a new technique. We don't know where this message will end up in your dream, but we hope it works. Please wake up, we miss you."
+  ]
+  
+  for s in testStrings do
+    areEqual s (s |> String.toCodePoints |> String.ofCodePoints)
+


### PR DESCRIPTION
Related:  fsharp/fslang-suggestions#102 
Closes #158.

This PR adds more string functions to the String module (in Extensions.fs), and use them as the implementation of existing generic functions.

"Part 1" means we have some functions left to be discussed in detail and they are not going to be added in this PR.

See #158 for the discussion.

TODO:

* Add the following functions ((*) Generic version already exists):
  - [x] findIndex / tryFindindex / findSliceIndex / tryFindSliceIndex
  - [x] padLeft / padRight / padLeftWith / padRightWith
  - [x] trim / trimStart / trimEnd : taking an array.
  - [x] toArray / ofArray / toList / ofList / toSeq / ofSeq (*)
  - [x] item/tryItem (*)
  - [x] rev (*)
  - [x] take / skip / takeWhile / skipWhile / truncate / drop (*)
  - [x] toCodePoints / ofCodePoints
  - [x] getBytes : accept always an encoding.

* Replace the implementation of following generic functions with the new ones:
  - [x] toArray / ~~ofArray~~ / toList / ofList / toSeq / ofSeq
  - [x] item/tryItem
  - [x] ~~rev~~ *skipped because adding it alone would break the existing overload resolution.*
  - [x] take / skip / takeWhile / skipWhile / truncate / drop

* Add some tests for: (skipped trivial functions)
  - [x] ~~findIndex / tryFindindex / findSliceIndex / tryFindSliceIndex~~
  - [x] ~~padLeft / padRight / padLeftWith / padRightWith~~
  - [x] ~~trim / trimStart / trimEnd~~
  - [x] ~~toArray / ofArray / toList / ofList / toSeq / ofSeq~~
  - [x] ~~item/tryItem~~
  - [x] ~~rev~~
  - [x] ~~take / skip / takeWhile / skipWhile / truncate / drop~~
  - [x] toCodePoints / ofCodePoints
  - [x] ~~getBytes~~