### PR TITLE
+Choice Invoker

### DIFF
--- a/docsrc/content/abstraction-misc.fsx
+++ b/docsrc/content/abstraction-misc.fsx
@@ -44,6 +44,15 @@ let a = skip 3 [1..10]
 let b = chunkBy fst [1, "a"; 1, "b"; 2, "c"; 1, "d"]
 
 
+// Reducibles
+
+let c = nel {1; 2; 3}
+let d = reduce (+) c
+
+let resultList = nel {Error "1"; Error "2"; Ok 3; Ok 4; Error "5"}
+let firstOk = choice resultList
+
+
 // Invariant Functor
 type StringConverter<'t> = StringConverter of (string -> 't) * ('t -> string) with
     static member Invmap (StringConverter (f, g), f',g') = StringConverter (f' << f, g << g')

--- a/src/FSharpPlus/Control/Alternative.fs
+++ b/src/FSharpPlus/Control/Alternative.fs
@@ -27,7 +27,7 @@ type Empty =
         let inline call (mthd: ^M, output: ^R) = ((^M or ^R) : (static member Empty : _*_ -> _) output, mthd)
         call (Unchecked.defaultof<Empty>, Unchecked.defaultof<'``Alternative<'T>``> )
 
-    static member inline InvokeOnInstance () : '``Alternative<'T>`` = (^``Alternative<'T>`` : (static member Empty : ^``Alternative<'T>``) ())
+    static member inline InvokeOnInstance () : '``Alternative<'T>`` = (^``Alternative<'T>`` : (static member Empty : ^``Alternative<'T>``) ()) : '``Alternative<'T>``
 
 
 type Append =
@@ -48,3 +48,76 @@ type Append =
         let inline call (mthd: ^M, input1: ^I, input2: ^I) = ((^M or ^I) : (static member ``<|>`` : _*_*_ -> _) input1, input2, mthd)
         call (Unchecked.defaultof<Append>, x, y)
 
