### PR TITLE
Document extensions

### DIFF
--- a/docsrc/content/extensions.fsx
+++ b/docsrc/content/extensions.fsx
@@ -21,18 +21,20 @@ such as `map`, `bind` and `apply` on List, Array, and Seq, but also Option and R
 
 Construction:
 =============
-This is added and is already defined for Seq, Array and List:
+The `singleton` function is already defined for Seq, Array and List, but F#+ adds it for Enumerator:
 
  * Enumerator.singleton - construct a container with the given value inside it
 
 To construct MonadError instances (Result or Choice) you can use result/throw:
 
- * result - construct with the given value (as Ok or Choice1Of2)
- * throw - construct an error from the given value (as Error or Choice2of2)
+ * Result.result / Choice.result - construct with the given value (as Ok or Choice1Of2)
+ * Result.throw / Choice.throw - construct an error from the given value (as Error or Choice2of2)
 
 It's also possible to construct by wrapping exception producing functions:
 
- * protect - protect a function in try/catch, returning a wrapped value
+ * Option.protect - returns None on exception
+ * Result.protect - returns Error with exception value on exception
+ * Choice.protect - returns Choice2Of2 with exception value on exception
 *)
     // throws "ArgumentException: The input sequence was empty."
     let expectedSingleItem = List.exactlyOne []
@@ -53,12 +55,13 @@ Some extensions on Result are designed to behave like Option:
 
  * Result.get - unwraps the value when it is an 'ok, otherwise throws an exception
  * Result.defaultValue - return the 'ok value if present, otherwise the default value
- * Result.defaultWith - return the 'ok value uif present, otherwise apply the given function
+ * Result.defaultWith - return the 'ok value if present, otherwise apply the given function
    to the 'error value
 
 To deconstruct MonadError instances (Result or Choice) use:
 
- * either - unwraps the result/choice by applying the given `ok` or `err` function as appropriate
+ * Result.either - unwraps the result by applying the given `ok` or `err` function as appropriate
+ * Choice.either - unwraps the choice by applying the given `choice1` or `choice2` function as appropriate
 
 Note that there is also the generic `either` operator function that works
 exactly the same as `Result.either`.

--- a/docsrc/content/extensions.fsx
+++ b/docsrc/content/extensions.fsx
@@ -163,7 +163,7 @@ Converting between `Choice` and `Result` is often useful:
 The String type:
 ================
 
- * [ String ](reference/fsharppuls-string.html)
+ * [ String ](reference/fsharpplus-string.html)
    * intercalate, intersperse, 
    * split, replace
    * isSubString, startsWith, endsWith, contains
@@ -189,9 +189,9 @@ Collections / Traversable types:
    * split, replace,
    * findSliceIndex, trySliceIndex,
    * partitionMap
- * [IList](reference/fsharpplus-ilist.html)]
+ * [IList](reference/fsharpplus-ilist.html)
    * toIReadOnlyList
- * [List](reference/fsharpplus-list.html)]
+ * [List](reference/fsharpplus-list.html)
    * singleton,
    * cons,
    * apply,
@@ -227,7 +227,7 @@ Collections / Traversable types:
  * [ IReadOnlyCollection ](reference/fsharpplus-ireadonlycollection.html)
      * ofArray, ofList, ofSeq
      * map
- * [ IReadOnlyList ](reference/fsharpplus-readonlylist.html)
+ * [ IReadOnlyList ](reference/fsharpplus-ireadonlylist.html)
    * ofArray, toArray
    * trySetItem, tryItem
  * [ Map ](reference/fsharpplus-map.html)

