### PR TITLE
Lens: add _at and non for working with Maps

### DIFF
--- a/src/FSharpPlus/Extensions/IReadOnlyDictionary.fs
+++ b/src/FSharpPlus/Extensions/IReadOnlyDictionary.fs
@@ -6,13 +6,14 @@ open System
 [<RequireQualifiedAccess>]
 module IReadOnlyDictionary =
     #if !FABLE_COMPILER
-    
+
     open System.Linq
     #endif
     open System.Collections.Generic
     /// Replaces or sets the item associated with a specified key with the specified value.
 
     let add key value (table: IReadOnlyDictionary<'Key, 'Value>) = table |> Seq.map (|KeyValue|) |> Map |> Map.add key value :> IReadOnlyDictionary<_,_>
+    let remove key (table: IReadOnlyDictionary<'Key, 'Value>) = table |> Seq.filter (fun t -> t.Key <> key) |> Seq.map (|KeyValue|) |> Map :> IReadOnlyDictionary<_,_>
 
     /// Gets the value associated with the specified key. Returns None if a value associated with the key is not found.
     let tryGetValue k (dct: IReadOnlyDictionary<'Key, 'Value>) =
@@ -70,14 +71,14 @@ module IReadOnlyDictionary =
         d :> IReadOnlyDictionary<'Key,'Value>
 
     #if !FABLE_COMPILER
-    
+
     /// Returns the union of two dictionaries, preferring values from the first in case of duplicate keys.
