### PR TITLE
Better default for Delay

### DIFF
--- a/src/FSharpPlus/Builders.fs
+++ b/src/FSharpPlus/Builders.fs
@@ -119,7 +119,7 @@ module Builders =
             fix ()
         member inline this.For (p: #seq<'T>, rest: 'T->'``MonadPlus<'U>``) : '``MonadPlus<'U>`` =
             let mutable isReallyDelayed = true
-            Delay.Invoke (fun () -> isReallyDelayed <- false; Unchecked.defaultof<'``MonadPlus<'U>``>) |> ignore
+            Delay.Invoke (fun () -> isReallyDelayed <- false; Empty.Invoke () : '``MonadPlus<'U>``) |> ignore
             Using.Invoke (p.GetEnumerator () :> IDisposable) (fun enum ->
                 let enum = enum :?> IEnumerator<_>
                 if isReallyDelayed then this.While (enum.MoveNext, Delay.Invoke (fun () -> rest enum.Current))
@@ -153,7 +153,7 @@ module Builders =
             loop guard body
         member inline this.For (p: #seq<'T>, rest: 'T->'``Monad<unit>``) : '``Monad<unit>``=
             let mutable isReallyDelayed = true
-            Delay.Invoke (fun () -> isReallyDelayed <- false; Unchecked.defaultof<'``Monad<unit>``>) |> ignore
+            Delay.Invoke (fun () -> isReallyDelayed <- false; Return.Invoke () : '``Monad<unit>``) |> ignore
             Using.Invoke (p.GetEnumerator () :> IDisposable) (fun enum ->
                 let enum = enum :?> IEnumerator<_>
                 if isReallyDelayed then this.While (enum.MoveNext, Delay.Invoke (fun () -> rest enum.Current))

--- a/src/FSharpPlus/Control/Monad.fs
+++ b/src/FSharpPlus/Control/Monad.fs
@@ -141,8 +141,7 @@ type Return =
 type Delay =
     inherit Default1
     
-    static member inline Delay (_mthd: Default3, x: unit-> ^``Monad<'T>`` when ^``Monad<'T>`` :     struct, _: Default2) = x ()
-    static member inline Delay (_mthd: Default3, x: unit-> ^``Monad<'T>`` when ^``Monad<'T>`` : not struct, _: Default1) = x ()
+    static member inline Delay (_mthd: Default3, x: unit-> ^``Monad<'T>``                                 , _: Default1) = Bind.Invoke (Return.Invoke ()) x : ^``Monad<'T>``
     static member inline Delay (_mthd: Default1, x: unit-> ^I                                             , _: Delay   ) = (^I : (static member Delay : _->_) x) : ^I
     static member inline Delay (_mthd: Default1, _: unit-> ^t when  ^t : null and ^t  : struct            , _          ) = ()
 

--- a/src/FSharpPlus/Control/Monad.fs
+++ b/src/FSharpPlus/Control/Monad.fs
@@ -213,11 +213,10 @@ type Using =
         (^``Monad<'U>`` : (static member Using : _*_->_) resource, body) : '``Monad<'U>``
 
 type Using with
-static member inline Using (resource: 'T when 'T :> IDisposable, body: 'T -> '``Monad<'U>`` when '``Monad<'U>``:     struct , _: Default3) = using resource body
-static member inline Using (resource: 'T when 'T :> IDisposable, body: 'T -> '``Monad<'U>`` when '``Monad<'U>``: not struct , _: Default2) = using resource body
-static member inline Using (resource: 'T when 'T :> IDisposable, body: 'T -> '``Monad<'U>``                                 , _: Default1) = TryFinally.InvokeOnInstance (body resource) (fun () -> if not (isNull (box resource)) then resource.Dispose ()) : '``Monad<'U>``
-#if !FABLE_COMPILER
-static member inline Using (resource: 'T when 'T :> IDisposable, body: 'T -> '``Monad<'U>``                                 , _: Using   ) = Using.InvokeOnInstance resource body : '``Monad<'U>``
-static member inline Using (_                                  , _   : 'a -> ^t when ^t : null and ^t: struct               , _: Using   ) = ()
-#endif
-
+    static member inline Using (resource: 'T when 'T :> IDisposable, body: 'T -> '``Monad<'U>`` when '``Monad<'U>``:     struct , _: Default3) = using resource body
+    static member inline Using (resource: 'T when 'T :> IDisposable, body: 'T -> '``Monad<'U>`` when '``Monad<'U>``: not struct , _: Default2) = using resource body
+    static member inline Using (resource: 'T when 'T :> IDisposable, body: 'T -> '``Monad<'U>``                                 , _: Default1) = TryFinally.InvokeOnInstance (body resource) (fun () -> if not (isNull (box resource)) then resource.Dispose ()) : '``Monad<'U>``
+    #if !FABLE_COMPILER
+    static member inline Using (resource: 'T when 'T :> IDisposable, body: 'T -> '``Monad<'U>``                                 , _: Using   ) = Using.InvokeOnInstance resource body : '``Monad<'U>``
+    static member inline Using (_                                  , _   : 'a -> ^t when ^t : null and ^t: struct               , _: Using   ) = ()
+    #endif

--- a/src/FSharpPlus/Data/Cont.fs
+++ b/src/FSharpPlus/Data/Cont.fs
@@ -1,6 +1,8 @@
 ﻿namespace FSharpPlus.Data
 open System.ComponentModel
 
+#nowarn "1125"
+
 /// <summary> Computation type: Computations which can be interrupted and resumed.
 /// <para/>   Binding strategy: Binding a function to a monadic value creates a new continuation which uses the function as the continuation of the monadic computation.
 /// <para/>   Useful for: Complex control structures, error handling, and creating co-routines.</summary>

--- a/src/FSharpPlus/Data/Free.fs
+++ b/src/FSharpPlus/Data/Free.fs
@@ -78,3 +78,4 @@ type Free<'``functor<'t>``,'t> with
     static member Return x = Pure x
     static member inline (>>=) (x: Free<'``Functor<'T>``,'T>, f: 'T -> Free<'``Functor<'U>``,'U>)   = Free.bind  f x : Free<'``Functor<'U>``,'U>
     static member inline (<*>) (f: Free<'``Functor<'T->'U>``,'T->'U>, x: Free<'``Functor<'T>``,'T>) = Free.apply f x : Free<'``Functor<'U>``,'U>
+    static member        Delay (x: unit -> Free<'``Functor<'T>``,'T>) = x ()

--- a/src/FSharpPlus/Data/Free.fs
+++ b/src/FSharpPlus/Data/Free.fs
@@ -5,6 +5,8 @@ open FSharpPlus
 open FSharpPlus.Control
 open FSharpPlus.Internals.Prelude
 
+#nowarn "686"
+
 [<NoComparison>]
 type Free<'``functor<'t>``,'t> = Pure of 't | Roll of obj
 

--- a/src/FSharpPlus/Data/Reader.fs
+++ b/src/FSharpPlus/Data/Reader.fs
@@ -1,5 +1,7 @@
 ﻿namespace FSharpPlus.Data
 
+#nowarn "1125"
+
 open FSharpPlus
 open FSharpPlus.Control
 open System.ComponentModel

--- a/src/FSharpPlus/Data/Reader.fs
+++ b/src/FSharpPlus/Data/Reader.fs
@@ -48,6 +48,7 @@ type Reader<'r,'t> with
     static member inline Extract (Reader (f : 'Monoid -> 'T)) = f (Zero.Invoke ()) : 'T
     static member inline (=>>)   (Reader (g : 'Monoid -> 'T), f : Reader<'Monoid,'T> -> 'U) = Reader (fun a -> f (Reader (fun b -> (g (Plus.Invoke a b))))) : Reader<'Monoid,'U>
 
+    static member TryFinally (Reader computation, f) = Reader (fun s -> try computation s finally f())
 
 /// Monad Transformer for Reader<'R, 'T>
 [<Struct>]

--- a/src/FSharpPlus/Data/Reader.fs
+++ b/src/FSharpPlus/Data/Reader.fs
@@ -48,7 +48,8 @@ type Reader<'r,'t> with
     static member inline Extract (Reader (f : 'Monoid -> 'T)) = f (Zero.Invoke ()) : 'T
     static member inline (=>>)   (Reader (g : 'Monoid -> 'T), f : Reader<'Monoid,'T> -> 'U) = Reader (fun a -> f (Reader (fun b -> (g (Plus.Invoke a b))))) : Reader<'Monoid,'U>
 
-    static member TryFinally (Reader computation, f) = Reader (fun s -> try computation s finally f())
+    static member TryFinally (Reader computation, f) = Reader (fun s -> try computation s finally f ())
+    static member Delay (body: unit -> Reader<'R,'T>) = body () : Reader<'R,'T>
 
 /// Monad Transformer for Reader<'R, 'T>
 [<Struct>]

--- a/src/FSharpPlus/Data/Reader.fs
+++ b/src/FSharpPlus/Data/Reader.fs
@@ -48,8 +48,10 @@ type Reader<'r,'t> with
     static member inline Extract (Reader (f : 'Monoid -> 'T)) = f (Zero.Invoke ()) : 'T
     static member inline (=>>)   (Reader (g : 'Monoid -> 'T), f : Reader<'Monoid,'T> -> 'U) = Reader (fun a -> f (Reader (fun b -> (g (Plus.Invoke a b))))) : Reader<'Monoid,'U>
 
+    static member TryWith (Reader computation, h)    = Reader (fun s -> try computation s with e -> (h e) s) : Reader<'R,'T>
     static member TryFinally (Reader computation, f) = Reader (fun s -> try computation s finally f ())
-    static member Delay (body: unit -> Reader<'R,'T>) = Reader (fun s -> Reader.run (body ()) s) : Reader<'R,'T>
+    static member Using (resource, f: _ -> Reader<'R,'T>) = Reader.TryFinally (f resource, fun () -> dispose resource)
+    static member Delay (body: unit->Reader<'R,'T>)  = Reader (fun s -> Reader.run (body ()) s) : Reader<'R,'T>
 
 
 /// Monad Transformer for Reader<'R, 'T>

--- a/src/FSharpPlus/Data/Reader.fs
+++ b/src/FSharpPlus/Data/Reader.fs
@@ -49,7 +49,8 @@ type Reader<'r,'t> with
     static member inline (=>>)   (Reader (g : 'Monoid -> 'T), f : Reader<'Monoid,'T> -> 'U) = Reader (fun a -> f (Reader (fun b -> (g (Plus.Invoke a b))))) : Reader<'Monoid,'U>
 
     static member TryFinally (Reader computation, f) = Reader (fun s -> try computation s finally f ())
-    static member Delay (body: unit -> Reader<'R,'T>) = body () : Reader<'R,'T>
+    static member Delay (body: unit -> Reader<'R,'T>) = Reader (fun s -> Reader.run (body ()) s) : Reader<'R,'T>
+
 
 /// Monad Transformer for Reader<'R, 'T>
 [<Struct>]

--- a/src/FSharpPlus/Data/State.fs
+++ b/src/FSharpPlus/Data/State.fs
@@ -2,6 +2,8 @@
 open System.ComponentModel
 open FSharpPlus
 
+#nowarn "1125"
+
 /// <summary> Computation type: Computations which maintain state.
 /// <para/>   Binding strategy: Threads a state parameter through the sequence of bound functions so that the same state value is never used twice, giving the illusion of in-place update.
 /// <para/>   Useful for: Building computations from sequences of operations that require a shared state. </summary>

--- a/src/FSharpPlus/Data/State.fs
+++ b/src/FSharpPlus/Data/State.fs
@@ -50,8 +50,11 @@ type State<'s,'t> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Zip (x, y) = State.zip x y
 
-    static member TryFinally (State computation, f) = State (fun s -> try computation s finally f ())
-    static member Delay (body: unit -> State<'S,'T>) = State (fun s -> State.run (body ()) s) : State<'S,'T>
+    static member TryWith (State computation, h)    = State (fun s -> try computation s with e -> (h e) s) : State<'S,'T>
+    static member TryFinally (State computation, f) = State (fun s -> try computation s finally f ()) : State<'S,'T>
+    static member Using (resource, f: _ -> State<'S,'T>) = State.TryFinally (f resource, fun () -> dispose resource)
+    static member Delay (body: unit->State<'S,'T>)  = State (fun s -> State.run (body ()) s) : State<'S,'T>
+
 
 open FSharpPlus.Control
 open FSharpPlus.Internals.Prelude

--- a/src/FSharpPlus/Data/State.fs
+++ b/src/FSharpPlus/Data/State.fs
@@ -50,6 +50,8 @@ type State<'s,'t> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Zip (x, y) = State.zip x y
 
+    static member TryFinally (State computation, f) = State (fun s -> try computation s finally f())
+
 open FSharpPlus.Control
 open FSharpPlus.Internals.Prelude
 

--- a/src/FSharpPlus/Data/State.fs
+++ b/src/FSharpPlus/Data/State.fs
@@ -50,7 +50,8 @@ type State<'s,'t> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Zip (x, y) = State.zip x y
 
-    static member TryFinally (State computation, f) = State (fun s -> try computation s finally f())
+    static member TryFinally (State computation, f) = State (fun s -> try computation s finally f ())
+    static member Delay (body: unit -> State<'S,'T>) = State (fun s -> State.run (body ()) s) : State<'S,'T>
 
 open FSharpPlus.Control
 open FSharpPlus.Internals.Prelude

--- a/src/FSharpPlus/Data/Validations.fs
+++ b/src/FSharpPlus/Data/Validations.fs
@@ -5,6 +5,8 @@ open FSharpPlus.Lens
 open FSharpPlus.Data
 open System.ComponentModel
 
+#nowarn "44"
+
 // Validation is based on https://github.com/qfpl/validation
 
 /// A 'Validation' is either a value of the type 'error or 't, similar to 'Result'. However,

--- a/src/FSharpPlus/Samples/Learn You a Haskell.fsx
+++ b/src/FSharpPlus/Samples/Learn You a Haskell.fsx
@@ -535,7 +535,7 @@ let res119 = solveRPN "1 8 wharglbllargh"                                       
 
 module Probability =
 
-    type Prob<'a> = Prob of List<'a * float>
+    type Prob<'t> = Prob of List<'t * float>
 
     type Prob<'a> with
         static member probMap f (Prob prob : Prob<'a>) : Prob<'b> = List.map (fun (x, p) -> (f x, p)) prob |> Prob

--- a/tests/FSharpPlus.Tests/ComputationExpressions.fs
+++ b/tests/FSharpPlus.Tests/ComputationExpressions.fs
@@ -347,7 +347,7 @@ module ComputationExpressions =
           while (SideEffects.add "moving"; enum.MoveNext ()) do
              SideEffects.add (sprintf "--> %i" enum.Current) }
 
-        areEqual effects (SideEffects.get ())
+        areEqual [] (SideEffects.get ())
         funcM ()
         areEqual effects (SideEffects.get ())
 
@@ -358,7 +358,7 @@ module ComputationExpressions =
           while (SideEffects.add "moving"; enum.MoveNext ()) do
              SideEffects.add (sprintf "--> %i" enum.Current) }
 
-        areEqual effects (SideEffects.get ())
+        areEqual [] (SideEffects.get ())
         Reader.run readerM ()
         areEqual effects (SideEffects.get ())
 
@@ -369,7 +369,7 @@ module ComputationExpressions =
           while (SideEffects.add "moving"; enum.MoveNext ()) do
              SideEffects.add (sprintf "--> %i" enum.Current) }
 
-        areEqual effects (SideEffects.get ())
+        areEqual [] (SideEffects.get ())
         State.run stateM () |> ignore
         areEqual effects (SideEffects.get ())
 
@@ -380,6 +380,6 @@ module ComputationExpressions =
           while (SideEffects.add "moving"; enum.MoveNext ()) do
              SideEffects.add (sprintf "--> %i" enum.Current) }
 
-        areEqual effects (SideEffects.get ())
+        areEqual [] (SideEffects.get ())
         Cont.run contM id
         areEqual effects (SideEffects.get ())

--- a/tests/FSharpPlus.Tests/ComputationExpressions.fs
+++ b/tests/FSharpPlus.Tests/ComputationExpressions.fs
@@ -383,3 +383,28 @@ module ComputationExpressions =
         areEqual [] (SideEffects.get ())
         Cont.run contM id
         areEqual effects (SideEffects.get ())
+
+
+        SideEffects.reset ()
+
+        let readertoptionM : ReaderT<unit,unit option> = monad {
+          use enum = toDebugEnum (SideEffects.add "using"; testSeq.GetEnumerator ())
+          while (SideEffects.add "moving"; enum.MoveNext ()) do
+             SideEffects.add (sprintf "--> %i" enum.Current) }
+
+        areEqual [] (SideEffects.get ())
+        ReaderT.run readertoptionM () |> ignore
+        areEqual effects (SideEffects.get ())
+
+        SideEffects.reset ()
+
+        let readertfuncM : ReaderT<unit,unit->unit> = monad {
+          use enum = toDebugEnum (SideEffects.add "using"; testSeq.GetEnumerator ())
+          while (SideEffects.add "moving"; enum.MoveNext ()) do
+             SideEffects.add (sprintf "--> %i" enum.Current) }
+
+        areEqual [] (SideEffects.get ())
+        let a = ReaderT.run readertfuncM ()
+        areEqual [] (SideEffects.get ())
+        let b = a ()
+        areEqual effects (SideEffects.get ())


### PR DESCRIPTION
This PR will switch the default for `delay` to the one that it's technically correct for delayed builders.

Auto-sense had to be adjusted because the bind operation inside this delay implementation would fail with a null value.

Also, type inference is a bit more complicate which forced me to add a specific delay for Free<'T> with a trivial implementation since it's not a "delayed monad".

It would be interesting to add more testing and see if there is a change in functionality, good or bad (breaking).