--- a/docsrc/content/extensions.fsx
+++ b/docsrc/content/extensions.fsx
@@ -1,0 +1,295 @@
+(*** hide ***)
+// This block of code is omitted in the generated HTML documentation. Use 
+// it to define helpers that you do not want to show in the documentation.
+#I "../../bin"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
+
+(**
+Extensions
+=======================
+Extensions are what you probably expect: helper functions for existing types.
+ 
+They are defined as modules with the same name as the types they operate on
+under the FSharpPlus namespace, so can be accessed via:
+*)
+open FSharpPlus
+
+(**
+Some functions are common across traversable types such as `intercalate` on
+List, Array and Seq, and others are common across wrapping containers,
+such as `map`, `bind` and `apply` on List, Array, and Seq, but also Option and Result.
+
+Construction:
+=============
+This is added and is already defined for Seq, Array and List:
+
+ * Enumerator.singleton - construct a container with the given value inside it
+
+To construct MonadError instances (Result or Choice) you can use result/throw:
+
+ * result - construct with the given value (as Ok or Choice1Of2)
+ * throw - construct an error from the given value (as Error or Choice2of2)
+
+It's also possible to construct by wrapping exception producing functions:
+
+ * protect - protect a function in try/catch, returning a wrapped value
+
+    // throws "ArgumentException: The input sequence was empty."
+    let expectedSingleItem = List.exactlyOne []
+
+    // returns a Result.Error holding the exception as its value:
+    let expectedSingleItem = Result.protect List.exactlyOne []
+
+    // ...or like typical try prefixed functions, treat exception as None
+    let expectedSingleItem = Option.protect List.exactlyOne []
+
+    // which might look like this:
+    let inline tryExactlyOne xs = Option.protect List.exactlyOne xs
+
+Deconstruction (unwrapping):
+============================
+Some extensions on Result are designed to behave like Option:
+
+ * Result.get - unwraps the value when it is an 'ok, otherwise throws an exception
+ * Result.defaultValue - return the 'ok value if present, otherwise the default value
+ * Result.defaultWith - return the 'ok value uif present, otherwise apply the given function
+   to the 'error value
+
+To deconstruct MonadError instances (Result or Choice) use:
+
+ * either - unwraps the result/choice by applying the given `ok` or `err` function as appropriate
+
+Note that there is also the generic `either` operator function that works
+exactly the same as `Result.either`.
+
+Also, see the generic function [`option`](reference/fsharpplus-operators.html) that
+unwraps an Option in a similar way to `either`.
+
+On Foldables (collections)
+==========================
+Most collections, or specifically 'foldable' instances implement these:
+
+ * intersperse - takes an element and `intersperses' that element between the elements
+
+    ["Bob"; "Jane"] |> List.intersperse "and"
+    // ["Bob"; "and"; "Jane"]
+
+    "WooHoo" |> String.intersperse '-'
+    // val it : string = "W-o-o-H-o-o"
+
+ * intercalate - insert a list of elements between each element and flattens
+
+    [[1;2]; [3;4]] |> List.intercalate [-1;-2];;  
+    // val it : int list = [1; 2; -1; -2; 3; 4]
+
+    ["Woo"; "Hoo"] |> String.intercalate "--o.o--";;
+    // val it : string = "Woo--o.o--Hoo"
+    
+ * zip/unzip - tuple together values inside two containers, or untuble tupled values
+
+On Monad/Functor/Applicatives
+=============================
+Types that implement these will (typically) have these functions defined:
+
+ * map - apply a mapping function to the value inside a container
+ * bind - take a contained value, and apply a function that produces another contained value
+ * apply - like map but where the mapping function is also inside a container
+
+These can also be invoked from the generic functions without module prefix as per
+[generic functions & operators](reference/fsharpplus-operators.html).
+
+Flatten:
+========
+Flatten can be used when a container has another container inside it:
+
+ * Choice.flatten
+ * Result.flatten
+ * Option.flatten (already defined in FSharp Core)
+
+Note that on traversable types like List, Array and Seq, FSharp Core uses the
+more common `concat` for flatten and so this naming is continued for Enumerable:
+
+ * Enumerable.concat
+
+Partitioning:
+=============
+Partitioning can be done by applying a separating function that produces a Choice:
+
+ * Array.partitionMap
+ * List.partitionMap
+
+    let isEven x = (x % 2) = 0
+    let chooseEven x = if isEven x then Choice1Of2 x else Choice2Of2 x
+    
+    [1; 2; 3; 4] |> List.partitionMap chooseEven
+    // val it : int list * int list = ([2; 4], [1; 3])
+
+Conversion functions:
+=====================
+F#+ adds functions to convert between Result, Choice and Option types.
+
+These should be self explanatory, but be aware that sometimes they are 'lossy'
+usually when converting to Option:
+
+    // Convert a `Result` to an `Option` - effectively throws away error value
+    // when present, by replacing with `None`
+    request |> validateRequest |> Option.ofResult
+
+Going the other way is similar, but a value needs to be filled in for None:
+
+    let firstElementOption = xs |> List.tryHead
+
+    // Convert an `Option` to a `Result` will use unit as the Error:
+    firstElementOption |> Option.toResult
+
+    // ...but you can specify an error value with Option.toResultWith:
+    firstElementOption |> Option.toResultWith "No Element"
+
+Converting between `Choice` and `Result` is often useful:
+
+    let asyncChoice = anAsyncValue |> Async.Catch |> Async.map Result.ofChoice
+
+The String type:
+================
+
+ * [ String ](reference/fsharppuls-string.html)
+   * intercalate, intersperse, 
+   * split, replace
+   * isSubString, startsWith, endsWith, contains
+   * toUpper, toLower
+   * trimWhiteSpaces
+   * normalize
+   * removeDiacritics
+   * padLeft, padLeftWith, padRight, padRightWith
+   * trim, trimStart, trimEnd
+   * item, tryItem
+   * rev
+   * take, skip takeWhile, skipWhile
+   * truncate, drop
+   * findIndex, tryFindIndex
+   * findSliceIndex, tryFindSliceIndex
+   * toArray, ofArray, toList, ofList, toSeq, ofSeq, toCodePoints, ofCodePoints
+   * getBytes
+
+Collections / Traversable types:
+=================================
+ * [Array](reference/fsharpplus-array.html)
+   * intercalate, intersperse,
+   * split, replace,
+   * findSliceIndex, trySliceIndex,
+   * partitionMap
+ * [IList](reference/fsharpplus-ilist.html)]
+   * toIReadOnlyList
+ * [List](reference/fsharpplus-list.html)]
+   * singleton,
+   * cons,
+   * apply,
+   * tails, take, skip, drop,
+   * intercalate, intersperse, 
+   * split, replace,
+   * toIReadOnlyList,
+   * findSliceIndex, tryFindSliceIndex,
+   * partitionMap
+ * [Enumerator](reference/fsharpplus-enumerator.html)
+   * EmptyEnumerator
+      * Empty - create an empty enumerator
+   * ConcatEnumerator
+      * concat
+   * MapEnumerators
+      * map, mapi, map2, mapi2, map3
+   * singleton
+   * tryItem, nth
+   * choose
+   * filter
+   * unfold
+   * upto
+   * zip, zip3
+ * [ Seq ](reference/fsharpplus-seq.html)
+    * bind, apply, foldback
+    * chunkBy
+    * intersperse, intercalate,
+    * split, replace
+    * drop
+    * replicate
+    * toIReadOnlyList
+    * findSliceIndex, tryFindSliceIndex
+ * [ IReadOnlyCollection ](reference/fsharpplus-ireadonlycollection.html)
+     * ofArray, ofList, ofSeq
+     * map
+ * [ IReadOnlyList ](reference/fsharpplus-readonlylist.html)
+   * ofArray, toArray
+   * trySetItem, tryItem
+ * [ Map ](reference/fsharpplus-map.html)
+   * keys, values
+   * mapValues, mapValues2
+   * zip, unzip
+   * unionWith, union, intersectWith, intersect
+ * [ Dict ](reference/fsharpplus-dict.html)
+   * toIReadOnlyDictionary
+   * tryGetValue
+   * containsKey
+   * keys, values
+   * map, map2
+   * zip, unzip
+   * unionWith, union, intersectWith, intersect
+ * [ IReadOnlyDictionary ](reference/fsharpplus-ireadonlydictionary.html)
+   * add, 
+   * tryGetValue, containsKey,
+   * keys, values,
+   * map, map2, 
+   * zip, unzip, 
+   * unionWith, union, intersectWith, intersect
+
+Async and Tasks:
+================
+ * [ Task ](reference/fsharpplus-task.html)
+   * map, map2
+   * apply
+   * zip
+   * join
+ * [ Async ](reference/fsharpplus-async.html)
+   * map, map2
+   * zip
+   * join
+   * apply
+   * raise
+
+Option, Choice and Result types:
+================================
+ * [Option](reference/fsharpplus-option.html)
+   * apply, 
+   * unzip, zip,
+   * toResult, toResultWith, ofResult, 
+   * protect
+ * [Choice](reference/fsharpplus-choice.html)
+   * result, throw - construct a Choice
+   * bind, apply, flatten,
+   * map,
+   * catch, - deprecated
+   * bindChoice2Of2,
+   * either,
+   * protect
+ * [ Result ](reference/fsharpplus-result.html)
+   * result, throw - construct a Result
+   * apply, (map, bind already defined)
+   * flatten,
+   * bindError,
+   * either,
+   * protect,
+   * get,
+   * defaultValue, defaultWith,
+   * toChoice, ofChoice,
+   * partition
+
+Extensions Methods (on existing types):
+=======================================
+These are usable from C#
+
+ * [ Extension Methods ](extension-methods.html)
+   * IEnumerable<'T'>.GetSlice
+   * List<'T>.GetSlice
+   * Task<'T>.WhenAll
+   * Async.Sequence - of seq, list or array
+   * Option.Sequence - of seq
+
+*)

--- a/docsrc/content/extensions.fsx
+++ b/docsrc/content/extensions.fsx
@@ -15,7 +15,7 @@ under the FSharpPlus namespace, so can be accessed via:
 open FSharpPlus
 
 (**
-Some functions are common across traversable types such as `intercalate` on
+Some functions are common across foldable types such as `intercalate` on
 List, Array and Seq, and others are common across wrapping containers,
 such as `map`, `bind` and `apply` on List, Array, and Seq, but also Option and Result.
 
@@ -65,9 +65,11 @@ exactly the same as `Result.either`.
 Also, see the generic function [`option`](reference/fsharpplus-operators.html) that
 unwraps an Option in a similar way to `either`.
 
-On Foldables (collections)
-==========================
+On Foldables
+============
+Foldables are the class of data structures that can be folded to a summary value.
 Most collections, or specifically 'foldable' instances implement these:
+
 
  * intersperse - takes an element and `intersperses' that element between the elements
 
@@ -79,12 +81,12 @@ Most collections, or specifically 'foldable' instances implement these:
 
  * intercalate - insert a list of elements between each element and flattens
 
-    [[1;2]; [3;4]] |> List.intercalate [-1;-2];;  
+    [[1;2]; [3;4]] |> List.intercalate [-1;-2];;
     // val it : int list = [1; 2; -1; -2; 3; 4]
 
     ["Woo"; "Hoo"] |> String.intercalate "--o.o--";;
     // val it : string = "Woo--o.o--Hoo"
-    
+
  * zip/unzip - tuple together values inside two containers, or untuble tupled values
 
 On Monad/Functor/Applicatives

--- a/docsrc/content/extensions.fsx
+++ b/docsrc/content/extensions.fsx
@@ -33,7 +33,7 @@ To construct MonadError instances (Result or Choice) you can use result/throw:
 It's also possible to construct by wrapping exception producing functions:
 
  * protect - protect a function in try/catch, returning a wrapped value
-
+*)
     // throws "ArgumentException: The input sequence was empty."
     let expectedSingleItem = List.exactlyOne []
 