-    let union (source: IReadOnlyDictionary<'Key, 'T>) (altSource: IReadOnlyDictionary<'Key, 'T>) = 
+    let union (source: IReadOnlyDictionary<'Key, 'T>) (altSource: IReadOnlyDictionary<'Key, 'T>) =
         Enumerable
           .Union(
-            source, 
+            source,
             altSource,
-            { new IEqualityComparer<KeyValuePair<'Key,'T>> with 
+            { new IEqualityComparer<KeyValuePair<'Key,'T>> with
                       member __.Equals ((a:KeyValuePair<'Key,'T>),(b:KeyValuePair<'Key,'T>)) : bool = a.Key = b.Key
                       member __.GetHashCode (a:KeyValuePair<'Key,'T>) = a.Key.GetHashCode () })
           .ToDictionary((fun x -> x.Key), (fun y -> y.Value)) :> IReadOnlyDictionary<'Key, 'T>
@@ -86,15 +87,15 @@ module IReadOnlyDictionary =
     let intersectWith combiner (source1:IReadOnlyDictionary<'Key, 'T>) (source2:IReadOnlyDictionary<'Key, 'T>) =
         Enumerable
             .Join(
-            source1, 
-            source2, 
-            (fun (x:KeyValuePair<'Key, 'T>) -> x.Key), 
-            (fun (y:KeyValuePair<'Key, 'T>) -> y.Key), 
-            (fun (x:KeyValuePair<'Key, 'T>) (y:KeyValuePair<'Key, 'T>) -> 
+            source1,
+            source2,
+            (fun (x:KeyValuePair<'Key, 'T>) -> x.Key),
+            (fun (y:KeyValuePair<'Key, 'T>) -> y.Key),
+            (fun (x:KeyValuePair<'Key, 'T>) (y:KeyValuePair<'Key, 'T>) ->
                 KeyValuePair<'Key, 'T>(x.Key, combiner (x.Value) (y.Value))))
             .ToDictionary((fun x -> x.Key), (fun y -> y.Value)) :> IReadOnlyDictionary<'Key, 'T>
 
     /// Returns the intersection of two readonly dictionaries, preferring values from the first in case of duplicate keys.
-    let intersect (source1:IReadOnlyDictionary<'Key, 'T>) (source2:IReadOnlyDictionary<'Key, 'T>) = 
+    let intersect (source1:IReadOnlyDictionary<'Key, 'T>) (source2:IReadOnlyDictionary<'Key, 'T>) =
         intersectWith (fun a _ -> a) source1 source2
     #endif

--- a/src/FSharpPlus/Lens.fs
+++ b/src/FSharpPlus/Lens.fs
@@ -116,9 +116,15 @@ module Lens =
     [<RequireQualifiedAccess>]
     module Map=
         let inline _item i f t = Map.InvokeOnInstance (fun x -> Map.add i x t) (f (Map.tryFind i t))
+        let inline _at i f t = Map.InvokeOnInstance
+                                  (function | None -> Map.remove i t | Some(x) -> Map.add i x t)
+                                  (f (Map.tryFind i t))
     [<RequireQualifiedAccess>]
     module IReadOnlyDictionary=
         let inline _item i f t = Map.InvokeOnInstance (fun x -> IReadOnlyDictionary.add i x t) (f (IReadOnlyDictionary.tryGetValue i t))
+
+    /// Lens for the value inside an Option or the given default value if the Option is None.  Works well when combined with Map._at
+    let inline non def f ma = Map.InvokeOnInstance (fun a' -> if a' = def then None else Some(a')) (f (Option.defaultValue def ma))
 
     // Prism
 

--- a/src/FSharpPlus/Lens.fs
+++ b/src/FSharpPlus/Lens.fs
@@ -115,15 +115,22 @@ module Lens =
 
     [<RequireQualifiedAccess>]
     module Map=
-        let inline _item i f t = Map.InvokeOnInstance (fun x -> Map.add i x t) (f (Map.tryFind i t))
-        let inline _at i f t = Map.InvokeOnInstance
+        /// Given a specific key, produces a Lens from a Map<key, value> to an Option<value>.  When setting,
+        /// a Some(value) will insert or replace the value into the map at the given key.  Setting a value of
+        /// None will delete the value at the specified key.  Works well together with non.
+        let inline _item i f t = Map.InvokeOnInstance
                                   (function | None -> Map.remove i t | Some(x) -> Map.add i x t)
                                   (f (Map.tryFind i t))
     [<RequireQualifiedAccess>]
     module IReadOnlyDictionary=
-        let inline _item i f t = Map.InvokeOnInstance (fun x -> IReadOnlyDictionary.add i x t) (f (IReadOnlyDictionary.tryGetValue i t))
+        /// Given a specific key, produces a Lens from a IReadOnlyDictionary<key, value> to an Option<value>.  When setting,
+        /// a Some(value) will insert or replace the value into the dictionary at the given key.  Setting a value of
+        /// None will delete the value at the specified key.  Works well together with non.
+        let inline _item i f t = Map.InvokeOnInstance
+                                  (function | None -> IReadOnlyDictionary.remove i t | Some(x) -> IReadOnlyDictionary.add i x t)
+                                  (f (IReadOnlyDictionary.tryGetValue i t))
 
-    /// Lens for the value inside an Option or the given default value if the Option is None.  Works well when combined with Map._at
+    /// Lens for the value inside an Option or the given default value if the Option is None.  Works well when combined with Map._item
     let inline non def f ma = Map.InvokeOnInstance (fun a' -> if a' = def then None else Some(a')) (f (Option.defaultValue def ma))
 
     // Prism

--- a/tests/FSharpPlus.Tests/Lens.fs
+++ b/tests/FSharpPlus.Tests/Lens.fs
@@ -84,3 +84,16 @@ let lens_set_contains () =
     let s = set [1;2]
     areEqual (true) (s ^. Set._contains 1)
     areEqual (set [1;2;3]) (s |> Set._contains 3 .-> true)
+
+[<Test>]
+let map_at () =
+  let m = Map.ofList [("Hello", 100); ("Hi", 200)]
+  areEqual (Some 100) (m ^. Map._at "Hello")
+  areEqual None (m ^. Map._at "Hey")
+  areEqual (Map.ofList [("Hello", 150); ("Hi", 200)]) (m |> Map._at "Hello" .-> Some 150)
+  areEqual (Map.ofList [("Hello", 150); ("Hi", 200)]) (m |> Map._at "Hello" %-> (function | None -> failwith "Unexpected None" | Some(x) -> Some(x+50)))
+  areEqual (Map.ofList [("Hi", 200)]) (m |> Map._at "Hello" .-> None)
+  areEqual (Map.ofList [("Hello", 100);("Hi", 200);("Hey", 300)]) (m |> Map._at "Hey" .-> Some 300)
+
+  areEqual (Map.ofList [("Hello", 100);("Hi", 200);("Hey", 50)]) (m |> (Map._at "Hey" << non 0) %-> (fun x -> x + 50))
+  areEqual (Map.ofList [("Hi", 200)]) (m |> (Map._at "Hello" << non 0) %-> (fun x -> x - 100))

--- a/tests/FSharpPlus.Tests/Lens.fs
+++ b/tests/FSharpPlus.Tests/Lens.fs
@@ -69,31 +69,38 @@ let iso () =
 
 [<Test>]
 let lens_map_item () =
-    let m = Map.ofList [("hello","there")]
-    areEqual (Some "there") (m ^. Map._item "hello")
-    areEqual (Map.ofList [("hello","world")]) (m |> setl (Map._item "hello") "world")
+    let m = Map.ofList [("Hello", 100); ("Hi", 200)]
+    areEqual (Some 100) (m ^. Map._item "Hello")
+    areEqual None (m ^. Map._item "Hey")
+    areEqual (Map.ofList [("Hello", 150); ("Hi", 200)]) (m |> Map._item "Hello" .-> Some 150)
+    areEqual (Map.ofList [("Hello", 150); ("Hi", 200)]) (m |> Map._item "Hello" %-> (function | None -> failwith "Unexpected None" | Some(x) -> Some(x+50)))
+    areEqual (Map.ofList [("Hi", 200)]) (m |> Map._item "Hello" .-> None)
+    areEqual (Map.ofList [("Hello", 100);("Hi", 200);("Hey", 300)]) (m |> Map._item "Hey" .-> Some 300)
+
+    areEqual (Map.ofList [("Hello", 100);("Hi", 200);("Hey", 50)]) (m |> (Map._item "Hey" << non 0) %-> (fun x -> x + 50))
+    areEqual (Map.ofList [("Hi", 200)]) (m |> (Map._item "Hello" << non 0) %-> (fun x -> x - 100))
 
 [<Test>]
 let lens_readonlydictionary_item () =
-    let r = Map.ofList [("hello","there")] :> IReadOnlyDictionary<_,_>
-    areEqual (Some "there") (r ^. IReadOnlyDictionary._item "hello")
-    areEqual (Map.ofList [("hello","world")] :> IReadOnlyDictionary<_,_>) (r |> setl (IReadOnlyDictionary._item "hello") "world")
+    let m = Map.ofList [("Hello", 100); ("Hi", 200)] :> IReadOnlyDictionary<_,_>
+    areEqual (Some 100) (m ^. IReadOnlyDictionary._item "Hello")
+    areEqual None (m ^. IReadOnlyDictionary._item "Hey")
+    areEqual (Map.ofList [("Hello", 150); ("Hi", 200)] :> IReadOnlyDictionary<_, _>)
+             (m |> IReadOnlyDictionary._item "Hello" .-> Some 150)
+    areEqual (Map.ofList [("Hello", 150); ("Hi", 200)] :> IReadOnlyDictionary<_, _>)
+             (m |> IReadOnlyDictionary._item "Hello" %-> (function | None -> failwith "Unexpected None" | Some(x) -> Some(x+50)))
+    areEqual (Map.ofList [("Hi", 200)] :> IReadOnlyDictionary<_, _>)
+             (m |> IReadOnlyDictionary._item "Hello" .-> None)
+    areEqual (Map.ofList [("Hello", 100);("Hi", 200);("Hey", 300)] :> IReadOnlyDictionary<_, _>)
+             (m |> IReadOnlyDictionary._item "Hey" .-> Some 300)
+
+    areEqual (Map.ofList [("Hello", 100);("Hi", 200);("Hey", 50)] :> IReadOnlyDictionary<_, _>)
+             (m |> (IReadOnlyDictionary._item "Hey" << non 0) %-> (fun x -> x + 50))
+    areEqual (Map.ofList [("Hi", 200)] :> IReadOnlyDictionary<_, _>)
+             (m |> (IReadOnlyDictionary._item "Hello" << non 0) %-> (fun x -> x - 100))
 
 [<Test>]
 let lens_set_contains () =
     let s = set [1;2]
     areEqual (true) (s ^. Set._contains 1)
     areEqual (set [1;2;3]) (s |> Set._contains 3 .-> true)
-
-[<Test>]
-let map_at () =
-  let m = Map.ofList [("Hello", 100); ("Hi", 200)]
-  areEqual (Some 100) (m ^. Map._at "Hello")
-  areEqual None (m ^. Map._at "Hey")
-  areEqual (Map.ofList [("Hello", 150); ("Hi", 200)]) (m |> Map._at "Hello" .-> Some 150)
-  areEqual (Map.ofList [("Hello", 150); ("Hi", 200)]) (m |> Map._at "Hello" %-> (function | None -> failwith "Unexpected None" | Some(x) -> Some(x+50)))
-  areEqual (Map.ofList [("Hi", 200)]) (m |> Map._at "Hello" .-> None)
-  areEqual (Map.ofList [("Hello", 100);("Hi", 200);("Hey", 300)]) (m |> Map._at "Hey" .-> Some 300)
-
-  areEqual (Map.ofList [("Hello", 100);("Hi", 200);("Hey", 50)]) (m |> (Map._at "Hey" << non 0) %-> (fun x -> x + 50))
-  areEqual (Map.ofList [("Hi", 200)]) (m |> (Map._at "Hello" << non 0) %-> (fun x -> x - 100))


### PR DESCRIPTION
The existing Map._item isn't a nice lens to work with since the getter/view returns type Option<'a> but the setter receives 'a.  That is, it violates the lens law of setting what you get doesn't change anything `set l (view l s) s ~ s` (It doesn't even compile.)

I added the _at lens https://hackage.haskell.org/package/lens-4.18.1/docs/Control-Lens-At.html#t:At which both the getter and setter use Option<'a>.

I also added non (https://hackage.haskell.org/package/lens-4.18.1/docs/Control-Lens-Iso.html#v:non) which works well together with _at.