### PR TITLE
Reproduce issue around operator

### DIFF
--- a/tests/FSharpPlusFable.Tests/FSharpPlusFable.Tests.fsproj
+++ b/tests/FSharpPlusFable.Tests/FSharpPlusFable.Tests.fsproj
@@ -8,16 +8,17 @@
   <ItemGroup>
     <Compile Include="Util.fs" />
     <Compile Include="FSharpTests/Extensions.fs" />
+    <Compile Include="FSharpTests/General.fs" />
     <Compile Include="Tests.fs" />
   </ItemGroup>
 
 
   <ItemGroup>
-    <PackageReference Include="Fable.Core" Version="3.0.0" />
-    <PackageReference Include="Fable.Promise" Version="2.0.0-beta-001" />
-    <PackageReference Include="Fable.Fetch" Version="2.0.0-beta-001" />
-    <PackageReference Include="Expecto" Version="8.11.0" /> 
-    <PackageReference Include="Expecto.TestResults" Version="8.11.0" /> 
+    <PackageReference Include="Fable.Core" Version="3.1.4" />
+    <PackageReference Include="Fable.Promise" Version="2.0.0" />
+    <PackageReference Include="Fable.Fetch" Version="2.2.0" />
+    <PackageReference Include="Expecto" Version="8.13.1" /> 
+    <PackageReference Include="Expecto.TestResults" Version="8.13.1" /> 
  </ItemGroup>
 
   <ItemGroup>

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General.fs
@@ -2,10 +2,11 @@ module GeneralTests
 
 open Testing
 open FSharpPlus
+open FSharpPlus.Control
 
 let GeneralTest = 
     testList "General Tests" [
 
       testCase "possible to map simple values" 
-        (fun () -> equal (Some (4)) (map ((+) 2) (Some 2)))
+        (fun () -> equal (Some (4)) (Map.Invoke ((+) 2) (Some 2)))
     ]

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General.fs
@@ -1,0 +1,11 @@
+module GeneralTests
+
+open Testing
+open FSharpPlus
+
+let GeneralTest = 
+    testList "General Tests" [
+
+      testCase "possible to map simple values" 
+        (fun () -> equal (Some (4)) (map ((+) 2) (Some 2)))
+    ]

--- a/tests/FSharpPlusFable.Tests/Tests.fs
+++ b/tests/FSharpPlusFable.Tests/Tests.fs
@@ -5,7 +5,7 @@ open GeneralTests
 open Testing
 
 
-let AllTests =  testList "AllTests" [ExtensionsTest; GeneralTest]
+let AllTests =  testList "AllTests" [ExtensionsTest; GeneralTest; ]
 
 #if FABLE_COMPILER
 

--- a/tests/FSharpPlusFable.Tests/Tests.fs
+++ b/tests/FSharpPlusFable.Tests/Tests.fs
@@ -1,10 +1,11 @@
 module Tests
 
 open ExtensionsTests
+open GeneralTests
 open Testing
 
 
-let AllTests =  testList "AllTests" [ExtensionsTest]
+let AllTests =  testList "AllTests" [ExtensionsTest; GeneralTest]
 
 #if FABLE_COMPILER
 


### PR DESCRIPTION
See https://github.com/fsprojects/FSharpPlus/issues/243
Though it could be an issue with other operators 
Anyone wanting to look further into this is more than welcome.
So far what I've found is that when the operator `map` is used, the GeneralTests file does not get emitted as a javascript file. In order to get full output you can do:
```npm run pretest --verbose ; npm run test --verbose```
in the FSharpPlusFable.Tests folder 