@@ -46,6 +46,7 @@ It's also possible to construct by wrapping exception producing functions:
     // which might look like this:
     let inline tryExactlyOne xs = Option.protect List.exactlyOne xs
 
+(**
 Deconstruction (unwrapping):
 ============================
 Some extensions on Result are designed to behave like Option:
@@ -70,23 +71,25 @@ On Foldables
 Foldables are the class of data structures that can be folded to a summary value.
 Most collections, or specifically 'foldable' instances implement these:
 
-
  * intersperse - takes an element and `intersperses' that element between the elements
 
+*)
     ["Bob"; "Jane"] |> List.intersperse "and"
     // ["Bob"; "and"; "Jane"]
 
     "WooHoo" |> String.intersperse '-'
     // val it : string = "W-o-o-H-o-o"
 
+(**
  * intercalate - insert a list of elements between each element and flattens
-
+*)
     [[1;2]; [3;4]] |> List.intercalate [-1;-2];;
     // val it : int list = [1; 2; -1; -2; 3; 4]
 
     ["Woo"; "Hoo"] |> String.intercalate "--o.o--";;
     // val it : string = "Woo--o.o--Hoo"
 
+(**
  * zip/unzip - tuple together values inside two containers, or untuble tupled values
 
 On Monad/Functor/Applicatives
@@ -119,25 +122,28 @@ Partitioning can be done by applying a separating function that produces a Choic
 
  * Array.partitionMap
  * List.partitionMap
-
+*)
     let isEven x = (x % 2) = 0
     let chooseEven x = if isEven x then Choice1Of2 x else Choice2Of2 x
-    
+
     [1; 2; 3; 4] |> List.partitionMap chooseEven
     // val it : int list * int list = ([2; 4], [1; 3])
 
+(**
 Conversion functions:
 =====================
 F#+ adds functions to convert between Result, Choice and Option types.
 
 These should be self explanatory, but be aware that sometimes they are 'lossy'
 usually when converting to Option:
-
+*)
     // Convert a `Result` to an `Option` - effectively throws away error value
     // when present, by replacing with `None`
     request |> validateRequest |> Option.ofResult
 
+(**
 Going the other way is similar, but a value needs to be filled in for None:
+*)
 
     let firstElementOption = xs |> List.tryHead
 
@@ -147,10 +153,13 @@ Going the other way is similar, but a value needs to be filled in for None:
     // ...but you can specify an error value with Option.toResultWith:
     firstElementOption |> Option.toResultWith "No Element"
 
+(**
 Converting between `Choice` and `Result` is often useful:
+*)
 
     let asyncChoice = anAsyncValue |> Async.Catch |> Async.map Result.ofChoice
 
+(**
 The String type:
 ================
 

--- a/docsrc/content/index.fsx
+++ b/docsrc/content/index.fsx
@@ -18,7 +18,7 @@ as possible.
 
 The additions can be summarised as:
 
- * extensions to core types, such as [`String.toLower`](reference/fsharpplus-string.html)
+ * [Extensions](extensions.html) to core types, such as [`String.toLower`](reference/fsharpplus-string.html)
 
  * [Generic Functions and Operators](reference/fsharpplus-operators.html),
    like `map`, which can be extended to support other types

--- a/docsrc/tools/generate.fsx
+++ b/docsrc/tools/generate.fsx
@@ -120,7 +120,8 @@ let processFile outdir path  =
     let t =
         { properties with
             Body = format body
-            Title = tips}
+            // Title = tips}
+        }
     t 
     |> template
     |> write outfile
@@ -135,6 +136,7 @@ let buildDocumentation () =
   Directory.copyRecursive Path.files Path.output
   IO.Directory.EnumerateFiles Path.content
   |> Seq.iter (processFile Path.output)
+
 // Generate
 copyFiles()
 buildDocumentation()

--- a/docsrc/tools/templates/template.fsx
+++ b/docsrc/tools/templates/template.fsx
@@ -87,9 +87,9 @@ let template (m:PropertyMeta) =
                                         [ str "Tutorial" ] ]
                                   li [ Class "nav-header" ]
                                     [ str "Documentation" ]
-                                  (*li [ ]
+                                  li [ ]
                                     [ a [ Href <| m.Root "/reference/index.html" ]
-                                        [ str "API Reference" ] ]*)
+                                        [ str "API Reference" ] ]
                                   li [ ]
                                     [ a [ Href <| m.Root "/types.html" ]
                                         [ str "Types" ] ]

--- a/src/FSharpPlus/Extensions/Enumerator.fs
+++ b/src/FSharpPlus/Extensions/Enumerator.fs
@@ -8,20 +8,31 @@ open System
 [<RequireQualifiedAccess>]
 module Enumerator =
         
+    /// [omit]
     let inline invalidArgFmt (arg: string) (format: string) paramArray = 
         let msg = String.Format (format,paramArray)
         raise (new ArgumentException (msg, arg))
     
+    /// [omit]
     let noReset ()         = raise (new System.NotSupportedException ("Reset is not supported on this enumerator."))
+    
+    /// [omit]
     let notStarted ()      = invalidOp "Enumeration has not started. Call MoveNext."
+
+    /// [omit]
     let alreadyFinished () = invalidOp "Enumeration already finished."
+
+    /// [omit]
     let check started = if not started then notStarted ()
+
+    /// [omit]
     let dispose (r: System.IDisposable) = r.Dispose ()
     
     open System.Collections
     open System.Collections.Generic
     
     /// A concrete implementation of an enumerator that returns no values
+    /// [omit]
     [<Sealed>]
     type EmptyEnumerator<'T> () =
         let mutable started = false
@@ -45,8 +56,10 @@ module Enumerator =
 
     let singleton x = (Seq.singleton x).GetEnumerator()
 
+    /// [omit]
     type IFinallyEnumerator = abstract AppendFinallyAction : (unit -> unit) -> unit
 
+    /// [omit]
     [<Sealed>]
     type ConcatEnumerator<'T> (sources: IEnumerator<IEnumerator<'T>>) =
         let mutable outerEnum = sources


### PR DESCRIPTION
Still WIP, but want to put this up for discussion.

The idea was to more conversationally introduce extensions from perspective of utility to user, rather than list off like an API doc.

I dumped all the functions into the doc, which was useful to 'see' them all, but not sure they'll stay -- can just link to the appropriate API doc. However, might still be useful to group within a module (eg map, apply, bind together) instead of alphabetical ordering default of API.