### PR TITLE
Adz document generic ops

### DIFF
--- a/docsrc/content/generic-doc.fsx
+++ b/docsrc/content/generic-doc.fsx
@@ -22,7 +22,7 @@ Read about the specific operators:
 
  * Docs on [Operators - Common Combinators](operators-common.html)
  * Other docs exist for each [abstraction](abstractions.html)
- * API Doc for [Generic functions and operators](operators.html)
+ * API Doc for [Generic functions and operators](reference/operators.html)
 
 They're particularly useful in that the specific function called will
 depend on the input arguments and return type. However, this means you
@@ -78,7 +78,7 @@ implementation is used otherwise.
 
 What does this all mean?
 
-It means care is taken to use the most optimised impelemntation, and you can
+It means care is taken to use the most optimised implementation, and you can
 implement your own instances of generic functions if you implement the required
 methods.
 

--- a/docsrc/content/generic-doc.fsx
+++ b/docsrc/content/generic-doc.fsx
@@ -24,7 +24,45 @@ Read about the specific operators:
  * Other docs exist for each [abstraction](abstractions.html)
  * API Doc for [Generic functions and operators](operators.html)
 
+They're particularly useful in that the specific function called will
+depend on the input arguments and return type. However, this means you
+sometimes need to explicitly specify the type if this information is
+not available (actually it's a good debug technique to temporarily add
+the types explicitly when the compiler tells you that the types are wrong).
 
+For example:
+*)
+
+// Convert the number 42 to bytes... 
+// ... here the type is known (42 is an int, the return value is byte[])
+> let a = 42 |> toBytes;;  
+val a : byte [] = [|42uy; 0uy; 0uy; 0uy|]
+
+// However, this can't compile since the return type is not inferrable
+> let b = [|42uy; 0uy; 0uy; 0uy|] |> ofBytes;;  
+
+// The error will be something like:
+// 
+//  let b = [|42uy; 0uy; 0uy; 0uy|] |> ofBytes;;
+//  -----------------------------------^^^^^^^
+//
+// error FS0071: Type constraint mismatch when applying the default type 'obj'
+// for a type inference variable. No overloads match for method 'OfBytes'.
+// The available overloads are shown below. Consider adding further type constraints
+
+// [followed by many possible implementations...]
+
+// So, in this case, we have to give the return type:
+>   let b :int = [|42uy; 0uy; 0uy; 0uy|] |> ofBytes;;
+val b : int = 42
+
+// ...or, the more usual case, you use in context where type can be inferred,
+// like this example:
+> 1 + ([|42uy; 0uy; 0uy; 0uy|] |> ofBytes);;
+val it : int = 43
+
+
+(**
 How do generic functions work?
 ==============================
 

--- a/docsrc/content/generic-doc.fsx
+++ b/docsrc/content/generic-doc.fsx
@@ -10,24 +10,42 @@ open FSharpPlus
 Generic operators and functions
 ===============================
 
-*)
+After reviewing [extension functions](extensions.html) it's natural to want to
+use generic functions that can work across different types.
 
-(**
+F#+ implements generic functions that efficiently call out to specific
+implementations. This handles existing .Net and F# types, and you can use them
+on your own and third-party types by implementing expected method names
+and signatures.
 
-Generic operators, functions and constants are included in this library.
+Read about the specific operators:
 
-They work with many types, including:
-
- 1) Existing .NET and F# types
-
- 2) Other types included in this library
-
- 3) Further user defined types
-
- 4) Types defined in other libraries
+ * Docs on [Operators - Common Combinators](operators-common.html)
+ * Other docs exist for each [abstraction](abstractions.html)
+ * API Doc for [Generic functions and operators](operators.html)
 
 
-Case 1 works by using overload resolution inside an internal class (referred to as the Invokable) used at the definition of the generic operation, while all the other cases work typically through Duck Typing, where an expected method name and signature must exists in the target Type or by using default implementations based on other operations.
+How do generic functions work?
+==============================
+
+F# does not support overloaded functions, but it does support overloaded
+methods on types (classes) - including static methods. F#+ takes
+advantage of this by definining generic functions that call out to
+an internal class (referred to as an "Invokable") where various overloaded 
+static methods are defined.
+
+An Invokable is written such that the most specific, and hence, optimised
+overload is resolved for existing .Net and F# types, and that a more general
+implementation is used otherwise.
+
+What does this all mean?
+
+It means care is taken to use the most optimised impelemntation, and you can
+implement your own instances of generic functions if you implement the required
+methods.
+
+Examples
+========
 
 Here are some examples of the generic ``map`` operation over existing .NET and F# types:
 

--- a/docsrc/content/index.fsx
+++ b/docsrc/content/index.fsx
@@ -20,8 +20,7 @@ The additions can be summarised as:
 
  * [Extensions](extensions.html) to core types, such as [`String.toLower`](reference/fsharpplus-string.html)
 
