### PR TITLE
+ Coproduct

### DIFF
--- a/docsrc/content/abstraction-functor.fsx
+++ b/docsrc/content/abstraction-functor.fsx
@@ -84,6 +84,7 @@ From F#+
  -  ``Const<'C,'T>``
  -  ``Kleisli<'T, 'Monad<'U>>``
  -  ``Compose<'F<'G<'T>>>``
+ -  ``Coproduct<'FunctorL<'T>,'FunctorR<'T>>``
  -  ``DList<'T>``
 
 Restricted:

--- a/src/FSharpPlus/Coproduct.fs
+++ b/src/FSharpPlus/Coproduct.fs
@@ -3,17 +3,19 @@
 open FSharpPlus
 open FSharpPlus.Control
 
+[<AbstractClass>]
 type CoproductBase<'``functorL<'t>``,'``functorR<'t>``> (left: '``functorL<'t>``, right: '``functorR<'t>``, isLeft: bool) =
     let (left, right, isLeft)    = left, right, isLeft
-    with member _.getContents () = left, right, isLeft
+    with
+        member _.getContents () = left, right, isLeft
+        override x.GetHashCode () = Unchecked.hash (x.getContents ())
+        override x.Equals o =
+            match o with
+            | :? CoproductBase<'``functorL<'t>``,'``functorR<'t>``> as y -> Unchecked.equals (x.getContents ()) (y.getContents ())
+            | _ -> false
 
 type Coproduct<[<EqualityConditionalOn>]'``functorL<'t>``,'``functorR<'t>``> (left: '``functorL<'t>``, right: '``functorR<'t>``, isLeft: bool) =
     inherit CoproductBase<'``functorL<'t>``,'``functorR<'t>``> (left, right, isLeft)
-    override x.GetHashCode () = Unchecked.hash (x.getContents ())
-    override x.Equals o =
-        match o with
-        | :? Coproduct<'``functorL<'t>``,'``functorR<'t>``> as y -> Unchecked.equals (x.getContents ()) (y.getContents ())
-        | _ -> false
 
 [<AutoOpen>]
 module CoproductPrimitives =
@@ -24,7 +26,7 @@ module CoproductPrimitives =
 
 type CoproductBase<'``functorL<'t>``,'``functorR<'t>``> with
     static member inline Map (x: CoproductBase<'``FunctorL<'T>``,'``FunctorR<'T>``>, f: 'T -> 'U) : Coproduct<'``FunctorL<'U>``,'``FunctorR<'U>``> =
-        let (l, r, isL) =  (x :?> Coproduct<'``FunctorL<'T>``,'``FunctorR<'T>``>).getContents ()
+        let (l, r, isL) = x.getContents ()
         if isL then InL (Map.Invoke f l)
         else        InR (Map.Invoke f r)
 

--- a/src/FSharpPlus/Coproduct.fs
+++ b/src/FSharpPlus/Coproduct.fs
@@ -1,0 +1,35 @@
+﻿namespace FSharpPlus.Data
+
+open FSharpPlus
+open FSharpPlus.Control
+
+type CoproductBase<'``functorL<'t>``,'``functorR<'t>``> (left: '``functorL<'t>``, right: '``functorR<'t>``, isLeft: bool) =
+    let (left, right, isLeft)    = left, right, isLeft
+    with member _.getContents () = left, right, isLeft
+
+type Coproduct<[<EqualityConditionalOn>]'``functorL<'t>``,'``functorR<'t>``> (left: '``functorL<'t>``, right: '``functorR<'t>``, isLeft: bool) =
+    inherit CoproductBase<'``functorL<'t>``,'``functorR<'t>``> (left, right, isLeft)
+    override x.GetHashCode () = Unchecked.hash (x.getContents ())
+    override x.Equals o =
+        match o with
+        | :? Coproduct<'``functorL<'t>``,'``functorR<'t>``> as y -> Unchecked.equals (x.getContents ()) (y.getContents ())
+        | _ -> false
+
+[<AutoOpen>]
+module CoproductPrimitives =
+    let InL x = Coproduct<'``functorL<'t>``,'``functorR<'t>``> (x, Unchecked.defaultof<'``functorR<'t>``>, true)
+    let InR x = Coproduct<'``functorL<'t>``,'``functorR<'t>``> (Unchecked.defaultof<'``functorL<'t>``>, x, false)
+    let (|InL|InR|) (x: Coproduct<'``functorL<'t>``,'``functorR<'t>``>) = let (l, r, isL) = x.getContents () in if isL then InL l else InR r
+
+
+type CoproductBase<'``functorL<'t>``,'``functorR<'t>``> with
+    static member inline Map (x: obj, f: 'T -> 'U) : Coproduct<'``FunctorL<'U>``,'``FunctorR<'U>``> =
+        let (l, r, isL) =  (x :?> Coproduct<'``FunctorL<'T>``,'``FunctorR<'T>``>).getContents ()
+        if isL then InL (Map.Invoke f l)
+        else        InR (Map.Invoke f r)
+
+type Coproduct<'``functorL<'t>``,'``functorR<'t>``> with
+    static member inline Map (a: Coproduct<'``FunctorL<'T>``,'``FunctorR<'T>``>, f: 'T -> 'U) : Coproduct<'``FunctorL<'U>``,'``FunctorR<'U>``> =
+        let (l, r, isL) =  a.getContents ()
+        if isL then InL (Map.InvokeOnInstance f l)
+        else        InR (Map.InvokeOnInstance f r)

