### PR TITLE
Generalize short-circuit for Traverse

### DIFF
--- a/src/FSharpPlus/Control/Alternative.fs
+++ b/src/FSharpPlus/Control/Alternative.fs
@@ -27,6 +27,8 @@ type Empty =
         let inline call (mthd: ^M, output: ^R) = ((^M or ^R) : (static member Empty : _*_ -> _) output, mthd)
         call (Unchecked.defaultof<Empty>, Unchecked.defaultof<'``Alternative<'T>``> )
 
+    static member inline InvokeOnInstance () : '``Alternative<'T>`` = (^``Alternative<'T>`` : (static member Empty : ^``Alternative<'T>``) ())
+
 
 type Append =
     inherit Default1

--- a/src/FSharpPlus/Control/Applicative.fs
+++ b/src/FSharpPlus/Control/Applicative.fs
@@ -61,3 +61,30 @@ type Apply =
 
     static member inline InvokeOnInstance (f: '``Applicative<'T->'U>``) (x: '``Applicative<'T>``) : '``Applicative<'U>`` =
         ((^``Applicative<'T->'U>`` or ^``Applicative<'T>`` or ^``Applicative<'U>``) : (static member (<*>) : _*_ -> _) (f, x))
+
+
+type IsLeftZeroForApply =
+    inherit Default1
+
+    static member IsLeftZeroForApply (Lazy (t: seq<_>     ) , _mthd: IsLeftZeroForApply) = Seq.isEmpty t
+    static member IsLeftZeroForApply (Lazy (t: list<_>    ) , _mthd: IsLeftZeroForApply) = List.isEmpty t
+    static member IsLeftZeroForApply (Lazy (t: array<_>   ) , _mthd: IsLeftZeroForApply) = Array.isEmpty t
+    static member IsLeftZeroForApply (Lazy (t: option<_>  ) , _mthd: IsLeftZeroForApply) = Option.isNone t
+    static member IsLeftZeroForApply (Lazy (t: Result<_,_>) , _mthd: IsLeftZeroForApply) = match t with Error _      -> true | _ -> false
+    static member IsLeftZeroForApply (Lazy (t: Choice<_,_>) , _mthd: IsLeftZeroForApply) = match t with Choice2Of2 _ -> true | _ -> false
+
+    static member inline Invoke (x: '``Applicative<'T>``) : bool =
+        let inline call (mthd : ^M, input: ^I) =
+            ((^M or ^I) : (static member IsLeftZeroForApply : _*_ -> _) (lazy input), mthd)
+        call(Unchecked.defaultof<IsLeftZeroForApply>, x)
+
+    static member inline InvokeOnInstance (x: '``Applicative<'T>``) : bool =
+        ((^``Applicative<'T>``) : (static member IsLeftZeroForApply : _ -> _) x)
+
+type IsLeftZeroForApply with
+
+    // empty <*> f = empty  ==> empty is left zero for <*>
+    static member inline IsLeftZeroForApply (Lazy (t: '``Alternative<'T>``)       , _mthd: Default2) = (t = Empty.InvokeOnInstance ())
+
+    static member inline IsLeftZeroForApply (Lazy (t: '``Applicative<'T>``)       , _mthd: Default1) = ((^``Applicative<'T>``) : (static member IsLeftZeroForApply : _ -> _) t)
+    static member inline IsLeftZeroForApply (Lazy (_: ^t when ^t: null and ^t: struct), _: Default1) = ()

--- a/src/FSharpPlus/Control/Applicative.fs
+++ b/src/FSharpPlus/Control/Applicative.fs
@@ -66,16 +66,16 @@ type Apply =
 type IsLeftZeroForApply =
     inherit Default1
 
-    static member IsLeftZeroForApply (Lazy (t: seq<_>     ) , _mthd: IsLeftZeroForApply) = Seq.isEmpty t
-    static member IsLeftZeroForApply (Lazy (t: list<_>    ) , _mthd: IsLeftZeroForApply) = List.isEmpty t
-    static member IsLeftZeroForApply (Lazy (t: array<_>   ) , _mthd: IsLeftZeroForApply) = Array.isEmpty t
-    static member IsLeftZeroForApply (Lazy (t: option<_>  ) , _mthd: IsLeftZeroForApply) = Option.isNone t
-    static member IsLeftZeroForApply (Lazy (t: Result<_,_>) , _mthd: IsLeftZeroForApply) = match t with Error _      -> true | _ -> false
-    static member IsLeftZeroForApply (Lazy (t: Choice<_,_>) , _mthd: IsLeftZeroForApply) = match t with Choice2Of2 _ -> true | _ -> false
+    static member IsLeftZeroForApply (t: ref<seq<_>>      , _mthd: IsLeftZeroForApply) = Seq.isEmpty t.Value
+    static member IsLeftZeroForApply (t: ref<list<_>>     , _mthd: IsLeftZeroForApply) = List.isEmpty t.Value
+    static member IsLeftZeroForApply (t: ref<array<_>>    , _mthd: IsLeftZeroForApply) = Array.isEmpty t.Value
+    static member IsLeftZeroForApply (t: ref<option<_>>   , _mthd: IsLeftZeroForApply) = Option.isNone t.Value
+    static member IsLeftZeroForApply (t: ref<Result<_,_>> , _mthd: IsLeftZeroForApply) = match t.Value with Error _      -> true | _ -> false
+    static member IsLeftZeroForApply (t: ref<Choice<_,_>> , _mthd: IsLeftZeroForApply) = match t.Value with Choice2Of2 _ -> true | _ -> false
 
     static member inline Invoke (x: '``Applicative<'T>``) : bool =
         let inline call (mthd : ^M, input: ^I) =
-            ((^M or ^I) : (static member IsLeftZeroForApply : _*_ -> _) (lazy input), mthd)
+            ((^M or ^I) : (static member IsLeftZeroForApply : _*_ -> _) ref input, mthd)
         call(Unchecked.defaultof<IsLeftZeroForApply>, x)
 
     static member inline InvokeOnInstance (x: '``Applicative<'T>``) : bool =
@@ -84,7 +84,7 @@ type IsLeftZeroForApply =
 type IsLeftZeroForApply with
 
     // empty <*> f = empty  ==> empty is left zero for <*>
-    static member inline IsLeftZeroForApply (Lazy (t: '``Alternative<'T>``)       , _mthd: Default2) = (t = Empty.InvokeOnInstance ())
+    static member inline IsLeftZeroForApply (t: ref<'``Alternative<'T>``>        , _mthd: Default2) = (t.Value = Empty.InvokeOnInstance ())
 
-    static member inline IsLeftZeroForApply (Lazy (t: '``Applicative<'T>``)       , _mthd: Default1) = ((^``Applicative<'T>``) : (static member IsLeftZeroForApply : _ -> _) t)
-    static member inline IsLeftZeroForApply (Lazy (_: ^t when ^t: null and ^t: struct), _: Default1) = ()
+    static member inline IsLeftZeroForApply (t: ref<'``Applicative<'T>``>        , _mthd: Default1) = (^``Applicative<'T>`` : (static member IsLeftZeroForApply : _ -> _) t.Value)
+    static member inline IsLeftZeroForApply (_: ref< ^t> when ^t: null and ^t: struct, _: Default1) = ()

--- a/src/FSharpPlus/Control/Traversable.fs
+++ b/src/FSharpPlus/Control/Traversable.fs
@@ -16,7 +16,7 @@ type Sequence =
 
     #if !FABLE_COMPILER
     [<EditorBrowsable(EditorBrowsableState.Never)>]
-    static member inline ForInfiniteSequences (t: seq<_>, isFailure) =
+    static member inline ForInfiniteSequences (t: seq<_>, isFailure, conversion) =
         let add x y = Array.append x [|y|]
         let mutable go = true
         let mutable r = result [||]
@@ -24,7 +24,7 @@ type Sequence =
         while e.MoveNext () && go do
             if isFailure e.Current then go <- false
             r <- Map.Invoke add r <*> e.Current
-        Map.Invoke Array.toSeq r
+        Map.Invoke conversion r
     #endif
     
 
@@ -46,7 +46,7 @@ type Traverse =
 
     static member inline Traverse (t: seq<'T>, f: 'T->'``Functor<'U>``, [<Optional>]_output: '``Functor<seq<'U>>``, [<Optional>]_impl: Default2) =
         let mapped = Seq.map f t
-        Sequence.ForInfiniteSequences (mapped, IsLeftZeroForApply.Invoke) : '``Functor<seq<'U>>``
+        Sequence.ForInfiniteSequences (mapped, IsLeftZeroForApply.Invoke, Array.toSeq) : '``Functor<seq<'U>>``
 
     static member Traverse (t: 't seq, f: 't->Async<'u>, [<Optional>]_output: Async<seq<'u>>, [<Optional>]_impl: Default2) : Async<seq<_>> = async {
         let! ct = Async.CancellationToken
@@ -92,23 +92,23 @@ type Sequence with
                         let cons_f x ys = Map.Invoke (cons: 'a->seq<_>->seq<_>) x <*> ys
                         Seq.foldBack cons_f t (result Seq.empty)
 
-    static member inline Sequence (t: seq<'``Applicative<'T>``>, [<Optional>]_output: '``Applicative<seq<'T>>``   , [<Optional>]_impl: Default4) = Sequence.ForInfiniteSequences (t, IsLeftZeroForApply.Invoke) : '``Applicative<seq<'T>>``
-    static member        Sequence (t: seq<option<'t>>   , [<Optional>]_output: option<seq<'t>>    , [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, Option.isNone)                              : option<seq<'t>>
-    static member        Sequence (t: seq<Result<'t,'e>>, [<Optional>]_output: Result<seq<'t>, 'e>, [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, function Error _      -> true | _ -> false) : Result<seq<'t>, 'e>
-    static member        Sequence (t: seq<Choice<'t,'e>>, [<Optional>]_output: Choice<seq<'t>, 'e>, [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, function Choice2Of2 _ -> true | _ -> false) : Choice<seq<'t>, 'e>
-    static member        Sequence (t: seq<list<'t>>     , [<Optional>]_output: list<seq<'t>>      , [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, List.isEmpty)                               : list<seq<'t>>
-    static member        Sequence (t: seq<'t []>        , [<Optional>]_output: seq<'t> []         , [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, Array.isEmpty)                              : seq<'t> []
+    static member inline Sequence (t: seq<'``Applicative<'T>``>, [<Optional>]_output: '``Applicative<seq<'T>>``   , [<Optional>]_impl: Default4) = Sequence.ForInfiniteSequences (t, IsLeftZeroForApply.Invoke, Array.toSeq)   : '``Applicative<seq<'T>>``
+    static member        Sequence (t: seq<option<'t>>   , [<Optional>]_output: option<seq<'t>>    , [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, Option.isNone, Array.toSeq)                                : option<seq<'t>>
+    static member        Sequence (t: seq<Result<'t,'e>>, [<Optional>]_output: Result<seq<'t>, 'e>, [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, (function Error _      -> true | _ -> false), Array.toSeq) : Result<seq<'t>, 'e>
+    static member        Sequence (t: seq<Choice<'t,'e>>, [<Optional>]_output: Choice<seq<'t>, 'e>, [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, (function Choice2Of2 _ -> true | _ -> false), Array.toSeq) : Choice<seq<'t>, 'e>
+    static member        Sequence (t: seq<list<'t>>     , [<Optional>]_output: list<seq<'t>>      , [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, List.isEmpty, Array.toSeq)                                 : list<seq<'t>>
+    static member        Sequence (t: seq<'t []>        , [<Optional>]_output: seq<'t> []         , [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, Array.isEmpty, Array.toSeq)                                : seq<'t> []
     #endif
 
-    static member        Sequence (t: seq<Async<'t>>    , [<Optional>]_output: Async<seq<'t>>     , [<Optional>]_impl: Default3) = Async.Sequence t                                                               : Async<seq<'t>>
+    static member        Sequence (t: seq<Async<'t>>    , [<Optional>]_output: Async<seq<'t>>     , [<Optional>]_impl: Default3) = Async.Sequence t                                                          : Async<seq<'t>>
 
-    static member inline Sequence (t: ^a                , [<Optional>]_output: 'R                 , [<Optional>]_impl: Default2) = Traverse.InvokeOnInstance id t                                                        : 'R
-    static member inline Sequence (t: ^a                , [<Optional>]_output: 'R                 , [<Optional>]_impl: Default1) = Sequence.InvokeOnInstance t                                                           : 'R
+    static member inline Sequence (t: ^a                , [<Optional>]_output: 'R                 , [<Optional>]_impl: Default2) = Traverse.InvokeOnInstance id t                                            : 'R
+    static member inline Sequence (t: ^a                , [<Optional>]_output: 'R                 , [<Optional>]_impl: Default1) = Sequence.InvokeOnInstance t                                               : 'R
 
     #if !FABLE_COMPILER
-    static member inline Sequence (t: option<_>         , [<Optional>]_output: 'R                 , [<Optional>]_impl: Sequence) = match t with Some x -> Map.Invoke Some x | _ -> result None                           : 'R
-    static member inline Sequence (t: list<_>           , [<Optional>]_output: 'R                 , [<Optional>]_impl: Sequence) = let cons_f x ys = Map.Invoke List.cons x <*> ys in List.foldBack cons_f t (result []) : 'R
-    static member inline Sequence (t: _ []              , [<Optional>]_output: 'R                 , [<Optional>]_impl: Sequence) = let cons x y = Array.append [|x|] y in let cons_f x ys = Map.Invoke cons x <*> ys in Array.foldBack cons_f t (result [||]) : 'R
+    static member inline Sequence (t: option<_>         , [<Optional>]_output: 'R                 , [<Optional>]_impl: Sequence) = match t with Some x -> Map.Invoke Some x | _ -> result None               : 'R
+    static member inline Sequence (t: list<_>           , [<Optional>]_output: 'R                 , [<Optional>]_impl: Sequence) = Sequence.ForInfiniteSequences(t, IsLeftZeroForApply.Invoke, Array.toList) : 'R
+    static member inline Sequence (t: _ []              , [<Optional>]_output: 'R                 , [<Optional>]_impl: Sequence) = Sequence.ForInfiniteSequences(t, IsLeftZeroForApply.Invoke, id) : 'R
     #endif
  
     static member inline Sequence (t: Id<'``Functor<'T>``>         , [<Optional>]_output: '``Functor<Id<'T>>``          , [<Optional>]_impl: Sequence) = Traverse.Invoke id t : '``Functor<Id<'T>>``

--- a/src/FSharpPlus/Control/Traversable.fs
+++ b/src/FSharpPlus/Control/Traversable.fs
@@ -90,12 +90,17 @@ type Traverse =
 type Sequence with
 
     #if !FABLE_COMPILER
-    static member inline Sequence (t:_ seq         , [<Optional>]_output: 'R, [<Optional>]_impl:Default4 ) : 'R =
+    static member inline Sequence (t:_ seq         , [<Optional>]_output: 'R, [<Optional>]_impl:Default5) : 'R =
                         let cons x y = seq {yield x; yield! y}
                         let cons_f x ys = Map.Invoke (cons: 'a->seq<_>->seq<_>) x <*> ys
                         Seq.foldBack cons_f t (result Seq.empty)
 
-    static member inline Sequence (t: seq<'``Applicative<'T>``>, [<Optional>]_output: '``Applicative<seq<'T>>``   , [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences (t, IsLeftZeroForApply.Invoke) : '``Applicative<seq<'T>>``
+    static member inline Sequence (t: seq<'``Applicative<'T>``>, [<Optional>]_output: '``Applicative<seq<'T>>``   , [<Optional>]_impl: Default4) = Sequence.ForInfiniteSequences (t, IsLeftZeroForApply.Invoke) : '``Applicative<seq<'T>>``
+    static member        Sequence (t: seq<option<'t>>   , [<Optional>]_output: option<seq<'t>>    , [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, Option.isNone)                              : option<seq<'t>>
+    static member        Sequence (t: seq<Result<'t,'e>>, [<Optional>]_output: Result<seq<'t>, 'e>, [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, function Error _      -> true | _ -> false) : Result<seq<'t>, 'e>
+    static member        Sequence (t: seq<Choice<'t,'e>>, [<Optional>]_output: Choice<seq<'t>, 'e>, [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, function Choice2Of2 _ -> true | _ -> false) : Choice<seq<'t>, 'e>
+    static member        Sequence (t: seq<list<'t>>     , [<Optional>]_output: list<seq<'t>>      , [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, List.isEmpty)                               : list<seq<'t>>
+    static member        Sequence (t: seq<'t []>        , [<Optional>]_output: seq<'t> []         , [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, Array.isEmpty)                              : seq<'t> []
     #endif
 
     static member        Sequence (t: seq<Async<'t>>    , [<Optional>]_output: Async<seq<'t>>     , [<Optional>]_impl: Default3) = Async.Sequence t                                                               : Async<seq<'t>>

--- a/src/FSharpPlus/Control/Traversable.fs
+++ b/src/FSharpPlus/Control/Traversable.fs
@@ -17,16 +17,13 @@ type Sequence =
     #if !FABLE_COMPILER
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline ForInfiniteSequences (t: seq<_>, isFailure) =
-        let mutable failure = None
-        let buf = Seq.toArray (seq {
-            use e = t.GetEnumerator ()
-            while e.MoveNext () && failure.IsNone do
-                if isFailure e.Current then failure <- Some e.Current
-                else yield e.Current })
-        let buf = match failure with None -> buf | Some e -> [|e|]
-        let cons x y = Array.append [|x|] y
-        let cons_f x ys = Map.Invoke cons x <*> ys
-        let r = Array.foldBack cons_f buf (result [||])
+        let add x y = Array.append x [|y|]
+        let mutable go = true
+        let mutable r = result [||]
+        use e = t.GetEnumerator ()
+        while e.MoveNext () && go do
+            if isFailure e.Current then go <- false
+            r <- Map.Invoke add r <*> e.Current
         Map.Invoke Array.toSeq r
     #endif
     

--- a/src/FSharpPlus/Control/Traversable.fs
+++ b/src/FSharpPlus/Control/Traversable.fs
@@ -14,8 +14,6 @@ type Sequence =
     inherit Default1
     static member inline InvokeOnInstance (t: '``Traversable<Functor<'T>>``) = (^``Traversable<Functor<'T>>`` : (static member Sequence : _ -> _) t) : '``Functor<'Traversable<'T>>``
 
-    // (f: 'T->'``Functor<'U>``) (t: '``Traversable<'T>``) : '``Functor<'Traversable<'U>>``
-
     #if !FABLE_COMPILER
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline ForInfiniteSequences (t: seq<_>, isFailure) =
@@ -49,15 +47,9 @@ type Traverse =
        Seq.foldBack cons_f t (result Seq.empty)
     #endif
 
-    static member Traverse (t: 't seq, f: 't->'u option, [<Optional>]_output: option<seq<'u>>, [<Optional>]_impl: Default2) =
-       let ok = ref true
-       let res = Seq.toArray (seq {
-           use e = t.GetEnumerator ()
-           while e.MoveNext() && ok.Value do
-               match f e.Current with
-               | Some v -> yield v
-               | None   -> ok.Value <- false})
-       if ok.Value then Some (Array.toSeq res) else None
+    static member inline Traverse (t: seq<'T>, f: 'T->'``Functor<'U>``, [<Optional>]_output: '``Functor<seq<'U>>``, [<Optional>]_impl: Default2) =
+        let mapped = Seq.map f t
+        Sequence.ForInfiniteSequences (mapped, IsLeftZeroForApply.Invoke) : '``Functor<seq<'U>>``
 
     static member Traverse (t: 't seq, f: 't->Async<'u>, [<Optional>]_output: Async<seq<'u>>, [<Optional>]_impl: Default2) : Async<seq<_>> = async {
         let! ct = Async.CancellationToken
@@ -103,11 +95,7 @@ type Sequence with
                         let cons_f x ys = Map.Invoke (cons: 'a->seq<_>->seq<_>) x <*> ys
                         Seq.foldBack cons_f t (result Seq.empty)
 
-    static member        Sequence (t: seq<option<'t>>   , [<Optional>]_output: option<seq<'t>>    , [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, Option.isNone)                                : option<seq<'t>>
-    static member        Sequence (t: seq<Result<'t,'e>>, [<Optional>]_output: Result<seq<'t>, 'e>, [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, function (Error _     ) -> true | _ -> false) : Result<seq<'t>, 'e>
-    static member        Sequence (t: seq<Choice<'t,'e>>, [<Optional>]_output: Choice<seq<'t>, 'e>, [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, function (Choice2Of2 _) -> true | _ -> false) : Choice<seq<'t>, 'e>
-    static member        Sequence (t: seq<list<'t>>     , [<Optional>]_output: list<seq<'t>>      , [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, List.isEmpty)                                 : list<seq<'t>>
-    static member        Sequence (t: seq<'t []>        , [<Optional>]_output: seq<'t> []         , [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, Array.isEmpty)                                : seq<'t> []
+    static member inline Sequence (t: seq<'``Applicative<'T>``>, [<Optional>]_output: '``Applicative<seq<'T>>``   , [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences (t, IsLeftZeroForApply.Invoke) : '``Applicative<seq<'T>>``
     #endif
 
     static member        Sequence (t: seq<Async<'t>>    , [<Optional>]_output: Async<seq<'t>>     , [<Optional>]_impl: Default3) = Async.Sequence t                                                               : Async<seq<'t>>

--- a/src/FSharpPlus/FSharpPlus.fsproj
+++ b/src/FSharpPlus/FSharpPlus.fsproj
@@ -62,9 +62,9 @@
     <Compile Include="Control/Numeric.fs" />
     <Compile Include="Control/Monoid.fs" />
     <Compile Include="Control/Monad.fs" />
+    <Compile Include="Control/Alternative.fs" />
     <Compile Include="Control/Applicative.fs" />
     <Compile Include="Control/Functor.fs" />
-    <Compile Include="Control/Alternative.fs" />
     <Compile Include="Control/MonadOps.fs" />
     <Compile Include="Control/Comonad.fs" />
     <Compile Include="Control/Invokable.fs" />

--- a/tests/FSharpPlus.Tests/General.fs
+++ b/tests/FSharpPlus.Tests/General.fs
@@ -964,21 +964,23 @@ module Traversable =
         let rs2  = sequence nel
         Assert.IsInstanceOf<option<NonEmptyList<int>>> rs2
 
+    let toOptions x = if x <> 4 then Some x       else None
+    let toChoices x = if x <> 4 then Choice1Of2 x else Choice2Of2 "This is a failure"
+    let toLists   x = if x <> 4 then [x; x]       else []
+    let toEithers x = if x <> 4 then Right x else Left ["This is a failure"]
+
+    let expectedEffects =
+        [
+            """f(x) <*> Right 0"""
+            """f(x) <*> Right 1"""
+            """f(x) <*> Right 2"""
+            """f(x) <*> Right 3"""
+            """f(x) <*> Left ["This is a failure"]"""
+        ]
+
     [<Test>]
     let traverseInfiniteApplicatives () =
-        let toOptions x = if x <> 4 then Some x       else None
-        let toChoices x = if x <> 4 then Choice1Of2 x else Choice2Of2 "This is a failure"
-        let toLists   x = if x <> 4 then [x; x]       else []
-        let toEithers x = if x <> 4 then Right x else Left ["This is a failure"]
 
-        let expectedEffects =
-            [
-                """f(x) <*> Right 0"""
-                """f(x) <*> Right 1"""
-                """f(x) <*> Right 2"""
-                """f(x) <*> Right 3"""
-                """f(x) <*> Left ["This is a failure"]"""
-            ]
         SideEffects.reset ()
 
         let a = sequence (Seq.initInfinite toOptions)
@@ -1006,25 +1008,41 @@ module Traversable =
 
     [<Test>]
     let traverseFiniteApplicatives () =
-        let toOptions x = if x <> 4 then Some x       else None
-        let toChoices x = if x <> 4 then Choice1Of2 x else Choice2Of2 "This is a failure"
-        let toLists   x = if x <> 4 then [x; x]       else []
-        let toEithers x = if x <> 4 then Right x else Left ["This is a failure"]
+
+        SideEffects.reset ()
+
         let a = sequence (Seq.initInfinite toOptions |> Seq.take 20 |> Seq.toList)
         let b = sequence (Seq.initInfinite toOptions |> Seq.take 20 |> Seq.toList)
         let c = sequence (Seq.initInfinite toChoices |> Seq.take 20 |> Seq.toList)
         let d = sequence (Seq.initInfinite toLists   |> Seq.take 20 |> Seq.toList)
         let e = sequence (Seq.initInfinite toEithers |> Seq.take 20 |> Seq.toList)
+
+        Assert.AreEqual (SideEffects.get (), expectedEffects)
+        SideEffects.reset ()
+
+        let f = sequence (Seq.initInfinite toEithers |> Seq.take 20 |> Seq.toArray)
+
+        Assert.AreEqual (SideEffects.get (), expectedEffects)
+        SideEffects.reset ()
+
         let a' = traverse toOptions [1..20]
         let b' = traverse toOptions [1..20]
         let c' = traverse toChoices [1..20]
         let d' = traverse toLists   [1..20]
         let e' = traverse toEithers [1..20]
+
+        Assert.AreEqual (SideEffects.get (), expectedEffects)
+        SideEffects.reset ()
+
+        let f' = traverse toEithers [|1..20|]
+
+        Assert.AreEqual (SideEffects.get (), expectedEffects)
         Assert.AreEqual (None, a)
         Assert.AreEqual (None, b)
-        Assert.AreEqual (Choice<seq<int>,string>.Choice2Of2 "This is a failure", c)
+        Assert.AreEqual (Choice<list<int>,string>.Choice2Of2 "This is a failure", c)
         Assert.AreEqual ([], d)
-        Assert.AreEqual (Either<string list,seq<int>>.Left ["This is a failure"], e)
+        Assert.AreEqual (Either<string list,list<int>>.Left ["This is a failure"], e)
+        Assert.AreEqual (Either<string list,array<int>>.Left ["This is a failure"], f)
         ()
 
     [<Test>]

--- a/tests/FSharpPlus.Tests/General.fs
+++ b/tests/FSharpPlus.Tests/General.fs
@@ -979,9 +979,9 @@ module Traversable =
         let e' = traverse toEithers (Seq.initInfinite id)
         Assert.AreEqual (None, a)
         Assert.AreEqual (None, b)
-        Assert.AreEqual (Choice2Of2 "This is a failure", c)
+        Assert.AreEqual (Choice<seq<int>,string>.Choice2Of2 "This is a failure", c)
         Assert.AreEqual ([], d)
-        Assert.True ((Left ["This is a failure"] = e))
+        Assert.AreEqual (Either<string list,seq<int>>.Left ["This is a failure"], e)
         let resNone   = traverse (fun x -> if x > 4 then Some x else None) (Seq.initInfinite id) // optimized method, otherwise it doesn't end
         ()
 

--- a/tests/FSharpPlus.Tests/General.fs
+++ b/tests/FSharpPlus.Tests/General.fs
@@ -989,7 +989,7 @@ module Traversable =
         let d = sequence (Seq.initInfinite toLists)
         let e = sequence (Seq.initInfinite toEithers)
 
-        Assert.AreEqual (SideEffects.get (), expectedEffects)
+        CollectionAssert.AreEqual (SideEffects.get (), expectedEffects)
         SideEffects.reset ()
 
         let a' = traverse toOptions (Seq.initInfinite id)
@@ -998,7 +998,7 @@ module Traversable =
         let d' = traverse toLists   (Seq.initInfinite id)
         let e' = traverse toEithers (Seq.initInfinite id)
 
-        Assert.AreEqual (SideEffects.get (), expectedEffects)
+        CollectionAssert.AreEqual (SideEffects.get (), expectedEffects)
         Assert.AreEqual (None, a)
         Assert.AreEqual (None, b)
         Assert.AreEqual (Choice<seq<int>,string>.Choice2Of2 "This is a failure", c)
@@ -1017,12 +1017,12 @@ module Traversable =
         let d = sequence (Seq.initInfinite toLists   |> Seq.take 20 |> Seq.toList)
         let e = sequence (Seq.initInfinite toEithers |> Seq.take 20 |> Seq.toList)
 
-        Assert.AreEqual (SideEffects.get (), expectedEffects)
+        CollectionAssert.AreEqual (SideEffects.get (), expectedEffects)
         SideEffects.reset ()
 
         let f = sequence (Seq.initInfinite toEithers |> Seq.take 20 |> Seq.toArray)
 
-        Assert.AreEqual (SideEffects.get (), expectedEffects)
+        CollectionAssert.AreEqual (SideEffects.get (), expectedEffects)
         SideEffects.reset ()
 
         let a' = traverse toOptions [1..20]
@@ -1031,12 +1031,12 @@ module Traversable =
         let d' = traverse toLists   [1..20]
         let e' = traverse toEithers [1..20]
 
-        Assert.AreEqual (SideEffects.get (), expectedEffects)
+        CollectionAssert.AreEqual (SideEffects.get (), expectedEffects)
         SideEffects.reset ()
 
         let f' = traverse toEithers [|1..20|]
 
-        Assert.AreEqual (SideEffects.get (), expectedEffects)
+        CollectionAssert.AreEqual (SideEffects.get (), expectedEffects)
         Assert.AreEqual (None, a)
         Assert.AreEqual (None, b)
         Assert.AreEqual (Choice<list<int>,string>.Choice2Of2 "This is a failure", c)

--- a/tests/FSharpPlus.Tests/General.fs
+++ b/tests/FSharpPlus.Tests/General.fs
@@ -912,7 +912,8 @@ module Traversable =
     type Either<'l,'r> = Left of 'l | Right of 'r with
         static member Return x = Right x
         static member inline get_Empty () = Left empty
-        static member (<*>) (f, x) = match f, x with Right a, Right b -> Right (a b) | Left e, _ | _, Left e -> Left e        
+        static member (<*>) (f, x) = match f, x with Right a, Right b -> Right (a b) | Left e, _ | _, Left e -> Left e
+        static member IsLeftZeroForApply x = match x with Left _ -> true | _ -> false
 
     let traverseTest =
         let resNone = sequence (seq [Some 3;None ;Some 1])
@@ -978,7 +979,7 @@ module Traversable =
         let e' = traverse toEithers (Seq.initInfinite id)
         Assert.AreEqual (None, a)
         Assert.AreEqual (None, b)
-        Assert.True ((Choice2Of2 "This is a failure" = c))
+        Assert.AreEqual (Choice2Of2 "This is a failure", c)
         Assert.AreEqual ([], d)
         Assert.True ((Left ["This is a failure"] = e))
         let resNone   = traverse (fun x -> if x > 4 then Some x else None) (Seq.initInfinite id) // optimized method, otherwise it doesn't end

--- a/tests/FSharpPlus.Tests/General.fs
+++ b/tests/FSharpPlus.Tests/General.fs
@@ -1031,12 +1031,12 @@ module Traversable =
         let d' = traverse toLists   [1..20]
         let e' = traverse toEithers [1..20]
 
-        CollectionAssert.AreEqual (SideEffects.get (), expectedEffects)
+        CollectionAssert.AreNotEqual (SideEffects.get (), expectedEffects)
         SideEffects.reset ()
 
         let f' = traverse toEithers [|1..20|]
 
-        CollectionAssert.AreEqual (SideEffects.get (), expectedEffects)
+        CollectionAssert.AreNotEqual (SideEffects.get (), expectedEffects)
         Assert.AreEqual (None, a)
         Assert.AreEqual (None, b)
         Assert.AreEqual (Choice<list<int>,string>.Choice2Of2 "This is a failure", c)

--- a/tests/FSharpPlus.Tests/General.fs
+++ b/tests/FSharpPlus.Tests/General.fs
@@ -982,7 +982,6 @@ module Traversable =
         Assert.AreEqual (Choice<seq<int>,string>.Choice2Of2 "This is a failure", c)
         Assert.AreEqual ([], d)
         Assert.AreEqual (Either<string list,seq<int>>.Left ["This is a failure"], e)
-        let resNone   = traverse (fun x -> if x > 4 then Some x else None) (Seq.initInfinite id) // optimized method, otherwise it doesn't end
         ()
 
     [<Test>]


### PR DESCRIPTION
This PR will offer a general solution for #41 

The solution presented here adds a (redundant) method to `Apply` intended for internal use, called `IsLeftZeroForApply`.

The theory behind it is that a binary operation can have one (or more) left-zero elements, a left zero element is a element `z` such that:

    z * e = z

So, we add overloads of this method for some types that we can tell about their left-zero elements. But for types that are Alternatives we don't need an overload because:

    empty <*> f = empty

Which means we can use that knowledge automatically.

For types we can't tell about their left-zero elements we don't add an overload.