### PR TITLE
Workaround F# type inference bug

### DIFF
--- a/src/FSharpPlus/Error.fs
+++ b/src/FSharpPlus/Error.fs
@@ -63,7 +63,9 @@ type ResultT<'``monad<'result<'t,'e>>``> with
     static member inline Delay (body : unit   ->  ResultT<'``Monad<'Result<'T,'E>>``>)    = ResultT (Delay.Invoke (fun _ -> ResultT.run (body ())))
 
     #if !FABLE_COMPILER
-    static member inline Lift (x: '``Monad<'T>``) = x |> liftM Ok |> ResultT : ResultT<'``Monad<Result<'T,'E>>``>
+    static member inline Lift (x: '``Monad<'T>``) : ResultT<'``Monad<Result<'T,'E>>``> =
+        if FSharpPlus.Internals.Helpers.alwaysFalse<bool> then x |> liftM Ok |> ResultT
+        else x |> map Ok |> ResultT
 
     static member inline Throw (x: 'E) = x |> Error |> result |> ResultT : ResultT<'``Monad<Result<'T,'E>>``>
     static member inline Catch (ResultT x: ResultT<'``MonadError<'E1,'T>``>, f: 'E1 -> _) = (ResultT (x >>= (fun a -> match a with Error l -> ResultT.run (f l) | Ok r -> result (Ok r)))) : ResultT<'``Monad<Result<'T,'E2>>``>
@@ -115,7 +117,9 @@ type ChoiceT<'``monad<'choice<'t,'e>>``> with
     #if !FABLE_COMPILER
     static member inline (>>=) (x: ChoiceT<'``Monad<'Choice<'T,'E>>``>, f: 'T->ChoiceT<'``Monad<'Choice<'U,'E>>``>)     = ChoiceT.bind f x
 
-    static member inline Lift (x: '``Monad<'T>``) = x |> liftM Choice1Of2 |> ChoiceT : ChoiceT<'``Monad<Choice<'T,'E>>``>
+    static member inline Lift (x: '``Monad<'T>``) : ChoiceT<'``Monad<Choice<'T,'E>>``> =
+        if FSharpPlus.Internals.Helpers.alwaysFalse<bool> then x |> liftM Choice1Of2 |> ChoiceT
+        else x |> map Choice1Of2 |> ChoiceT
 
     static member inline Throw (x: 'E) = x |> Choice2Of2 |> result |> ChoiceT : ChoiceT<'``Monad<Choice<'T,'E>>``>
     static member inline Catch (ChoiceT x: ChoiceT<'``MonadError<'E1,'T>``>, f: 'E1 -> _) = (ChoiceT (x >>= (fun a -> match a with Choice2Of2 l -> ChoiceT.run (f l) | Choice1Of2 r -> result (Choice1Of2 r)))) : ChoiceT<'``Monad<Choice<'T,'E2>>``>

--- a/src/FSharpPlus/Internals.fs
+++ b/src/FSharpPlus/Internals.fs
@@ -15,6 +15,9 @@ module internal Prelude =
     let inline tupleToOption x = match x with true, value -> Some value | _ -> None
     let inline retype (x: 'T) : 'U = (# "" x: 'U #)
 
+module Helpers =
+    let alwaysFalse<'t> = false
+
 
 
 [<RequireQualifiedAccess>]

--- a/src/FSharpPlus/List.fs
+++ b/src/FSharpPlus/List.fs
@@ -73,7 +73,9 @@ type ListT<'``monad<list<'t>>``> with
     static member inline Delay (body : unit   ->  ListT<'``Monad<list<'T>>``>)    = ListT (Delay.Invoke (fun _ -> ListT.run (body ()))) : ListT<'``Monad<list<'T>>``>
 
     #if !FABLE_COMPILER
-    static member inline Lift (x: '``Monad<'T>``) = x |> liftM List.singleton |> ListT : ListT<'``Monad<list<'T>>``>
+    static member inline Lift (x: '``Monad<'T>``) : ListT<'``Monad<list<'T>>``> =
+        if FSharpPlus.Internals.Helpers.alwaysFalse<bool> then x |> liftM List.singleton |> ListT
+        else x |> map List.singleton |> ListT
     
     static member inline LiftAsync (x: Async<'T>) = lift (liftAsync x) : '``ListT<'MonadAsync<'T>>``
     

--- a/src/FSharpPlus/Option.fs
+++ b/src/FSharpPlus/Option.fs
@@ -44,7 +44,9 @@ type OptionT<'``monad<option<'t>>``> with
     static member inline Delay (body : unit   ->  OptionT<'``Monad<option<'T>>``>)    = OptionT (Delay.Invoke (fun _ -> OptionT.run (body ()))) : OptionT<'``Monad<option<'T>>``>
 
     #if !FABLE_COMPILER
-    static member inline Lift (x: '``Monad<'T>``) = x |> liftM Some |> OptionT : OptionT<'``Monad<option<'T>>``>
+    static member inline Lift (x: '``Monad<'T>``) : OptionT<'``Monad<option<'T>>``> =
+        if FSharpPlus.Internals.Helpers.alwaysFalse<bool> then x |> liftM Some |> OptionT
+        else x |> map Some |> OptionT
     #endif
 
     static member inline LiftAsync (x : Async<'T>) = lift (liftAsync x) : '``OptionT<'MonadAsync<'T>>``

--- a/src/FSharpPlus/Seq.fs
+++ b/src/FSharpPlus/Seq.fs
@@ -58,7 +58,9 @@ type SeqT<'``monad<seq<'t>>``> with
     static member inline Delay (body : unit   ->  SeqT<'``Monad<seq<'T>>``>)    = SeqT (Delay.Invoke (fun _ -> SeqT.run (body ()))) : SeqT<'``Monad<seq<'T>>``>
     
     #if !FABLE_COMPILER
-    static member inline Lift (x: '``Monad<'T>``) = x |> liftM Seq.singleton |> SeqT : SeqT<'``Monad<seq<'T>>``>
+    static member inline Lift (x: '``Monad<'T>``) : SeqT<'``Monad<seq<'T>>``> =
+        if FSharpPlus.Internals.Helpers.alwaysFalse<bool> then x |> liftM Seq.singleton |> SeqT
+        else x |> map Seq.singleton |> SeqT
     
     static member inline LiftAsync (x: Async<'T>) = lift (liftAsync x) : '``SeqT<'MonadAsync<'T>>``
     

--- a/src/FSharpPlus/State.fs
+++ b/src/FSharpPlus/State.fs
@@ -75,7 +75,9 @@ type StateT<'s,'``monad<'t * 's>``> with
     static member inline Delay (body : unit   ->  StateT<'S,'``Monad<'T * 'S>``>)    = StateT (fun s -> Delay.Invoke (fun _ -> StateT.run (body ()) s)) : StateT<'S,'``Monad<'T * 'S>``>
 
     #if !FABLE_COMPILER
-    static member inline Lift (m: '``Monad<'T>``) : StateT<'S,'``Monad<'T * 'S>``> = StateT <| fun s -> m >>= fun a -> result (a, s)
+    static member inline Lift (m: '``Monad<'T>``) : StateT<'S,'``Monad<'T * 'S>``> =
+        if FSharpPlus.Internals.Helpers.alwaysFalse<bool> then StateT <| fun s -> (m |> liftM (fun a -> (a, s)))
+        else StateT <| fun s -> (m |> map (fun a -> (a, s)))
     #endif
 
     static member inline LiftAsync (x :Async<'T>) = lift (liftAsync x) : '``StateT<'S,'MonadAsync<'T>>``

--- a/src/FSharpPlus/Writer.fs
+++ b/src/FSharpPlus/Writer.fs
@@ -101,7 +101,9 @@ type WriterT<'``monad<'t * 'monoid>``> with
     static member inline Listen (WriterT m: WriterT<'``Monad<('T * ('Monoid'T -> 'Monoid)) * 'Monoid>``>) = WriterT (m >>= (fun (a, w) -> result ((a, w), w))) : WriterT<'``Monad<('T * 'Monoid) * 'Monoid>``>
     static member inline Pass   (WriterT m: WriterT<'``Monad<'T * 'Monoid>``>) = WriterT (m >>= (fun ((a, f), w) -> result (a, f w)))                          : WriterT<'``Monad<'T * 'Monoid>``>
 
-    static member inline Lift (m: '``Monad<'T>``) : WriterT<'``Monad<'T * 'Monoid>``> = WriterT (m >>= (fun a -> result (a, getZero ())))
+    static member inline Lift (m: '``Monad<'T>``) : WriterT<'``Monad<'T * 'Monoid>``> =
+        if FSharpPlus.Internals.Helpers.alwaysFalse<bool> then m |> liftM (fun a -> (a, getZero ())) |> WriterT
+        else m |> map (fun a -> (a, getZero ())) |> WriterT
     #endif
     
     static member inline LiftAsync (x: Async<'T>) = lift (liftAsync x) : '``WriterT<'MonadAsync<'T>>``

--- a/tests/FSharpPlus.Tests/General.fs
+++ b/tests/FSharpPlus.Tests/General.fs
@@ -1156,6 +1156,11 @@ module MonadTransformers =
 
         let okFoo10 = okFoo10Comp |> ChoiceT.run |> Async.RunSynchronously
 
+        // test generic put (no unknown(1,1): error FS0073: internal error: Undefined or unsolved type variable:  ^_?51242)
+        let initialState = -1
+        let x = put initialState : ListT<State<int, unit list>>
+        let y = put initialState : ChoiceT<State<int, Choice<unit,string>>>
+
         ()
 
 module ProfunctorDefaults =


### PR DESCRIPTION
This is a way to workaround #23 

Actually, the root cause of it which is the linked F# compiler bug.

Constraints generated by the IlxGen are affected by the optimizer which is the root cause of many of the unsolved type variables errors.