### PR TITLE
Add missing cexpr members to Monad Transformers

### DIFF
--- a/src/FSharpPlus/Cont.fs
+++ b/src/FSharpPlus/Cont.fs
@@ -32,9 +32,11 @@ type Cont<'r,'t> with
 
     static member (<*>) (f, x: Cont<'R,'T>) = Cont.apply f x  : Cont<'R,'U>
     static member (>>=) (x, f: 'T->_)       = Cont.bind f x   : Cont<'R,'U>
+
     static member Delay f = Cont (fun k -> Cont.run (f ()) k) : Cont<'R,'T>
     static member TryWith    (Cont c, h) = Cont (fun k -> try (c k) with e -> Cont.run (h e) k) : Cont<'R,'T>
     static member TryFinally (Cont c, h) = Cont (fun k -> try (c k) finally h ())               : Cont<'R,'T>
+    static member Using (resource, f: _ -> Cont<'R,'T>) = Cont.TryFinally (f resource, fun () -> dispose resource)
 
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member CallCC (f: ('T -> Cont<'R,'U>) -> _) = Cont.callCC f : Cont<'R,'T>

--- a/src/FSharpPlus/Error.fs
+++ b/src/FSharpPlus/Error.fs
@@ -49,6 +49,11 @@ type ResultT<'``monad<'result<'t,'e>>``> with
     static member inline (<*>) (f: ResultT<'``Monad<'Result<('T -> 'U),'E>>``>, x: ResultT<'``Monad<'Result<'T,'E>>``>) = ResultT.apply f x : ResultT<'``Monad<'Result<'U,'E>>``>
     static member inline (>>=) (x: ResultT<'``Monad<'Result<'T,'E>>``>, f: 'T->ResultT<'``Monad<'Result<'U,'E>>``>)     = ResultT.bind  f x
 
+    static member inline TryWith (source: ResultT<'``Monad<'Result<'T,'E>>``>, f: exn -> ResultT<'``Monad<'Result<'T,'E>>``>) = ResultT (TryWith.Invoke (ResultT.run source) (ResultT.run << f))
+    static member inline TryFinally (computation: ResultT<'``Monad<'Result<'T,'E>>``>, f) = ResultT (TryFinally.Invoke     (ResultT.run computation) f)
+    static member inline Using (resource, f: _ -> ResultT<'``Monad<'Result<'T,'E>>``>)    = ResultT (Using.Invoke resource (ResultT.run << f))
+    static member inline Delay (body : unit   ->  ResultT<'``Monad<'Result<'T,'E>>``>)    = ResultT (Delay.Invoke (fun _ -> ResultT.run (body ())))
+
     static member inline Lift (x: '``Monad<'T>``) = x |> liftM Ok |> ResultT : ResultT<'``Monad<Result<'T,'E>>``>
 
     static member inline Throw (x: 'E) = x |> Error |> result |> ResultT : ResultT<'``Monad<Result<'T,'E>>``>

--- a/src/FSharpPlus/List.fs
+++ b/src/FSharpPlus/List.fs
@@ -62,6 +62,11 @@ type ListT<'``monad<list<'t>>``> with
     static member inline get_Empty () = ListT <| result [] : ListT<'``MonadPlus<list<'T>``>
     static member inline (<|>) (ListT x, ListT y) = ListT (x >>= (fun a -> y >>= (fun b -> result (a @ b)))) : ListT<'``MonadPlus<list<'T>``>
 
+    static member inline TryWith (source: ListT<'``Monad<list<'T>>``>, f: exn -> ListT<'``Monad<list<'T>>``>) = ListT (TryWith.Invoke (ListT.run source) (ListT.run << f))
+    static member inline TryFinally (computation: ListT<'``Monad<list<'T>>``>, f) = ListT (TryFinally.Invoke     (ListT.run computation) f)
+    static member inline Using (resource, f: _ -> ListT<'``Monad<list<'T>>``>)    = ListT (Using.Invoke resource (ListT.run << f))
+    static member inline Delay (body : unit   ->  ListT<'``Monad<list<'T>>``>)    = ListT (Delay.Invoke (fun _ -> ListT.run (body ()))) : ListT<'``Monad<list<'T>>``>
+
     static member inline Lift (x: '``Monad<'T>``) = x |> liftM List.singleton |> ListT : ListT<'``Monad<list<'T>>``>
     
     static member inline LiftAsync (x: Async<'T>) = lift (liftAsync x) : '``ListT<'MonadAsync<'T>>``

--- a/src/FSharpPlus/Option.fs
+++ b/src/FSharpPlus/Option.fs
@@ -32,6 +32,11 @@ type OptionT<'``monad<option<'t>>``> with
 
     static member inline get_Empty () = OptionT <| result None : OptionT<'``MonadPlus<option<'T>``>
     static member inline (<|>) (OptionT x, OptionT y) = OptionT <| (x  >>= (fun maybe_value -> match maybe_value with Some value -> result (Some value) | _ -> y)) : OptionT<'``MonadPlus<option<'T>``>
+  
+    static member inline TryWith (source: OptionT<'``Monad<option<'T>>``>, f: exn -> OptionT<'``Monad<option<'T>>``>) = OptionT (TryWith.Invoke (OptionT.run source) (OptionT.run << f))
+    static member inline TryFinally (computation: OptionT<'``Monad<option<'T>>``>, f) = OptionT (TryFinally.Invoke     (OptionT.run computation) f)
+    static member inline Using (resource, f: _ -> OptionT<'``Monad<option<'T>>``>)    = OptionT (Using.Invoke resource (OptionT.run << f))
+    static member inline Delay (body : unit   ->  OptionT<'``Monad<option<'T>>``>)    = OptionT (Delay.Invoke (fun _ -> OptionT.run (body ()))) : OptionT<'``Monad<option<'T>>``>
 
     static member inline Lift (x: '``Monad<'T>``) = x |> liftM Some |> OptionT : OptionT<'``Monad<option<'T>>``>
 

--- a/src/FSharpPlus/Writer.fs
+++ b/src/FSharpPlus/Writer.fs
@@ -86,6 +86,11 @@ type WriterT<'``monad<'t * 'monoid>``> with
     static member inline get_Empty () = WriterT (getEmpty ()) : WriterT<'``MonadPlus<'T * 'Monoid>``>
     static member inline (<|>) (WriterT m, WriterT n) = WriterT (m <|> n) : WriterT<'``MonadPlus<'T * 'Monoid>``>
 
+    static member inline TryWith (source: WriterT<'``Monad<'T * 'Monoid>``>, f: exn -> WriterT<'``Monad<'T * 'Monoid>``>) = WriterT (TryWith.Invoke (WriterT.run source) (WriterT.run << f))
+    static member inline TryFinally (computation: WriterT<'``Monad<'T * 'Monoid>``>, f) = WriterT (TryFinally.Invoke     (WriterT.run computation) f)
+    static member inline Using (resource, f: _ -> WriterT<'``Monad<'T * 'Monoid>``>)    = WriterT (Using.Invoke resource (WriterT.run << f))
+    static member inline Delay (body : unit   ->  WriterT<'``Monad<'T * 'Monoid>``>)    = WriterT (Delay.Invoke (fun _ -> WriterT.run (body ()))) : WriterT<'``Monad<'T * 'Monoid>``>
+
     static member inline Tell   (w: 'Monoid) = WriterT (result ((), w))                                                                                        : WriterT<'``Monad<unit * 'Monoid>``>
     static member inline Listen (WriterT m: WriterT<'``Monad<('T * ('Monoid'T -> 'Monoid)) * 'Monoid>``>) = WriterT (m >>= (fun (a, w) -> result ((a, w), w))) : WriterT<'``Monad<('T * 'Monoid) * 'Monoid>``>
     static member inline Pass   (WriterT m: WriterT<'``Monad<'T * 'Monoid>``>) = WriterT (m >>= (fun ((a, f), w) -> result (a, f w)))                          : WriterT<'``Monad<'T * 'Monoid>``>

--- a/tests/FSharpPlus.Tests/ComputationExpressions.fs
+++ b/tests/FSharpPlus.Tests/ComputationExpressions.fs
@@ -264,11 +264,12 @@ module ComputationExpressions =
     [<Test>]
     let usingInOptionT () =
         SideEffects.reset ()
-        let reproducePrematureDisposal : Async<int option> = monad {
-            use somethingDisposable = new AsyncOfOptionDisposable ()
-            let! (result: int) = OptionT <| somethingDisposable.AsyncSomeOption ()
-            SideEffects.add "I'm doing something async" result
-            return result } |> OptionT.run
-
+        let reproducePrematureDisposal : Async<int option> =
+            monad {
+                use somethingDisposable = new AsyncOfOptionDisposable ()
+                let! (result: int) = OptionT <| somethingDisposable.AsyncSomeOption ()
+                SideEffects.add "I'm doing something async" result
+                return result
+            } |> OptionT.run
         let _ = reproducePrematureDisposal |> Async.RunSynchronously
         areEqual (SideEffects.get()) ["I'm doing something async"; "Unpacked async option: 1"; "I'm disposed"]

--- a/tests/FSharpPlus.Tests/ComputationExpressions.fs
+++ b/tests/FSharpPlus.Tests/ComputationExpressions.fs
@@ -268,7 +268,7 @@ module ComputationExpressions =
             monad {
                 use somethingDisposable = new AsyncOfOptionDisposable ()
                 let! (result: int) = OptionT <| somethingDisposable.AsyncSomeOption ()
-                SideEffects.add "I'm doing something async" result
+                SideEffects.add (sprintf "Unpacked async option: %A" result)
                 return result
             } |> OptionT.run
         let _ = reproducePrematureDisposal |> Async.RunSynchronously


### PR DESCRIPTION
This will fix #156 

The idea is that these members need to be defined in such a way that they can "talk" about these constructions with their inner (or outer, depends on the convention) monad.

As showed by the provided repro: no matter if the transformer is not a delayed monad, its outer monad could be a delayed one and would know how to handle these methods.