### PR TITLE
Add Task Applicative instance

### DIFF
--- a/src/FSharpPlus/Extensions.fs
+++ b/src/FSharpPlus/Extensions.fs
@@ -1,6 +1,7 @@
 namespace FSharpPlus
 
 open System
+open System.Threading.Tasks
 
 /// Additional operations on Option
 [<RequireQualifiedAccess>]
@@ -1055,6 +1056,39 @@ module Enumerator =
                         try e2.Dispose ()
                         finally e3.Dispose () }
 
+module Task =
+
+    /// <summary>Creates a task workflow from another workflow 'x', mapping its result with 'f'.</summary>
+    let map (f : 'T -> 'U) (t : Task<'T>) : Task<'U> = t.ContinueWith(fun (t' : Task<'T>) -> f (t'.Result))
+
+    /// <summary>Creates a task workflow from two workflows 'x' and 'y', mapping it results with 'f'.</summary>
+    /// <remarks>Workflows are run in sequence.</remarks>
+    /// <param name="f">The mapping function.</param>
+    /// <param name="x">First task workflow.</param>
+    /// <param name="y">Second task workflow.</param>
+    let map2 (f : 'T -> 'U -> 'V) (x : Task<'T>) (y : Task<'U>) : Task<'V> =
+        x.ContinueWith(fun (x' : Task<'T>) ->
+            y.ContinueWith(fun (y' : Task<'U>) ->
+                (f x'.Result y'.Result))).Unwrap()
+
+    /// <summary>Create a task workflow that is the result of applying the resulting function of a task workflow
+    /// to the resulting value of another task workflow</summary>
+    /// <param name="f">Task workflow returning a function</param>
+    /// <param name="x">Task workflow returning a value</param>
+    let apply (f : Task<'T -> 'U>) (t : Task<'T>) : Task<'U> =
+        f.ContinueWith(fun (f' : Task<'T -> 'U>) ->
+            t.ContinueWith(fun (t' : Task<'T>) ->
+                f'.Result t'.Result)).Unwrap()
+
+    /// <summary>Creates a task workflow from two workflows 'x' and 'y', tupling it results.</summary>
+    let zip (x : Task<'T>) (y : Task<'U>) : Task<'T * 'U> =
+        x.ContinueWith(fun (x' : Task<'T>) ->
+            y.ContinueWith(fun (y' : Task<'U>) ->
+                (x'.Result, y'.Result))).Unwrap()
+
+    /// flatten two nested tasks into one.
+    let join (t : Task<Task<'T>>) : Task<'T> =
+        t.Unwrap()
 
 /// Additional operations on IEnumerator
 module Async =

--- a/src/FSharpPlus/Functor.fs
+++ b/src/FSharpPlus/Functor.fs
@@ -150,6 +150,7 @@ type Apply =
     static member        ``<*>`` (f: _ []             , x: 'T []                , [<Optional>]_output: 'U []                , [<Optional>]_mthd: Apply) = Array.collect (fun x1 -> Array.collect (fun x2 -> [|x1 x2|]) x) f : 'U []
     static member        ``<*>`` (f: 'r -> _          , g: _ -> 'T              , [<Optional>]_output:  'r -> 'U            , [<Optional>]_mthd: Apply) = fun x -> f x (g x)                           : 'U
     static member inline ``<*>`` ((a: 'Monoid, f)     , (b: 'Monoid, x: 'T)     , [<Optional>]_output: 'Monoid * 'U         , [<Optional>]_mthd: Apply) = (Plus.Invoke a b, f x)                       : 'Monoid *'U
+    static member        ``<*>`` (f: Task<_>          , x: Task<'T>             , [<Optional>]_output: Task<'U>             , [<Optional>]_mthd: Apply) = Task.apply   f x : Task<'U>
     static member        ``<*>`` (f: Async<_>         , x: Async<'T>            , [<Optional>]_output: Async<'U>            , [<Optional>]_mthd: Apply) = Async.apply  f x : Async<'U>
     static member        ``<*>`` (f: option<_>        , x: option<'T>           , [<Optional>]_output: option<'U>           , [<Optional>]_mthd: Apply) = Option.apply f x : option<'U>
     static member        ``<*>`` (f: Result<_,'E>     , x: Result<'T,'E>        , [<Optional>]_output: Result<'b,'E>        , [<Optional>]_mthd: Apply) = Result.apply f x : Result<'U,'E>

--- a/tests/FSharpPlus.Tests/General.fs
+++ b/tests/FSharpPlus.Tests/General.fs
@@ -943,6 +943,11 @@ module Traversable =
         Assert.AreEqual ([], d)
         let resNone   = traverse (fun x -> if x > 4 then Some x else None) (Seq.initInfinite id) // optimized method, otherwise it doesn't end
         ()
+
+    let traverseTask () =
+        let a = traverse Task.FromResult [1;2]
+        Assert.AreEqual([1;2], a.RunSynchronously())
+        ()
         
         
 type ZipList<'s> = ZipList of 's seq with


### PR DESCRIPTION
This PR adds an overload of `<*>` for `Task`, as well as some helpful extensions to the `Task` module.