- * [Generic Functions and Operators](reference/fsharpplus-operators.html),
-   like `map`, which can be extended to support other types
+ * [Generic Functions and Operators](generic-doc.html) like `map`, which can be extended to support other types
 
  * Generic and customizable [Computation Expressions](computation-expressions.html),
    like `monad`

--- a/docsrc/content/operators-common.fsx
+++ b/docsrc/content/operators-common.fsx
@@ -1,0 +1,149 @@
+(*** hide ***)
+// This block of code is omitted in the generated HTML documentation. Use 
+// it to define helpers that you do not want to show in the documentation.
+#I "../../bin"
+
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
+open FSharpPlus
+
+(**
+Operators - Common Combinators
+===============================
+
+These generic functions and operators are used commonly and are not part
+of any other abstraction.
+
+You can find these in the API docs: [Operators.fs](reference/operators.html)
+
+flip
+====
+
+Creates a new function with first two arguments flipped.
+
+
+konst
+=====
+
+Create a function that always returns the given argument.
+This is known as a 'constant' function.
+
+This is commonly useful where a function is required as a parameter
+for flexibility, but isn't required in a specific instance.
+
+example:
+*)
+    > [1;2;3] |> filter (konst true);; 
+    val it : int list = [1; 2; 3]
+
+(**
+curry, uncurry, curryN, uncurryN
+================================
+
+Currying is the process of taking a function expecting a tuple, and returning a
+function with the same number of arguments as the tuple size.
+
+Uncurrying is the reverse process.
+
+There is `curry` and `uncurry` that work on two arguments each, while `curryN`
+and `uncurryN` work on any number.
+
+example:
+*)
+    > let addThreeNums (x, y, z) = x + y + z;;
+    val addThreeNums : x:int * y:int * z:int -> int
+
+    > curryN addThreeNums 1 2 3;;
+    val it : int = 6
+
+(**
+Functions as operators - </ />
+==============================
+
+A pair of operators `</` and `/>` are defined to allow any function to be used as
+an operator. It will flip the args of your function so that it makes sense when
+the first argument is coming from the left-hand-side.
+
+example:
+*)
+> let biggerThan a b = a > b;;
+val biggerThan : a:'a -> b:'a -> bool when 'a : comparison
+
+> 10 </biggerThan/> 3;;
+val it : bool = true
+
+(**
+tap
+===
+
+Tap executes a side-effect function, then returns the original input value.
+Consider this as 'tapping into' a chain of functions.
+
+example:
+*)
+    // a pipeline of functions, with a tap in the middle
+    let names = ["John"; "Smith"]
+    names |> map String.toUpper |> tap (printfn "%A") |> map String.toLower;;
+
+    // prints this:
+    ["JOHN"; "SMITH"]
+
+    // but returns this:
+    val it : string list = ["john"; "smith"]
+
+(**
+either
+======
+
+Extracts the value inside a Result from either side - whether Ok or Error.
+
+It takes a pair of functions:
+
+ * fOk - a function applied to the source if it contains an Ok value
+ * fError - a function applied to the source if it contains an Error value
+
+...and the source:
+
+ * source - the source value containing an Ok or Error
+
+*)
+    > let myResult = Ok "I am ok!";;
+    val myResult : Result<string,'a>
+
+    > let myOther = Error -1;;
+    val myOther : Result<'a,int>
+
+    > either id id myResult;;
+    val it : string = "I am ok!"
+
+    > either id id myOther;;
+    val it : int = -1
+
+(**
+Don't confuse the `either` function with `result` which lifts a value into a
+Functor, just like `return` when in a computation expression.
+
+
+option
+======
+
+Takes a function, a default value and a option value. If the option value is None, the function returns the default value.
+Otherwise, it applies the function to the value inside Some and returns the result.
+*)
+    let inline option f n = function Some x -> f x | None -> n
+
+(**
+
+tuple2, tuple3, ...tuple8
+=========================
+
+Functions that generate a tuple. The number indicates the number of arguments
+that are defined, and the corresponding size of tuple.
+
+*)
+    let inline tuple2 a b             = a,b
+    let inline tuple3 a b c           = a,b,c
+    let inline tuple4 a b c d         = a,b,c,d
+    let inline tuple5 a b c d e       = a,b,c,d,e
+    let inline tuple6 a b c d e f     = a,b,c,d,e,f
+    let inline tuple7 a b c d e f g   = a,b,c,d,e,f,g
+    let inline tuple8 a b c d e f g h = a,b,c,d,e,f,g,h

