### PR TITLE
Fix 'use' for strict builders

### DIFF
--- a/src/FSharpPlus/Builders.fs
+++ b/src/FSharpPlus/Builders.fs
@@ -59,7 +59,7 @@ module Builders =
         member        __.TryWith    (expr, handler)      = try expr () with e -> handler e
         member        __.TryFinally (expr, compensation) = try expr () finally compensation ()
         member        rs.Using (disposable: #IDisposable, body) =
-            let body = fun () -> (body ()) disposable
+            let body = fun () -> body disposable
             rs.TryFinally (body, fun () -> dispose disposable)
 
     type DelayedBuilder () =

--- a/tests/FSharpPlus.Tests/ComputationExpressions.fs
+++ b/tests/FSharpPlus.Tests/ComputationExpressions.fs
@@ -270,8 +270,8 @@ module ComputationExpressions =
         let reproducePrematureDisposal : Async<int option> =
             monad {
                 use somethingDisposable = new AsyncOfOptionDisposable ()
-                let! (result: int) = OptionT <| somethingDisposable.AsyncSomeOption ()
-                SideEffects.add (sprintf "Unpacked async option: %A" result)
+                let! (res: int) = OptionT <| somethingDisposable.AsyncSomeOption ()
+                SideEffects.add (sprintf "Unpacked async option: %A" res)
                 return result
             } |> OptionT.run
         let _ = reproducePrematureDisposal |> Async.RunSynchronously
@@ -283,8 +283,8 @@ module ComputationExpressions =
         let reproducePrematureDisposal : Async<int option> =
             monad.strict {
                 use somethingDisposable = new AsyncOfOptionDisposable ()
-                let! (result: int) = OptionT <| somethingDisposable.AsyncSomeOption ()
-                SideEffects.add (sprintf "Unpacked async option: %A" result)
+                let! (res: int) = OptionT <| somethingDisposable.AsyncSomeOption ()
+                SideEffects.add (sprintf "Unpacked async option: %A" res)
                 return result
             } |> OptionT.run
         let _ = reproducePrematureDisposal |> Async.RunSynchronously
@@ -296,7 +296,7 @@ module ComputationExpressions =
             monad.strict {
                 use somethingDisposable = new AsyncOfOptionDisposable ()
                 let! (res: int) = OptionT <| somethingDisposable.IdSomeOption ()
-                SideEffects.add (sprintf "Unpacked id option: %A" result)
+                SideEffects.add (sprintf "Unpacked id option: %A" res)
                 return res
             } |> OptionT.run
         let _ = reproducePrematureDisposal |> Identity.run

--- a/tests/FSharpPlus.Tests/ComputationExpressions.fs
+++ b/tests/FSharpPlus.Tests/ComputationExpressions.fs
@@ -272,7 +272,7 @@ module ComputationExpressions =
                 use somethingDisposable = new AsyncOfOptionDisposable ()
                 let! (res: int) = OptionT <| somethingDisposable.AsyncSomeOption ()
                 SideEffects.add (sprintf "Unpacked async option: %A" res)
-                return result
+                return res
             } |> OptionT.run
         let _ = reproducePrematureDisposal |> Async.RunSynchronously
         areEqual (SideEffects.get()) ["I'm doing something async"; "Unpacked async option: 1"; "I'm disposed"]
@@ -285,7 +285,7 @@ module ComputationExpressions =
                 use somethingDisposable = new AsyncOfOptionDisposable ()
                 let! (res: int) = OptionT <| somethingDisposable.AsyncSomeOption ()
                 SideEffects.add (sprintf "Unpacked async option: %A" res)
-                return result
+                return res
             } |> OptionT.run
         let _ = reproducePrematureDisposal |> Async.RunSynchronously
         areEqual (SideEffects.get()) ["I'm disposed"; "I'm doing something async"; "Unpacked async option: 1"]

--- a/tests/FSharpPlus.Tests/ComputationExpressions.fs
+++ b/tests/FSharpPlus.Tests/ComputationExpressions.fs
@@ -273,3 +273,17 @@ module ComputationExpressions =
             } |> OptionT.run
         let _ = reproducePrematureDisposal |> Async.RunSynchronously
         areEqual (SideEffects.get()) ["I'm doing something async"; "Unpacked async option: 1"; "I'm disposed"]
+        
+        
+
+    let testCompileUsingInOptionTStrict () =
+        SideEffects.reset ()
+        let reproducePrematureDisposal : Async<int option> =
+            monad.strict {
+                use somethingDisposable = new AsyncOfOptionDisposable ()
+                let! (result: int) = OptionT <| somethingDisposable.AsyncSomeOption ()
+                SideEffects.add (sprintf "Unpacked async option: %A" result)
+                return result
+            } |> OptionT.run
+        let _ = reproducePrematureDisposal |> Async.RunSynchronously
+        ()

--- a/tests/FSharpPlus.Tests/ComputationExpressions.fs
+++ b/tests/FSharpPlus.Tests/ComputationExpressions.fs
@@ -292,6 +292,7 @@ module ComputationExpressions =
         
     [<Test>]
     let UsingInOptionTStrict () = // this is the way to use it with a strict monad
+        SideEffects.reset ()
         let reproducePrematureDisposal : Identity<int option> =
             monad.strict {
                 use somethingDisposable = new AsyncOfOptionDisposable ()


### PR DESCRIPTION
This will fix `use` for strict computation expressions #183