--- a/src/FSharpPlus/Coproduct.fs
+++ b/src/FSharpPlus/Coproduct.fs
@@ -23,7 +23,7 @@ module CoproductPrimitives =
 
 
 type CoproductBase<'``functorL<'t>``,'``functorR<'t>``> with
-    static member inline Map (x: obj, f: 'T -> 'U) : Coproduct<'``FunctorL<'U>``,'``FunctorR<'U>``> =
+    static member inline Map (x: CoproductBase<'``FunctorL<'T>``,'``FunctorR<'T>``>, f: 'T -> 'U) : Coproduct<'``FunctorL<'U>``,'``FunctorR<'U>``> =
         let (l, r, isL) =  (x :?> Coproduct<'``FunctorL<'T>``,'``FunctorR<'T>``>).getContents ()
         if isL then InL (Map.Invoke f l)
         else        InR (Map.Invoke f r)

--- a/src/FSharpPlus/FSharpPlus.fsproj
+++ b/src/FSharpPlus/FSharpPlus.fsproj
@@ -16,8 +16,9 @@
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
     <FileVersion>$(VersionPrefix).0</FileVersion>
     <RepositoryUrl>https://github.com/gusty/FSharpPlus</RepositoryUrl>
-    <Description>A complete and extensible base library for F#.
-      </Description>
+    <Description>
+      A complete and extensible base library for F#.
+    </Description>
     <Authors>Gusty</Authors>
     <Copyright>2012-2018 Gustavo P. Leon (and contributors https://github.com/gusty/FSharpPlus/graphs/contributors)</Copyright>
     <PackageLicenseUrl>http://opensource.org/licenses/Apache-2.0</PackageLicenseUrl>
@@ -72,6 +73,7 @@
     <Compile Include="Validations.fs" />
     <Compile Include="Kleisli.fs" />
     <Compile Include="Free.fs" />
+    <Compile Include="Coproduct.fs" />
     <Compile Include="Memoization.fs" />
     <Compile Include="Parsing.fs" />
     <None Include="Samples\Collections.fsx" />

--- a/tests/FSharpPlus.Tests/Free.fs
+++ b/tests/FSharpPlus.Tests/Free.fs
@@ -252,7 +252,29 @@ module Sample3 =
     let interpretedProgram = interpret tryReserve
 
 
-module TestApplicatives =
+module TestCoproduct =
+
+    let a11 = if true  then InL (Some 1) else InR ([20])
+    let a12 = if false then InL (Some 1) else InR ([20])
+
+    let a14 = map ((+)10) a11
+    let a15 = map ((+)10) a12
+
+    let a16 = map string a11
+    let a17 = map string a12
+
+    let a31 = if true  then InL (Some 1) else InR (ZipList [20])
+    let a32 = if false then InL (Some 1) else InR (ZipList [20])
+
+    let a34 = map ((+)10) a31
+    let a35 = map ((+)10) a32
+
+    let a36 = map string a31
+    let a37 = map string a32
+
+    let a41 = InL [3] : Coproduct<_,_ list>
+    let a42 = map ((+)10 >> string) a41
+
     open Sample3
 
     let readReservationRequest =


### PR DESCRIPTION
A Coproduct of two functors is like a `Choice<'FunctorL<'T>,'FunctorR<'T>>`  which results in a single functor.

This is useful for combining Free monad's functors, as a cheap alternative to using a Free monad transformer.