--- a/src/FSharpPlus/Operators.fs
+++ b/src/FSharpPlus/Operators.fs
@@ -690,6 +690,24 @@ module Operators =
     /// <exception cref="System.ArgumentNullException">Thrown when the input collection is null.</exception>
     let inline skipWhile (predicate: 'T->bool) (source: '``Collection<'T>``) : '``Collection<'T>`` = SkipWhile.Invoke predicate source
 
+    /// <summary>
+    /// Generic 'choose' for any collection.
+    /// 
+    /// A combination of map and filter, `choose` enables you to transform
+    /// and select elements at the same time.
+    /// </summary>
+    ///
+    /// <param name="chooser">
+    /// A function that is applied to each element in the
+    /// collection and returns an option value. When the result is a Some then
+    /// the unwrapped value is included in the result collection, otherwise
+    /// it is discarded.
+    /// </param>
+    /// <param name="source">The input collection.</param>
+    ///
+    /// <returns>The result collection.</returns>
+    ///
+    /// <exception cref="System.InvalidOperationException">Thrown when the input collection is an Id.</exception>
     let inline choose (chooser: 'T->'U option) (source: '``Collection<'T>``) : '``Collection<'U>`` = Choose.Invoke chooser source
 
     /// <summary>Returns a collection that contains no duplicate entries according to generic hash and
@@ -718,6 +736,14 @@ module Operators =
     /// Inserts a separator between each element.
     let inline intersperse (sep: 'T) (source: '``Collection<'T>``) : '``Collection<'T>`` = Intersperse.Invoke sep source
     
+    /// <summary>Replaces part of the collection with a new part</summary>
+    ///
+    /// <param name="oldValue">A collection that if part of the source collection
+    /// should be replaced with newValue.</param>
+    /// <param name="newValue">The collection to replace oldValue with.</param>
+    /// <param name="source">The input collection.</param>
+    ///
+    /// <returns>The resulting collection with oldValue replaced with newValue.</returns>
     let inline replace (oldValue: 'Collection) (newValue: 'Collection) (source: 'Collection) = Replace.Invoke oldValue newValue source : 'Collection
 
     /// <summary>Returns a new collection with the elements in reverse order.</summary>
@@ -780,11 +806,15 @@ module Operators =
 
     /// Splits a given ordered collection at each of the given sub-ordered collections
     ///
-    ///     > "asdf" |> split ["s"];;
-    ///        val it : string list = ["a"; "df"]
+    /// <example>
+    /// <code>
+    /// > "asdf" |> split ["s"];;
+    /// val it : string list = ["a"; "df"]
     ///
-    ///     > [1;2;3;4;5;6] |> split [ [2]; [5] ];;
-    ///        val it : int list list = [[1]; [3; 4]; [6]]
+    /// > [1;2;3;4;5;6;7] |> split [ [2;3]; [5] ];;
+    /// val it : int list list = [[1]; [4]; [6; 7]]
+    /// </code>
+    /// </example>
     let inline split (sep: '``'Collection<'OrderedCollection>``) (source: 'OrderedCollection) = Split.Invoke sep source : '``'Collection<'OrderedCollection>``
 
 

--- a/src/FSharpPlus/Operators.fs
+++ b/src/FSharpPlus/Operators.fs
@@ -49,12 +49,19 @@ module Operators =
     /// Otherwise, it applies the function to the value inside Some and returns the result.
     let inline option f n = function Some x -> f x | None -> n
 
+    /// Tuple two arguments
     let inline tuple2 a b             = a,b
+    /// Tuple three arguments
     let inline tuple3 a b c           = a,b,c
+    /// Tuple four arguments
     let inline tuple4 a b c d         = a,b,c,d
+    /// Tuple five arguments
     let inline tuple5 a b c d e       = a,b,c,d,e
+    /// Tuple six arguments
     let inline tuple6 a b c d e f     = a,b,c,d,e,f
+    /// Tuple seven arguments
     let inline tuple7 a b c d e f g   = a,b,c,d,e,f,g
+    /// Tuple eight arguments
     let inline tuple8 a b c d e f g h = a,b,c,d,e,f,g,h
 
 
@@ -93,7 +100,7 @@ module Operators =
 
     #endif
 
-    /// Apply a lifted argument to a lifted function.
+    /// Apply a lifted argument to a lifted function: f <*> arg
     let inline (<*>) (f: '``Applicative<'T -> 'U>``) (x: '``Applicative<'T>``) : '``Applicative<'U>`` = Apply.Invoke f x : '``Applicative<'U>``
 
     /// Apply 2 lifted arguments to a non-lifted function.
@@ -109,6 +116,7 @@ module Operators =
     /// Sequences two applicatives left-to-right, discarding the value of the second argument.
     let inline (<*  ) (x: '``Applicative<'U>``) (y: '``Applicative<'T>``): '``Applicative<'U>`` = ((fun (k: 'U) (_: 'T) -> k ) <!> x : '``Applicative<'T->'U>``) <*> y
 
+    /// Apply a lifted argument to a lifted function (flipped): arg <**> f
     let inline (<**>) (x: '``Applicative<'T>``) : '``Applicative<'T -> 'U>``->'``Applicative<'U>`` = flip (<*>) x
     
     #if !FABLE_COMPILER
@@ -185,6 +193,10 @@ module Operators =
     let inline (<|>) (x: '``Functor<'T>``) (y: '``Functor<'T>``) : '``Functor<'T>`` = Append.Invoke x y
 
     #if !FABLE_COMPILER
+    /// Conditional failure of Alternative computations.
+    /// If true it lifts the unit value, else it returns empty.
+    ///
+    /// Common uses of guard include conditionally signaling an error in an error monad and conditionally rejecting the current choice in an Alternative-based parser.
     let inline guard x: '``MonadPlus<unit>`` = if x then Return.Invoke () else Empty.Invoke ()
     #endif
 
@@ -387,10 +399,19 @@ module Operators =
     /// <returns>The length of the foldable.</returns>
     let inline length (source: '``Foldable<'T>``) : int = Length.Invoke source
 
+    /// Gets the maximum value in the foldable
     let inline maximum (source: '``Foldable<'T>``) = Max.Invoke source : 'T when 'T : comparison
+
+    /// Gets the minimum value in the foldable
     let inline minimum (source: '``Foldable<'T>``) = Min.Invoke source : 'T when 'T : comparison
+
+    /// Gets the maximum value after projecting in the foldable
     let inline maxBy (projection: 'T->'U when 'U : comparison) (source: '``Foldable<'T>``) = MaxBy.Invoke projection source : 'T
+
+    /// Gets the minimum value after projecting in the foldable
     let inline minBy (projection: 'T->'U when 'U : comparison) (source: '``Foldable<'T>``) = MinBy.Invoke projection source : 'T
+
+    /// Gets the nth value in the foldable - i.e. at position 'n'
     let inline nth (n: int) (source: '``Foldable<'T>``) : 'T = Nth.Invoke n source
 
     // Traversable
@@ -757,6 +778,13 @@ module Operators =
     /// <exception cref="System.ArgumentNullException">Thrown when the input collection is null.</exception>
     let inline sortByDescending (projection: 'T->'Key when 'Key : comparison) (source: '``Collection<'T>``) : '``Collection<'T>`` = SortByDescending.Invoke projection source
 
+    /// Splits a given ordered collection at each of the given sub-ordered collections
+    ///
+    ///     > "asdf" |> split ["s"];;
+    ///        val it : string list = ["a"; "df"]
+    ///
+    ///     > [1;2;3;4;5;6] |> split [ [2]; [5] ];;
+    ///        val it : int list list = [[1]; [3; 4]; [6]]
     let inline split (sep: '``'Collection<'OrderedCollection>``) (source: 'OrderedCollection) = Split.Invoke sep source : '``'Collection<'OrderedCollection>``
 
 
@@ -800,11 +828,19 @@ module Operators =
     /// Converts using the explicit operator.
     let inline explicit (value: 'T) : 'U = Explicit.Invoke value
 
+    /// Convert from a byte array value, given options of little-endian, and startIndex
     let inline ofBytesWithOptions (isLtEndian: bool) (startIndex: int) (value: byte[]) = OfBytes.Invoke isLtEndian startIndex value
+
+    /// Convert from a byte array value, assuming little-endian
     let inline ofBytes (value: byte[]) = OfBytes.Invoke true 0 value
+
+    /// Convert from a byte array value, assuming big-endian
     let inline ofBytesBE (value: byte[]) = OfBytes.Invoke false 0 value
 
+    /// Convert to a byte array value, assuming little endian
     let inline toBytes value : byte[] = ToBytes.Invoke true value
+
+    /// Convert to a byte array value, assuming big endian
     let inline toBytesBE value : byte[] = ToBytes.Invoke false value
      
     /// Converts to a value from its string representation.


### PR DESCRIPTION
Addressed questions, https://github.com/fsprojects/FSharpPlus/pull/278/commits/ecd430114b6bd88d949684fbd3da12526ae24baf

...and then added these new commits:

Add two missed docs on choose and replace in Operators:
https://github.com/fsprojects/FSharpPlus/pull/278/commits/8111022e0fa3e146287c10979154761f0c5fd021

Add new index for Operators - first section is on "common" ones since they don't fall under any specific abstraction:
https://github.com/fsprojects/FSharpPlus/pull/278/commits/63d7b9f8393f6aae0125fe78e3035d72a0831043

I was thinking to detail the other generic operators in the appropriate abstraction page which often already does in it's 'minimal definition' and 'additional operator' sections. 
eg: http://fsprojects.github.io/FSharpPlus/abstraction-functor.html#map

If ok, I'll merge and squash before doing any more.