### PR TITLE
Simplify README, and move most body/links to index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,41 @@
-FSharpPlus [![Build Status](https://api.travis-ci.org/fsprojects/FSharpPlus.svg?branch=master)](https://travis-ci.org/fsprojects/FSharpPlus) [![Build status](https://ci.appveyor.com/api/projects/status/25ukpc0lamyf7pdx/branch/master?svg=true)](https://ci.appveyor.com/project/wallymathieu/fsharpplus/branch/master) [![Join the chat at https://gitter.im/fsprojects/FSharpPlus](https://badges.gitter.im/fsprojects/FSharpPlus.svg)](https://gitter.im/fsprojects/FSharpPlus?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+FSharpPlus
+[![Build Status](https://api.travis-ci.org/fsprojects/FSharpPlus.svg?branch=master)](https://travis-ci.org/fsprojects/FSharpPlus) 
+[![Build status](https://ci.appveyor.com/api/projects/status/25ukpc0lamyf7pdx/branch/master?svg=true)](https://ci.appveyor.com/project/wallymathieu/fsharpplus/branch/master) 
+[![Downloaded](https://img.shields.io/nuget/dt/FSharpPlus.svg)](https://www.nuget.org/packages/FSharpPlus)
+[![NuGet](https://img.shields.io/nuget/v/FSharpPlus.svg)](https://www.nuget.org/packages/FSharpPlus)
+[![NuGet Pre](https://img.shields.io/nuget/vpre/FSharpPlus.svg?label=pre)](https://www.nuget.org/packages/FSharpPlus/absoluteLatest)
 ==========
 
-A complete and extensible base library for F#.
+F#+ is a base library that aims to take F# to the next level of functional
+programming. 
 
-It contains the most requested additions to the F# core library, including:
+*What if we imagine F# as more than it is?*
 
- - Common FP combinators, generic functions and operators.
- - Extension methods for F# types with consistent names and signatures.
- - Standard Monads: Cont, Reader, Writer, State and their Monad Transformers.
- - Other popular [FP abstractions](//fsprojects.github.io/FSharpPlus/abstractions.html).
- - [Generic Functions and Operators](//fsprojects.github.io/FSharpPlus/reference/fsharpplus-operators.html) which may be further extended to support other types.
- - Generic and customizable [Computation Expressions](//fsprojects.github.io/FSharpPlus/computation-expressions.html).
- - A [generic Math](//fsprojects.github.io/FSharpPlus/numerics.html) module.
- - A true polymorphic [Lens/Optics module](//fsprojects.github.io/FSharpPlus/tutorial.html#Lens).
+F#+ builds upon FSharp, with a special focus on generic programming.
+However, by naming conventions and signatures it can be seen to
+'enhance' rather than 'replace' existing patterns as much as possible.
 
-Users of this library have the option to use their functions in different styles:
- - F# Standard module + function style: [module].[function] [arg]
- - As [generic functions](//fsprojects.github.io/FSharpPlus/generic-doc.html) [function] [arg]
- - As [extension methods](//fsprojects.github.io/FSharpPlus/extension-methods.html) [type].[function] [arg]
-
-In the [Sample folder](//github.com/fsprojects/FSharpPlus/tree/master/src/FSharpPlus/Samples) you can find scripts showing how to use F#+ in your code.
+Getting started is easy since you can start with enjoying some of the extensions
+and generic functions, but you will find other parts of F#+ unfold before you
+and become useful the deeper in you get.
 
 See the [documentation](//fsprojects.github.io/FSharpPlus) for more details.
 
+## Seeking Help
+
+We're happy to help with any questions, including complete beginners!
+
+Please do join us to chat on Gitter:
+
+[![Join the chat at https://gitter.im/fsprojects/FSharpPlus](https://badges.gitter.im/fsprojects/FSharpPlus.svg)](https://gitter.im/fsprojects/FSharpPlus?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+...or you can [ask a question on stack overflow](https://stackoverflow.com/questions/ask?tags=f%23%2b)
+with tag `F#+`
+
 ## Contribute
+
+The project is hosted on GitHub where you can report issues, fork the project and submit pull requests.
+Opening issues for discussion or asking questions is welcome, don't hesitate to fill the [New Issue](issues/new) form!
 
 * The [Developer Guide](DEVELOPER_GUIDE.md) contains details about idioms of implementation in terms of how the type class concept translates in the implementation.
 * The [Design Guidelines](DESIGN_GUIDELINES.md) contains details about design choices guiding the implementation with regard to naming, and choices impacting runtime and compile time performance.
-* Opening issues for discussion or asking questions is welcome, don't hesitate to fill the [New Issue](issues/new) form!

--- a/docsrc/content/index.fsx
+++ b/docsrc/content/index.fsx
@@ -6,24 +6,50 @@
 (**
 FSharpPlus
 ======================
+F#+ is a base library that aims to take F# to the next level of functional
+programming. 
 
-Documentation
+*What if we imagine F# as more than it is?*
 
-<div class="row">
-  <div class="span1"></div>
-  <div class="span6">
-    <div class="well well-small" id="nuget">
-      The FSharpPlus library can be <a href="https://nuget.org/packages/FSharpPlus">installed from NuGet</a>:
-      <pre>PM> Install-Package FSharpPlus</pre>
-    </div>
-  </div>
-  <div class="span1"></div>
-</div>
+F#+ builds upon FSharp, with a special focus on generic programming.
+However, by naming conventions and signatures it can be seen to
+'enhance' rather than 'replace' existing patterns as much as possible.
+
+The additions can be summarised as:
+
+ * extensions to core types, such as [`String.toLower`](reference/fsharpplus-string.html)
+
+ * [Generic Functions and Operators](reference/fsharpplus-operators.html),
+   like `map`, which can be extended to support other types
+
+ * Generic and customizable [Computation Expressions](computation-expressions.html),
+   like `monad`
+
+ * A generic [Math Module](numerics.html)
+
+ * [Abstractions](abstractions.html) that capture common FP patterns, such as
+   the standard monads Cont, Reader, Writer, State and their Monad Transformers
+
+ * Some new types that work well with the abstractions, such as NonEmptyList,
+   DList and Validation
+
+ * A polymorphic [Lenses/Optics](tutorial.html#Lens) to easily read and update
+   parts of immutable data
+
+Note, however, that F#+ does not go into solving a specific thing for a specific
+technology, such as JSON parsing.
+
+Some functions are available as [extension methods](extension-methods.html)
+so are callable from C#. Note that this is not complete, or currently considered high priority.
+
+Getting started is easy since you can start with enjoying some of the extensions
+and generic functions, but you will find other parts of F#+ unfold before you
+and become useful the deeper in you get.
 
 Example 1
 ---------
 
-This example demonstrates using a function defined in this library.
+This example demonstrates using an extenstion function defined in this library.
 
 *)
 #r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
@@ -54,42 +80,47 @@ map string (NonEmptyList.create 2 [3;4;5])
 
 (**
 
-Some more info
-
-Samples & documentation
------------------------
-
-The library comes with comprehensible documentation. 
-It include tutorials automatically generated from `*.fsx` files in [the content folder][content]. 
-The API reference is automatically generated from Markdown comments in the library implementation.
+For a more hands on run through F#+ we recommend following the tutorial:
 
  * [Tutorial](tutorial.html) contains a further explanation of this library.
 
+
+Reference Documentation
+-----------------------
+
  * [Types](types.html) contains detailed information about all the types provided in this library.
-
- * [Abstractions](abstractions.html) contains detailed information about all the abstractions represented in this library.
-
- * [Computation Expressions](computation-expressions.html) contains information about the generic computation expressions.
-
- * [Lens](lens.html) contains information and samples about lens and other optics.
 
  * [API Reference](reference/index.html) contains automatically generated documentation for all types, modules
    and functions in the library. This includes additional brief samples on using most of the
    functions.
+
+Samples
+-----------------------
+
+This documentation is automatically generated from `*.fsx` files in [the content folder][content]. 
+It can be useful to clone a local copy to review.
+
+The [API reference](reference/index.html) is automatically generated from
+Markdown comments in the library implementation.
  
+Also of note is the [Sample folder](samples)
+which contains sample scripts showing how to use F#+ in your code.
+
 Contributing and copyright
 --------------------------
 
 The project is hosted on [GitHub][gh] where you can [report issues][issues], fork 
-the project and submit pull requests. If you're adding a new public API, please also 
-consider adding [samples][content] that can be turned into a documentation. You might
-also want to read the [library design notes][design] to understand how it works.
+the project and submit pull requests.
 
-The library is available under Public Domain license, which allows modification and 
+If you're adding a new public API, please also consider adding [documentation][content].
+You might also want to read the [library design notes][design] to understand how it works.
+
+The library is available under Apache License, Version 2.0, which allows modification and 
 redistribution for both commercial and non-commercial purposes. For more information see the 
 [License file][license] in the GitHub repository. 
 
   [content]: https://github.com/fsprojects/FSharpPlus/tree/master/docsrc/content
+  [samples]: https://github.com/fsprojects/FSharpPlus/tree/master/src/FSharpPlus/Samples
   [gh]: https://github.com/fsprojects/FSharpPlus
   [issues]: https://github.com/fsprojects/FSharpPlus/issues
   [readme]: https://github.com/fsprojects/FSharpPlus/blob/master/README.md


### PR DESCRIPTION
Please review...

I tried to integrate with what was already there, but put all the links in on the fsproject index page.

I initially wanted the README to be a replica of the fsprojects index, but later felt that they should have different focus - the README should be intro to what it's about, where as the index is more full overview.

I'm keen to see how we can auto generate docs for extensions so that they can be separated nicely with a link to "Extensions". We could always do a manually written index, but would prefer auto.
