### PR TITLE
Align memoizeN code with F#+

### DIFF
--- a/src/FSharpPlus/Memoization.fs
+++ b/src/FSharpPlus/Memoization.fs
@@ -17,13 +17,10 @@ module Memoization =
         static member getOrAdd (cd: ConcurrentDictionary<MemoizationKeyWrapper<'a>,'b>) (f: 'a -> 'b) k =
             cd.GetOrAdd (MemoizationKeyWrapper k, (fun (MemoizationKeyWrapper x) -> x) >> f)
 
-    type MemoizeN with
-        static member inline Invoke (f:'``(T1 -> T2 -> ... -> Tn)``): '``(T1 -> T2 -> ... -> Tn)`` =
-            let inline call_2 (a: ^MemoizeN, b: ^b) = ((^MemoizeN or ^b) : (static member MemoizeN : ^MemoizeN * 'b -> _ ) (a, b))
-            call_2 (Unchecked.defaultof<MemoizeN>, Unchecked.defaultof<'``(T1 -> T2 -> ... -> Tn)``>) f
-            
-    let inline memoizeN (f:'``(T1 -> T2 -> ... -> Tn)``): '``(T1 -> T2 -> ... -> Tn)`` = MemoizeN.Invoke f
+    let inline memoizeN (f:'``(T1 -> T2 -> ... -> Tn)``): '``(T1 -> T2 -> ... -> Tn)`` =
+        let inline call_2 (a: ^MemoizeN, b: ^b) = ((^MemoizeN or ^b) : (static member MemoizeN : ^MemoizeN * 'b -> _ ) (a, b))
+        call_2 (Unchecked.defaultof<MemoizeN>, Unchecked.defaultof<'``(T1 -> T2 -> ... -> Tn)``>) f
 
     type MemoizeN with
         static member        MemoizeN (_: Default1, _:      'a -> 'b) = MemoizeN.getOrAdd (ConcurrentDictionary ())
-        static member inline MemoizeN (_: MemoizeN, _:'t -> 'a -> 'b) = MemoizeN.getOrAdd (ConcurrentDictionary ()) << (<<) MemoizeN.Invoke
+        static member inline MemoizeN (_: MemoizeN, _:'t -> 'a -> 'b) = MemoizeN.getOrAdd (ConcurrentDictionary ()) << (<<) memoizeN

--- a/src/FSharpPlus/Memoization.fs
+++ b/src/FSharpPlus/Memoization.fs
@@ -6,26 +6,24 @@ open FSharpPlus.Internals
 module Memoization =
 
     // From https://gist.github.com/gusty/70e5af737f2f6aed2bc0303a2e17c7d7
-
     open System.Collections.Concurrent
 
     // Key wrapper to allow null values, since dict keys can't be null
     [<Struct>]
     type MemoizationKeyWrapper<'a> = MemoizationKeyWrapper of 'a
 
-    type MemoizeN = MemoizeN with
+    type MemoizeN =
+        inherit Default1
         static member getOrAdd (cd: ConcurrentDictionary<MemoizationKeyWrapper<'a>,'b>) (f: 'a -> 'b) k =
             cd.GetOrAdd (MemoizationKeyWrapper k, (fun (MemoizationKeyWrapper x) -> x) >> f)
-
-    let inline memoizeN (f:'``(T1 -> T2 -> ... -> Tn)``): '``(T1 -> T2 -> ... -> Tn)`` =
-        let inline call_2 (a: ^MemoizeN, b: ^b) = ((^MemoizeN or ^b) : (static member MemoizeN : ^MemoizeN * 'b -> _ ) (a, b))
-        call_2 (Unchecked.defaultof<MemoizeN>, Unchecked.defaultof<'``(T1 -> T2 -> ... -> Tn)``>) f
 
     type MemoizeN with
         static member inline Invoke (f:'``(T1 -> T2 -> ... -> Tn)``): '``(T1 -> T2 -> ... -> Tn)`` =
             let inline call_2 (a: ^MemoizeN, b: ^b) = ((^MemoizeN or ^b) : (static member MemoizeN : ^MemoizeN * 'b -> _ ) (a, b))
             call_2 (Unchecked.defaultof<MemoizeN>, Unchecked.defaultof<'``(T1 -> T2 -> ... -> Tn)``>) f
+            
+    let inline memoizeN (f:'``(T1 -> T2 -> ... -> Tn)``): '``(T1 -> T2 -> ... -> Tn)`` = MemoizeN.Invoke f
 
     type MemoizeN with
-        static member        MemoizeN (_: Default1, _:   'a -> 'b) = MemoizeN.getOrAdd (ConcurrentDictionary ())
-        static member inline MemoizeN (MemoizeN, _:'t -> 'a -> 'b) = MemoizeN.getOrAdd (ConcurrentDictionary ()) << (<<) MemoizeN.Invoke
+        static member        MemoizeN (_: Default1, _:      'a -> 'b) = MemoizeN.getOrAdd (ConcurrentDictionary ())
+        static member inline MemoizeN (_: MemoizeN, _:'t -> 'a -> 'b) = MemoizeN.getOrAdd (ConcurrentDictionary ()) << (<<) MemoizeN.Invoke


### PR DESCRIPTION
Tried to integrate it a bit better at both internal code level and end user.

I would love to have the function in Operators (and the type in Control) but it seems it have to be interleaved in order to delay overload resolution.