### PR TITLE
#234 rename lifta2 to lift2

### DIFF
--- a/src/FSharpPlus/Data/ParallelArray.fs
+++ b/src/FSharpPlus/Data/ParallelArray.fs
@@ -31,8 +31,6 @@ module ParallelArray =
             else                                Bounded (Array.Parallel.mapi (fun i x -> f.[i] x) x)
     #endif
 
-    //let inline append (a:ParallelArray<'m>) (b:ParallelArray<'m>) = liftA2 mappend a b :ParallelArray<'m>
-
 /// A type alias for ParallelArray<'T>
 type parray<'t> = ParallelArray<'t>
 
@@ -54,5 +52,5 @@ type ParallelArray<'t> with
     #endif
     static member inline get_Zero () = Bounded (getZero ()) : parray<'m>
     #if !FABLE_COMPILER
-    static member inline (+) (x: parray<'m>, y: parray<'m>) = liftA2 plus x y : parray<'m>
+    static member inline (+) (x: parray<'m>, y: parray<'m>) = lift2 plus x y : parray<'m>
     #endif

--- a/src/FSharpPlus/Data/Reader.fs
+++ b/src/FSharpPlus/Data/Reader.fs
@@ -18,7 +18,7 @@ module Reader =
     let apply (Reader f) (Reader x) = Reader (fun a -> f a ((x: _->'T) a)) : Reader<'R,'U>
 
     /// Zips two Readers into one.
-    let zip (x: Reader<'R,'T>) (y: Reader<'R,'U>) = liftA2 tuple2 x y      : Reader<'R, 'T * 'U>
+    let zip (x: Reader<'R,'T>) (y: Reader<'R,'U>) = lift2 tuple2 x y      : Reader<'R, 'T * 'U>
 
     /// Retrieves the monad environment.
     let ask = Reader id                                                    : Reader<'R,'R>

--- a/src/FSharpPlus/Data/State.fs
+++ b/src/FSharpPlus/Data/State.fs
@@ -32,7 +32,7 @@ module State =
     let modify f = State (fun s -> ((), f s))                                                                     : State<'S,unit>
 
     /// Zips two States into one.
-    let zip (x: State<'S,'T>) (y: State<'S,'U>) = liftA2 tuple2 x y : State<'S, ('T * 'U)>
+    let zip (x: State<'S,'T>) (y: State<'S,'U>) = lift2 tuple2 x y : State<'S, ('T * 'U)>
 
 type State<'s,'t> with
 

--- a/src/FSharpPlus/Data/ZipList.fs
+++ b/src/FSharpPlus/Data/ZipList.fs
@@ -39,7 +39,7 @@ type ZipList<'s> with
     #if !FABLE_COMPILER
     static member inline get_Zero () = result (getZero ()) : ZipList<'a>
     #endif
-    static member inline (+) (x: ZipList<'a>, y: ZipList<'a>) = liftA2 plus x y : ZipList<'a>
+    static member inline (+) (x: ZipList<'a>, y: ZipList<'a>) = lift2 plus x y : ZipList<'a>
     static member ToSeq (ZipList x) = x
 
     #if !FABLE_COMPILER

--- a/src/FSharpPlus/Operators.fs
+++ b/src/FSharpPlus/Operators.fs
@@ -97,7 +97,11 @@ module Operators =
     let inline (<*>) (f: '``Applicative<'T -> 'U>``) (x: '``Applicative<'T>``) : '``Applicative<'U>`` = Apply.Invoke f x : '``Applicative<'U>``
 
     /// Apply 2 lifted arguments to a non-lifted function.
-    let inline liftA2 (f: 'T->'U->'V) (x: '``Applicative<'T>``) (y: '``Applicative<'U>``) : '``Applicative<'V>`` = (f <!> x : '``Applicative<'U->'V>``) <*> y
+    let inline lift2 (f: 'T->'U->'V) (x: '``Applicative<'T>``) (y: '``Applicative<'U>``) : '``Applicative<'V>`` = (f <!> x : '``Applicative<'U->'V>``) <*> y
+
+    [<System.Obsolete("Use lift2 instead.")>]
+    /// Apply 2 lifted arguments to a non-lifted function.
+    let inline liftA2 (f: 'T->'U->'V) (x: '``Applicative<'T>``) (y: '``Applicative<'U>``) : '``Applicative<'V>`` = lift2 f x y
 
     /// Sequences two applicatives left-to-right, discarding the value of the first argument.
     let inline ( *>) (x: '``Applicative<'T>``) (y: '``Applicative<'U>``) : '``Applicative<'U>`` = ((fun (_: 'T) (k: 'U) -> k) <!>  x : '``Applicative<'U->'U>``) <*> y

--- a/src/FSharpPlus/Samples/Learn You a Haskell.fsx
+++ b/src/FSharpPlus/Samples/Learn You a Haskell.fsx
@@ -31,7 +31,7 @@ let res14 = (+) <!> ((+) 3) <*> ((*) 100) <| 5                        // 508
 
 let res15 = (+) <!> (ZipList <| seq { 1..3 }) <*> (ZipList <| Seq.init 3 (fun _ -> 100)) |> ZipList.run  // seq [101; 102; 103]
 let res16 = (fun x -> [x]) <!> (Some 4)                               // Some [4]
-let res17 = liftA2 (fun x xs -> x::xs) (Some 3) (Some [4])            // [3; 4]
+let res17 = lift2 (fun x xs -> x::xs) (Some 3) (Some [4])            // [3; 4]
 
 let res18 = List.sequence [Some 3; Some 2; Some 1]                    // Some [3; 2; 1]
 

--- a/tests/FSharpPlus.Tests/General.fs
+++ b/tests/FSharpPlus.Tests/General.fs
@@ -200,7 +200,7 @@ module Monoid =
         static member Map   (ZipList x, f: 'a->'b)                = ZipList (Seq.map f x)
         static member (<*>) (ZipList (f: seq<'a->'b>), ZipList x) = ZipList (Seq.zip f x |> Seq.map (fun (f,x) -> f x)) : ZipList<'b>
         static member inline get_Zero () = result zero            : ZipList<'a>
-        static member inline (+) (x:ZipList<'a>, y:ZipList<'a>) = liftA2 plus x y :ZipList<'a>
+        static member inline (+) (x:ZipList<'a>, y:ZipList<'a>) = lift2 plus x y :ZipList<'a>
         static member ToSeq    (ZipList lst)     = lst
 
     type ZipList'<'s> = ZipList' of 's seq with
@@ -208,7 +208,7 @@ module Monoid =
         static member Map   (ZipList' x, f: 'a->'b)                 = ZipList' (Seq.map f x)
         static member (<*>) (ZipList' (f: seq<'a->'b>), ZipList' x) = ZipList' (Seq.zip f x |> Seq.map (fun (f,x) -> f x)) : ZipList'<'b>
         static member inline get_Zero () = result zero              : ZipList'<'a>
-        static member inline (+) (x: ZipList'<'a>, y: ZipList'<'a>) = liftA2 plus x y :ZipList'<'a>
+        static member inline (+) (x: ZipList'<'a>, y: ZipList'<'a>) = lift2 plus x y :ZipList'<'a>
         static member inline Sum (x: seq<ZipList'<'a>>) = SideEffects.add "Using optimized Sum"; List.foldBack plus (Seq.toList x) zero : ZipList'<'a>
         static member ToSeq    (ZipList' lst)     = lst
 


### PR DESCRIPTION
Add liftA function and replace all of the usages of liftA2.

Related: #234 