+
+
+type IsLeftZeroForAppend =
+    inherit Default1
+
+    static member inline IsLeftZeroForAppend (_: ref<'T>   when 'T : struct    , _mthd: Default3) = false
+    static member inline IsLeftZeroForAppend (_: ref<'T>   when 'T : not struct, _mthd: Default2) = false
+
+    static member inline IsLeftZeroForAppend (t: ref<'``Applicative<'T>``>             , _mthd: Default1) = (^``Applicative<'T>`` : (static member IsLeftZeroForAppend : _ -> _) t.Value)
+    static member inline IsLeftZeroForAppend (_: ref< ^t> when ^t: null and ^t: struct , _mthd: Default1) = ()
+
+    static member        IsLeftZeroForAppend (t: ref<option<_>  > , _mthd: IsLeftZeroForAppend) = Option.isSome t.Value
+    static member        IsLeftZeroForAppend (t: ref<Result<_,_>> , _mthd: IsLeftZeroForAppend) = match t.Value with (Ok _        ) -> true | _ -> false
+    static member        IsLeftZeroForAppend (t: ref<Choice<_,_>> , _mthd: IsLeftZeroForAppend) = match t.Value with (Choice1Of2 _) -> true | _ -> false
+
+    static member inline Invoke (x: '``Applicative<'T>``) : bool =
+        let inline call (mthd : ^M, input: ^I) =
+            ((^M or ^I) : (static member IsLeftZeroForAppend : _*_ -> _) (ref input), mthd)
+        call(Unchecked.defaultof<IsLeftZeroForAppend>, x)
+
+    static member inline InvokeOnInstance (x: '``Applicative<'T>``) : bool = (^``Applicative<'T>`` : (static member IsLeftZeroForAppend : _ -> _) x)
+
+
+type Choice =
+    inherit Default1
+
+    static member inline Choice (x: ref<'``Foldable<'Alternative<'T>>``>, _mthd: Default4) =
+        use e = (ToSeq.Invoke x.Value).GetEnumerator ()
+        let mutable res = Empty.Invoke ()
+        while e.MoveNext() && not (IsLeftZeroForAppend.Invoke res) do
+            res <- Append.Invoke res e.Current
+        res
+
+    static member inline Choice (x: ref<'``Reducible<'Alt<'T>>``>, _mthd: Default2) =
+        let inline _f f = Reduce.Invoke f x.Value : '``Alt<'T>>``
+        let t = ToSeq.Invoke x.Value
+        use e = t.GetEnumerator ()
+        e.MoveNext() |> ignore
+        let mutable res = e.Current
+        while e.MoveNext() && not (IsLeftZeroForAppend.Invoke res) do
+            res <- Append.Invoke res e.Current
+        res
+
+    static member inline Choice (x: ref<'``Foldable<'Alternative<'T>>``> , _mthd: Default1) = (^``Foldable<'Alternative<'T>>`` :  (static member Choice : _ -> _) x.Value) : '``Alternative<'T>``
+    static member inline Choice (_: ref< ^t> when ^t: null and ^t: struct, _mthd: Default1) = ()
+
+    static member inline Choice (x: ref<seq<'``Alternative<'T>``>>, _mthd: Choice) =
+        use e = x.Value.GetEnumerator ()
+        let mutable res = Empty.Invoke ()
+        while e.MoveNext() && not (IsLeftZeroForAppend.Invoke res) do
+            res <- Append.Invoke res e.Current
+        res
+
+    static member inline Choice (x: ref<list<'``Alternative<'T>``>>, _mthd: Choice) =
+        use e = (List.toSeq x.Value ).GetEnumerator ()
+        let mutable res = Empty.Invoke ()
+        while e.MoveNext() && not (IsLeftZeroForAppend.Invoke res) do
+            res <- Append.Invoke res e.Current
+        res
+
+    static member inline Choice (x: ref< array<'``Alternative<'T>``>>, _mthd: Choice) =
+        let arr = x.Value
+        let mutable i = 0
+        let mutable res = Empty.Invoke ()
+        let last = Array.length arr - 1
+        while i < last && not (IsLeftZeroForAppend.Invoke res) do
+            i <- i + 1
+            res <- Append.Invoke res arr.[i]
+        res
+
+    static member inline Invoke (x: '``Foldable<'Alternative<'T>>``) : '``Alternative<'T>>`` =
+        let inline call (mthd: ^M, input1: ^I) = ((^M or ^I) : (static member Choice : _*_ -> _) (ref input1, mthd))
+        call (Unchecked.defaultof<Choice>, x)

--- a/src/FSharpPlus/Control/Foldable.fs
+++ b/src/FSharpPlus/Control/Foldable.fs
@@ -387,3 +387,4 @@ type Length =
         call (Unchecked.defaultof<Length>, source) : int
 
 
+type Reduce = static member inline Invoke (f: 'T->'T->'T) (x: '``Reducible<'T>``) : 'T = (^``Reducible<'T>`` : (static member Reduce : _*_ -> _) x, f)

--- a/src/FSharpPlus/Data/NonEmptyList.fs
+++ b/src/FSharpPlus/Data/NonEmptyList.fs
@@ -181,6 +181,16 @@ type NonEmptyList<'t> with
         let lst = source |> NonEmptyList.toSeq |> Seq.replace oldValue newValue |> Seq.toList
         {Head = lst.Head; Tail = lst.Tail}
 
+    static member Reduce ({Head = x; Tail = xs}, reduction: 'T -> 'T -> 'T) = List.reduce reduction (x :: xs)
+
+    static member inline Choice (source: NonEmptyList<'``Alt<'T>``>) =
+        use e = (NonEmptyList.toSeq source).GetEnumerator ()
+        e.MoveNext() |> ignore
+        let mutable res = e.Current
+        while e.MoveNext() && not (IsLeftZeroForAppend.Invoke res) do
+            res <- Append.Invoke res e.Current
+        res
+
 
 [<AutoOpen>]
 module NonEmptyListBuilder =

--- a/src/FSharpPlus/FSharpPlus.fsproj
+++ b/src/FSharpPlus/FSharpPlus.fsproj
@@ -52,6 +52,7 @@
     <Compile Include="Control/Numeric.fs" />
     <Compile Include="Control/Monoid.fs" />
     <Compile Include="Control/Monad.fs" />
+    <Compile Include="Control/Foldable.fs" />
     <Compile Include="Control/Alternative.fs" />
     <Compile Include="Control/Applicative.fs" />
     <Compile Include="Control/Functor.fs" />
@@ -62,7 +63,6 @@
     <Compile Include="Control/Arrow.fs" />
     <Compile Include="Control/ArrowChoice.fs" />
     <Compile Include="Control/ArrowApply.fs" />
-    <Compile Include="Control/Foldable.fs" />
     <Compile Include="Control/Bifoldable.fs" />
     <Compile Include="Control/Traversable.fs" />
     <Compile Include="Control/Indexable.fs" />

--- a/src/FSharpPlus/Operators.fs
+++ b/src/FSharpPlus/Operators.fs
@@ -414,6 +414,20 @@ module Operators =
     /// Gets the nth value in the foldable - i.e. at position 'n'
     let inline nth (n: int) (source: '``Foldable<'T>``) : 'T = Nth.Invoke n source
 
+
+    // Reducible
+
+    /// <summary>Applies a function to each element of the reducible, threading an accumulator argument
+    /// through the computation. Apply the function to the first two elements of the reducible.
+    /// Then feed this result into the function along with the third element and so on. 
+    /// Return the final result. If the input function is <c>f</c> and the elements are <c>i0...iN</c> then computes 
+    /// <c>f (... (f i0 i1) i2 ...) iN</c>.</summary>
+    /// <param name="reduction">The function to reduce two reducible elements to a single element.</param>
+    /// <param name="source">The input reducible.</param>
+    /// <returns>The final reduced value.</returns>
+    let inline reduce reduction (source: '``Reducible<'T>``) = Reduce.Invoke reduction source : 'T
+
+
     // Traversable
 
     /// Map each element of a structure to an action, evaluate these actions from left to right, and collect the results.
@@ -988,8 +1002,8 @@ module Operators =
 
     // Additional functions
 
-    /// Folds using alternative operator `<|>`.
-    let inline choice (x: '``Foldable<'Alternative<'T>>``) = foldBack (<|>) x (getEmpty ()) : '``Alternative<'T>>``
+    /// Reduces using alternative operator `<|>`.
+    let inline choice (x: '``Foldable<'Alternative<'T>>``) = Choice.Invoke x : '``Alternative<'T>>``
 
     #if !FABLE_COMPILER
     /// Generic filter operation for MonadZero. It returns all values satisfying the predicate, if the predicate returns false will use the empty value.


### PR DESCRIPTION
This PR will add an Invoker for the `choice` function.

It will allow to run the function over semigroups of Alt's (Alternatives without zero), which is a common use case.

Most overloads will use the technique of a left-zero knowledge to support short-circuit.

Note that Left Zero here (in contrast to the applicative implementation) is implemented in such a way that it's always defined (defaulting to false). Which simplifies a bit the constraint solving.

This also adds the `Reducible` abstraction which is a Foldable special case where there's no need for a Zero value, or initial state to fold. This means that the `reduce` function is safe.