### PR TITLE
Make Async.Sequence (and Traverse) lazy

### DIFF
--- a/src/FSharpPlus/Traversable.fs
+++ b/src/FSharpPlus/Traversable.fs
@@ -7,6 +7,7 @@ open FSharpPlus.Internals
 open FSharpPlus.Internals.Prelude
 open FSharpPlus.Internals.MonadOps
 open FSharpPlus
+open FSharpPlus.Extensions
 
 
 type Sequence =
@@ -89,6 +90,7 @@ type Sequence with
     static member        Sequence (t: seq<Choice<'t,'e>>, [<Optional>]_output: Choice<seq<'t>, 'e>, [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, function (Choice2Of2 _) -> true | _ -> false) : Choice<seq<'t>, 'e>
     static member        Sequence (t: seq<list<'t>>     , [<Optional>]_output: list<seq<'t>>      , [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, List.isEmpty)                                 : list<seq<'t>>
     static member        Sequence (t: seq<'t []>        , [<Optional>]_output: seq<'t> []         , [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, Array.isEmpty)                                : seq<'t> []
+    static member        Sequence (t: seq<Async<'t>>    , [<Optional>]_output: Async<seq<'t>>     , [<Optional>]_impl: Default3) = Async.Sequence t                                                               : Async<seq<'t>>
 
     static member inline Sequence (t: ^a                , [<Optional>]_output: 'R                 , [<Optional>]_impl: Default2) = Traverse.InvokeOnInstance id t                                                        : 'R
     static member inline Sequence (t: ^a                , [<Optional>]_output: 'R                 , [<Optional>]_impl: Default1) = Sequence.InvokeOnInstance t                                                           : 'R

--- a/src/FSharpPlus/Traversable.fs
+++ b/src/FSharpPlus/Traversable.fs
@@ -54,7 +54,7 @@ type Traverse =
         return seq {
             use enum = t.GetEnumerator ()
             while enum.MoveNext() do
-                yield Async.RunSynchronously (Async.map f enum.Current, cancellationToken = ct) }}
+                yield Async.RunSynchronously (f enum.Current, cancellationToken = ct) }}
 
     static member inline Traverse (t: ^a   , f, [<Optional>]_output: 'R, [<Optional>]_impl: Default1) = Traverse.InvokeOnInstance f t : 'R
     static member inline Traverse (_: ^a when ^a : null and ^a :struct, _, _: 'R   , _impl: Default1) = id

--- a/tests/FSharpPlus.Tests/General.fs
+++ b/tests/FSharpPlus.Tests/General.fs
@@ -954,13 +954,11 @@ module Traversable =
         let s' = sequence s
         let l = s' |> Async.RunSynchronously |> Seq.take 10 |> Seq.toList
         CollectionAssert.AreEqual ([0;1;2;3;4;5;6;7;8;9], l)
-        ()
 
     [<Test>]
     let traverseTask () =
         let a = traverse Task.FromResult [1;2]
-        CollectionAssert.AreEqual ([1;2], a.RunSynchronously())
-        ()
+        CollectionAssert.AreEqual ([1;2], a.Result)
         
         
 type ZipList<'s> = ZipList of 's seq with

--- a/tests/FSharpPlus.Tests/General.fs
+++ b/tests/FSharpPlus.Tests/General.fs
@@ -948,6 +948,15 @@ module Traversable =
         let resNone   = traverse (fun x -> if x > 4 then Some x else None) (Seq.initInfinite id) // optimized method, otherwise it doesn't end
         ()
 
+    [<Test>]
+    let traverseInfiniteAsyncSequences =
+        let s = Seq.initInfinite async.Return
+        let s' = sequence s
+        let l = s' |> Async.RunSynchronously |> Seq.take 10 |> Seq.toList
+        Assert.AreEqual([0;1;2;3;4;5;6;7;8;9], l)
+        ()
+
+    [<Test>]
     let traverseTask () =
         let a = traverse Task.FromResult [1;2]
         Assert.AreEqual([1;2], a.RunSynchronously())

--- a/tests/FSharpPlus.Tests/General.fs
+++ b/tests/FSharpPlus.Tests/General.fs
@@ -953,13 +953,13 @@ module Traversable =
         let s = Seq.initInfinite async.Return
         let s' = sequence s
         let l = s' |> Async.RunSynchronously |> Seq.take 10 |> Seq.toList
-        Assert.AreEqual([0;1;2;3;4;5;6;7;8;9], l)
+        CollectionAssert.AreEqual ([0;1;2;3;4;5;6;7;8;9], l)
         ()
 
     [<Test>]
     let traverseTask () =
         let a = traverse Task.FromResult [1;2]
-        Assert.AreEqual([1;2], a.RunSynchronously())
+        CollectionAssert.AreEqual ([1;2], a.RunSynchronously())
         ()
         
         


### PR DESCRIPTION
This will allow to traverse infinite sequences.
Performance will be worst, when performing this operation in parallel, because of the internal `async.RunSynchronously` speaking at low level, or the fact that it becomes really a blocking sequence speaking at high level.

But in cases where performance is required and the sequence is finite, the way to go should be to make it an array.