### PR TITLE
Restrict Fable compatibity

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -21,5 +21,6 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: '12.x'
+    - run: npx fable-splitter --allFiles
     - run: npm install -g fable-splitter fable-compiler
     - run: cd tests/FSharpPlusFable.Tests; npm install; npm run buildFSharpPlus; npm run test

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -22,8 +22,4 @@ jobs:
       with:
         node-version: '12.x'
     - run: npm install -g fable-splitter fable-compiler
-    # - run: (cd src/FSharpPlus; npx fable-splitter --projFile FSharpPlus.fsproj --verbose  --allFiles)
-    - run: cd tests/FSharpPlusFable.Tests
-    - run: npm install
-    - run: npm run buildFSharpPlus
-    - run: npm run test
+    - run: cd tests/FSharpPlusFable.Tests; npm install; npm run buildFSharpPlus; npm run test

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -17,3 +17,13 @@ jobs:
       run: dotnet build build.proj --configuration Release
     - name: Test with dotnet
       run: dotnet test build.proj -v n
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+    - run: npm install -g fable-splitter fable-compiler
+    # - run: (cd src/FSharpPlus; npx fable-splitter --projFile FSharpPlus.fsproj --verbose  --allFiles)
+    - run: cd tests/FSharpPlusFable.Tests
+    - run: npm install
+    - run: npm run buildFSharpPlus
+    - run: npm run test

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -21,6 +21,6 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: '12.x'
-    - run: npx fable-splitter --allFiles
     - run: npm install -g fable-splitter fable-compiler
+    - run: npx fable-splitter --allFiles
     - run: cd tests/FSharpPlusFable.Tests; npm install; npm run buildFSharpPlus; npm run test

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -22,5 +22,5 @@ jobs:
       with:
         node-version: '12.x'
     - run: npm install -g fable-splitter fable-compiler
-    - run: npx fable-splitter --allFiles
+    - run: cd src/FSharpPlus; npx fable-splitter --allFiles
     - run: cd tests/FSharpPlusFable.Tests; npm install; npm run buildFSharpPlus; npm run test

--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,4 @@ tests/FSharpPlusFable.Tests/node_modules/
 
 # Fable compilation files
 tests/FSharpPlusFable.Tests/FSharpPlusFable
+/node_modules

--- a/src/FSharpPlus/Builders.fs
+++ b/src/FSharpPlus/Builders.fs
@@ -2,6 +2,8 @@
 
 #nowarn "40"
 
+#if !FABLE_COMPILER
+
 /// Constructs to express generic computations
 [<AutoOpenAttribute>]
 module Builders =    
@@ -16,11 +18,10 @@ module Builders =
         static member inline ($) (Idiomatic, si) = fun sfi x -> (Idiomatic $ x) (sfi <*> si)
         static member        ($) (Idiomatic, Ii) = id
     let inline idiomatic a b = (Idiomatic $ b) a
-    #if !FABLE_COMPILER
+    
     let inline iI x = (idiomatic << result) x
     type Idiomatic with static member inline ($) (Idiomatic, Ji) = fun xii -> join xii
     type Idiomatic with static member inline ($) (Idiomatic, J ) = fun fii x -> (Idiomatic $ x) (join fii)
-    #endif
 
     
     // Workflows
@@ -30,14 +31,11 @@ module Builders =
     open FSharpPlus.Control
 
     type Builder () =
-        member        __.ReturnFrom (expr) = expr                                        : '``Monad<'T>``
-        #if !FABLE_COMPILER
+        member        __.ReturnFrom (expr) = expr                                        : '``Monad<'T>``        
         member inline __.Return (x: 'T) = result x                                       : '``Monad<'T>``
         member inline __.Yield  (x: 'T) = result x                                       : '``Monad<'T>``
-        #endif
         member inline __.Bind (p: '``Monad<'T>``, rest: 'T->'``Monad<'U>``) = p >>= rest : '``Monad<'U>``
 
-        #if !FABLE_COMPILER
         [<CustomOperation("select", MaintainsVariableSpaceUsingBind=true, AllowIntoPattern=true)>]
         member inline __.Select (x, [<ProjectionParameter>] f) = map f x
 
@@ -55,7 +53,6 @@ module Builders =
 
         [<CustomOperation("orderBy", MaintainsVariableSpaceUsingBind=true, AllowIntoPattern=true)>]
         member inline __.OrderBy (x,[<ProjectionParameter>] f : 'T -> 'key) = sortBy f x
-        #endif
 
     type StrictBuilder () =
         inherit Builder ()
@@ -63,11 +60,10 @@ module Builders =
         member        __.Run f = f ()              : '``Monad<'T>``
         member        __.TryWith    (expr, handler)      = try expr () with e -> handler e
         member        __.TryFinally (expr, compensation) = try expr () finally compensation ()
-        #if !FABLE_COMPILER
+        
         member        rs.Using (disposable: #IDisposable, body) =
             let body = fun () -> body disposable
             rs.TryFinally (body, fun () -> dispose disposable)
-        #endif
 
     type DelayedBuilder () =
         inherit Builder ()
@@ -93,11 +89,10 @@ module Builders =
 
     type MonadFxStrictBuilder () =
         inherit StrictBuilder ()
-        #if !FABLE_COMPILER
+        
         member inline __.Zero () = result ()                                       : '``Monad<unit>``
-        #endif
         member inline __.Combine (a: '``Monad<unit>``, b) = a >>= (fun () -> b ()) : '``Monad<'T>``
-        #if !FABLE_COMPILER
+        
         member inline __.While (guard, body: unit -> '``Monad<unit>``)             : '``Monad<unit>`` =
             let rec loop guard body =
                 if guard () then body () >>= fun () -> loop guard body
@@ -107,7 +102,6 @@ module Builders =
             Using.Invoke (p.GetEnumerator () :> IDisposable) (fun enum ->
                 let enum = enum :?> IEnumerator<_>
                 this.While (enum.MoveNext, fun () -> rest enum.Current) : '``Monad<unit>``)
-        #endif
 
     type MonadPlusBuilder () =
         inherit DelayedBuilder()
@@ -141,11 +135,10 @@ module Builders =
         /// Makes it a strict monadic computation expression with side-effects
         member        __.fx'     = new MonadFxStrictBuilder ()
 
-        #if !FABLE_COMPILER
         member inline __.Zero () = result ()                                    : '``Monad<unit>``
-        #endif
+
         member inline __.Combine (a: '``Monad<unit>``, b) = a >>= (fun () -> b) : '``Monad<'T>``
-        #if !FABLE_COMPILER
+        
         member inline __.While (guard, body: '``Monad<unit>``)                  : '``Monad<unit>`` =
             let rec loop guard body =
                 if guard () then body >>= (fun () -> loop guard body)
@@ -158,7 +151,6 @@ module Builders =
                 let enum = enum :?> IEnumerator<_>
                 if isReallyDelayed then this.While (enum.MoveNext, Delay.Invoke (fun () -> rest enum.Current))
                 else this.strict.While (enum.MoveNext, fun () -> rest enum.Current))
-        #endif
 
 
     /// Creates a (lazy) monadic computation expression with side-effects (see http://fsprojects.github.io/FSharpPlus/computation-expressions.html for more information)
@@ -166,3 +158,5 @@ module Builders =
 
     /// Creates a strict monadic computation expression with side-effects (see http://fsprojects.github.io/FSharpPlus/computation-expressions.html for more information)
     let monad' = new MonadFxStrictBuilder ()
+
+#endif

--- a/src/FSharpPlus/Control/Alternative.fs
+++ b/src/FSharpPlus/Control/Alternative.fs
@@ -1,5 +1,7 @@
 namespace FSharpPlus.Control
 
+#if !FABLE_COMPILER
+
 open System
 open System.Runtime.CompilerServices
 open System.Runtime.InteropServices
@@ -15,10 +17,10 @@ open FSharpPlus
 type Empty =
     inherit Default1
     static member        Empty ([<Optional>]_output: seq<'T>             , [<Optional>]_mthd: Default2) = Seq.empty    : seq<'T>
-    #if !FABLE_COMPILER
+
     static member inline Empty ([<Optional>]_output: '``Alternative<'T>``, [<Optional>]_mthd: Default1) = (^``Alternative<'T>`` : (static member Empty : ^``Alternative<'T>``) ()) : '``Alternative<'T>``
     static member inline Empty (_output: ^t when ^t: null and ^t: struct ,             _mthd: Default1) = id    
-    #endif
+
     static member        Empty ([<Optional>]_output: option<'T>          , [<Optional>]_mthd: Empty   ) = None         : option<'T>
     static member        Empty ([<Optional>]_output: list<'T>            , [<Optional>]_mthd: Empty   ) = [  ]         : list<'T>
     static member        Empty ([<Optional>]_output: 'T []               , [<Optional>]_mthd: Empty   ) = [||]         : 'T []    
@@ -33,10 +35,10 @@ type Empty =
 type Append =
     inherit Default1
     static member        ``<|>`` (x: 'T seq              , y              , [<Optional>]_mthd: Default2) = Seq.append   x y
-    #if !FABLE_COMPILER
+
     static member inline ``<|>`` (x: '``Alt<'T>``        , y: '``Alt<'T>``, [<Optional>]_mthd: Default1) = (^``Alt<'T>`` :  (static member (<|>) : _*_ -> _) x, y) : '``Alt<'T>``
     static member inline ``<|>`` (_: ^t when ^t: null and ^t: struct   , _,             _mthd: Default1) = ()
-    #endif
+
     static member inline ``<|>`` (x: Result<_,_>         , y              , [<Optional>]_mthd: Append  ) = match x, y with Ok _        , _ -> x | Error x     , Error y      -> Error      (Plus.Invoke x y) | _, _ -> y
     static member inline ``<|>`` (x: Choice<_,_>         , y              , [<Optional>]_mthd: Append  ) = match x, y with Choice1Of2 _, _ -> x | Choice2Of2 x, Choice2Of2 y -> Choice2Of2 (Plus.Invoke x y) | _, _ -> y
     static member inline ``<|>`` (x: Either<_,_>         , y              , [<Optional>]_mthd: Append  ) = match x with Left _ -> y | xs -> xs
@@ -121,3 +123,5 @@ type Choice =
     static member inline Invoke (x: '``Foldable<'Alternative<'T>>``) : '``Alternative<'T>>`` =
         let inline call (mthd: ^M, input1: ^I) = ((^M or ^I) : (static member Choice : _*_ -> _) (ref input1, mthd))
         call (Unchecked.defaultof<Choice>, x)
+
+#endif

--- a/src/FSharpPlus/Control/Applicative.fs
+++ b/src/FSharpPlus/Control/Applicative.fs
@@ -9,6 +9,8 @@ open Microsoft.FSharp.Quotations
 open FSharpPlus.Internals
 open FSharpPlus
 
+#if !FABLE_COMPILER
+
 
 type Apply =
     inherit Default1
@@ -18,16 +20,12 @@ type Apply =
 
     static member        ``<*>`` (f: Lazy<'T->'U>     , x: Lazy<'T>             , [<Optional>]_output: Lazy<'U>             , [<Optional>]_mthd: Apply) = Lazy<_>.Create (fun () -> f.Value x.Value)   : Lazy<'U>
     static member        ``<*>`` (f: seq<_>           , x: seq<'T>              , [<Optional>]_output: seq<'U>              , [<Optional>]_mthd: Apply) = Seq.apply  f x                               : seq<'U>
-    #if !FABLE_COMPILER
     static member        ``<*>`` (f: IEnumerator<_>   , x: IEnumerator<'T>      , [<Optional>]_output: IEnumerator<'U>      , [<Optional>]_mthd: Apply) = Enumerator.map2 id f x : IEnumerator<'U>
-    #endif
     static member        ``<*>`` (f: list<_>          , x: list<'T>             , [<Optional>]_output: list<'U>             , [<Optional>]_mthd: Apply) = List.apply f x                               : list<'U>
     static member        ``<*>`` (f: _ []             , x: 'T []                , [<Optional>]_output: 'U []                , [<Optional>]_mthd: Apply) = Array.apply f x                              : 'U []
     static member        ``<*>`` (f: 'r -> _          , g: _ -> 'T              , [<Optional>]_output:  'r -> 'U            , [<Optional>]_mthd: Apply) = fun x -> f x (g x)                           : 'U
     static member inline ``<*>`` ((a: 'Monoid, f)     , (b: 'Monoid, x: 'T)     , [<Optional>]_output: 'Monoid * 'U         , [<Optional>]_mthd: Apply) = (Plus.Invoke a b, f x)                       : 'Monoid *'U
-    #if !FABLE_COMPILER
     static member        ``<*>`` (f: Task<_>          , x: Task<'T>             , [<Optional>]_output: Task<'U>             , [<Optional>]_mthd: Apply) = Task.apply   f x : Task<'U>
-    #endif
     static member        ``<*>`` (f: Async<_>         , x: Async<'T>            , [<Optional>]_output: Async<'U>            , [<Optional>]_mthd: Apply) = Async.apply  f x : Async<'U>
     static member        ``<*>`` (f: option<_>        , x: option<'T>           , [<Optional>]_output: option<'U>           , [<Optional>]_mthd: Apply) = Option.apply f x : option<'U>
     static member        ``<*>`` (f: Result<_,'E>     , x: Result<'T,'E>        , [<Optional>]_output: Result<'b,'E>        , [<Optional>]_mthd: Apply) = Result.apply f x : Result<'U,'E>
@@ -48,9 +46,7 @@ type Apply =
            | _        -> ()
        dct
     
-    #if !FABLE_COMPILER
     static member        ``<*>`` (f: Expr<'T->'U>, x: Expr<'T>, [<Optional>]_output: Expr<'U>, [<Optional>]_mthd: Apply) = Expr.Cast<'U> (Expr.Application (f, x))
-    #endif
     static member        ``<*>`` (f: ('T->'U) ResizeArray, x: 'T ResizeArray, [<Optional>]_output: 'U ResizeArray, [<Optional>]_mthd: Apply) =
        ResizeArray (Seq.collect (fun x1 -> Seq.collect (fun x2 -> Seq.singleton (x1 x2)) x) f) : 'U ResizeArray
 
@@ -88,3 +84,5 @@ type IsLeftZeroForApply with
 
     static member inline IsLeftZeroForApply (t: ref<'``Applicative<'T>``>        , _mthd: Default1) = (^``Applicative<'T>`` : (static member IsLeftZeroForApply : _ -> _) t.Value)
     static member inline IsLeftZeroForApply (_: ref< ^t> when ^t: null and ^t: struct, _: Default1) = ()
+
+#endif

--- a/src/FSharpPlus/Control/Arrow.fs
+++ b/src/FSharpPlus/Control/Arrow.fs
@@ -12,6 +12,8 @@ open FSharpPlus.Internals
 open FSharpPlus.Internals.Prelude
 open FSharpPlus
 
+#if !FABLE_COMPILER
+
 // Arrow class ------------------------------------------------------------
 
 #nowarn "0077"
@@ -27,11 +29,9 @@ type Arr =
 
     static member inline InvokeOnInstance (f: 'T -> 'U) : '``Arrow<'T,'U>`` = (^``Arrow<'T,'U>`` : (static member Arr: _ -> _) f)
 
-#if !FABLE_COMPILER
 type Arr with
     static member inline Arr (f: 'T -> 'U, _output: '``Arrow<'T,'U>``                , _mthd: Default1) = Arr.InvokeOnInstance f : '``Arrow<'T,'U>``
     static member inline Arr (_: 'T -> 'U, _output: ^t when ^t : null and ^t : struct, _mthd: Default1) = id
-#endif
 
 
 type ArrFirst =
@@ -45,11 +45,9 @@ type ArrFirst =
 
     static member inline InvokeOnInstance (f: '``Arrow<'T,'U>``) : '``Arrow<('T * 'V),('U * 'V)>`` = ((^``Arrow<'T,'U>`` or ^``Arrow<('T * 'V),('U * 'V)>``) : (static member First : _ -> _) f)
 
-#if !FABLE_COMPILER
 type ArrFirst with
     static member inline First (f: '``Arrow<'T,'U>``, _output: '``Arrow<('T * 'V),('U * 'V)>``, _mthd: Default1) = ArrFirst.InvokeOnInstance f  : '``Arrow<('T * 'V),('U * 'V)>``
     static member inline First (_: ^t when ^t : null and ^t : struct  , _output               , _mthd: Default1) = id
-#endif
 
 
 type ArrSecond =
@@ -68,10 +66,9 @@ type ArrSecond with
         let arrSwap = Arr.InvokeOnInstance (fun (x, y) -> (y, x))
         Comp.InvokeOnInstance arrSwap (Comp.InvokeOnInstance (ArrFirst.InvokeOnInstance f) arrSwap)
 
-    #if !FABLE_COMPILER
     static member inline Second (f: '``Arrow<'T,'U>``, _output: '``Arrow<('V * 'T),('V * 'U)>``, _mthd: Default1) = ArrSecond.InvokeOnInstance f : '``Arrow<('V * 'T),('V * 'U)>``
     static member inline Second (_: ^t when ^t : null and ^t : struct  , _output               , _mthd: Default1) = id
-    #endif
+
 
 type ArrCombine =
     inherit Default1
@@ -86,10 +83,9 @@ type ArrCombine =
 
 type ArrCombine with
     static member inline ``***`` (f: '``Arrow<'T1,'U1>``, g: '``Arrow<'T2,'U2>``, _output: '``Arrow<('T1 * 'T2),('U1 * 'U2)>``, _mthd: Default2) = Comp.InvokeOnInstance (ArrSecond.InvokeOnInstance g) (ArrFirst.InvokeOnInstance f) : '``Arrow<('T1 * 'T2),('U1 * 'U2)>``
-    #if !FABLE_COMPILER
+
     static member inline ``***`` (f: '``Arrow<'T1,'U1>``, g: '``Arrow<'T2,'U2>``, _output: '``Arrow<('T1 * 'T2),('U1 * 'U2)>``, _mthd: Default1) = ArrCombine.InvokeOnInstance f g                                                    : '``Arrow<('T1 * 'T2),('U1 * 'U2)>``
     static member inline ``***`` (_: '``Arrow<'T1,'U1>``, _: '``Arrow<'T2,'U2>``, _output: ^t when ^t : null and ^t : struct  , _mthd: Default1) = id
-    #endif
 
 
 type Fanout =
@@ -106,7 +102,8 @@ type Fanout =
 type Fanout with
     static member inline ``&&&`` (f: '``Arrow<'T,'U1>``, g: '``Arrow<'T,'U2>``, _output: '``Arrow<'T,('U1 * 'U2)>``,    _mthd: Default3) = Comp.InvokeOnInstance (Comp.InvokeOnInstance (ArrSecond.InvokeOnInstance g) (ArrFirst.InvokeOnInstance f)) (Arr.InvokeOnInstance (fun b -> (b, b))) : '``Arrow<'T,('U1 * 'U2)>``
     static member inline ``&&&`` (f: '``Arrow<'T,'U1>``, g: '``Arrow<'T,'U2>``, _output: '``Arrow<'T,('U1 * 'U2)>``,    _mthd: Default2) = Comp.InvokeOnInstance (ArrCombine.InvokeOnInstance f g) (Arr.InvokeOnInstance (fun b -> (b, b)))                                                    : '``Arrow<'T,('U1 * 'U2)>``
-    #if !FABLE_COMPILER
+
     static member inline ``&&&`` (f: '``Arrow<'T,'U1>``, g: '``Arrow<'T,'U2>``, _output: '``Arrow<'T,('U1 * 'U2)>``,    _mthd: Default1) = Fanout.InvokeOnInstance f g                                                                                                                         : '``Arrow<'T,('U1 * 'U2)>``
     static member inline ``&&&`` (_: '``Arrow<'T,'U1>``, _: '``Arrow<'T,'U2>``, _output: ^t when ^t:null and ^t:struct, _mthd: Default1) = id
-    #endif
+
+#endif

--- a/src/FSharpPlus/Control/ArrowApply.fs
+++ b/src/FSharpPlus/Control/ArrowApply.fs
@@ -12,6 +12,8 @@ open FSharpPlus.Internals
 open FSharpPlus.Internals.Prelude
 open FSharpPlus
 
+#if !FABLE_COMPILER
+
 // ArrowApply class -------------------------------------------------------
 
 type App =
@@ -25,8 +27,8 @@ type App =
 
     static member inline InvokeOnInstance () : '``ArrowApply<('ArrowApply<'T,'U> * 'T)>,'U)>`` = (^``ArrowApply<('ArrowApply<'T,'U> * 'T)>,'U)>`` : (static member App : _) ())
 
-#if !FABLE_COMPILER
 type App with
     static member inline App (_output: '``ArrowApply<('ArrowApply<'T,'U> * 'T)>,'U)>``, _mthd: Default1) = App.InvokeOnInstance () : '``ArrowApply<('ArrowApply<'T,'U> * 'T)>,'U)>``
     static member inline App (_output: ^t when ^t : null and ^t : struct              , _mthd: Default1) = id
+
 #endif

--- a/src/FSharpPlus/Control/ArrowChoice.fs
+++ b/src/FSharpPlus/Control/ArrowChoice.fs
@@ -12,6 +12,8 @@ open FSharpPlus.Internals
 open FSharpPlus.Internals.Prelude
 open FSharpPlus
 
+#if !FABLE_COMPILER
+
 // ArrowChoice class ------------------------------------------------------
 
 #nowarn "0077"
@@ -27,11 +29,9 @@ type Fanin =
 
     static member inline InvokeOnInstance (f: '``ArrowChoice<'T,'V>``) (g: '``ArrowChoice<'U,'V>``) : '``ArrowChoice<Choice<'U,'T>,'V>`` = (^``ArrowChoice<Choice<'U,'T>,'V>`` : (static member (|||) : _*_ -> _) f, g)
 
-#if !FABLE_COMPILER
 type Fanin with
     static member inline ``|||`` (f: '``ArrowChoice<'T,'V>``, g: '``ArrowChoice<'U,'V>``, _output: '``ArrowChoice<Choice<'U,'T>,'V>``, _mthd: Default1) = Fanin.InvokeOnInstance f g : '``ArrowChoice<Choice<'U,'T>,'V>``
     static member inline ``|||`` (_: '``ArrowChoice<'T,'V>``, _: '``ArrowChoice<'U,'V>``, _output: ^t when ^t : null and ^t : struct , _mthd: Default1) = id
-#endif
 
 
 type AcMerge =
@@ -45,11 +45,9 @@ type AcMerge =
 
     static member inline InvokeOnInstance (f: '``ArrowChoice<'T1,'U1>``) (g: '``ArrowChoice<'T2,'U2>``) : '``ArrowChoice<Choice<'T2,'T1>,Choice<'U2,'U1>>`` = (^``ArrowChoice<Choice<'T2,'T1>,Choice<'U2,'U1>>`` : (static member (+++) : _*_ -> _) f, g)
 
-#if !FABLE_COMPILER
 type AcMerge with
     static member inline ``+++`` (f: '``ArrowChoice<'T1,'U1>``, g: '``ArrowChoice<'T2,'U2>``, _output: '``ArrowChoice<Choice<'T2,'T1>,Choice<'U2,'U1>>``, _mthd: Default1) = AcMerge.InvokeOnInstance f g : '``ArrowChoice<Choice<'T2,'T1>,Choice<'U2,'U1>>``
     static member inline ``+++`` (_: '``ArrowChoice<'T1,'U1>``, _: '``ArrowChoice<'T2,'U2>``, _output: ^t when ^t : null and ^t : struct                , _mthd: Default1) = id
-#endif
 
 
 type AcLeft =
@@ -63,11 +61,10 @@ type AcLeft =
 
     static member inline InvokeOnInstance (f: '``ArrowChoice<'T,'U>``) : '``ArrowChoice<Choice<'V,'T>,Choice<'V,'U>>`` = ((^``ArrowChoice<'T,'U>`` or ^``ArrowChoice<Choice<'V,'T>,Choice<'V,'U>>``) : (static member Left : _ -> _) f)
 
-#if !FABLE_COMPILER
 type AcLeft with
     static member inline Left (f: '``ArrowChoice<'T,'U>``, _output: '``ArrowChoice<Choice<'V,'T>,Choice<'V,'U>>``, _mthd: Default1) = AcLeft.InvokeOnInstance f: '``ArrowChoice<Choice<'V,'T>,Choice<'V,'U>>``
     static member inline Left (_: '``ArrowChoice<'T,'U>``, _output: ^t when ^t : null and ^t : struct            , _mthd: Default1) = id
-#endif
+
 
 type AcRight =
     inherit Default1
@@ -80,8 +77,8 @@ type AcRight =
 
     static member inline InvokeOnInstance (f: '``ArrowChoice<'T,'U>``) : '``ArrowChoice<Choice<'V,'T>,Choice<'U,'V>>`` = ((^``ArrowChoice<'T,'U>`` or ^``ArrowChoice<Choice<'V,'T>,Choice<'U,'V>>``) : (static member Right : _ -> _) f)
 
-#if !FABLE_COMPILER
 type AcRight with
     static member inline Right (f: '``ArrowChoice<'T,'U>``, _output: '``ArrowChoice<Choice<'V,'T>,Choice<'U,'V>>``, _mthd: Default1) = AcRight.InvokeOnInstance f : '``ArrowChoice<Choice<'V,'T>,Choice<'U,'V>>``
     static member inline Right (_: '``ArrowChoice<'T,'U>``, _output: ^t when ^t : null and ^t : struct            , _mthd: Default1) = id
+
 #endif

--- a/src/FSharpPlus/Control/Bifoldable.fs
+++ b/src/FSharpPlus/Control/Bifoldable.fs
@@ -5,6 +5,8 @@ namespace FSharpPlus.Control
 open System.Runtime.InteropServices
 open FSharpPlus.Internals
 
+#if !FABLE_COMPILER
+
 type BifoldMap =
     inherit Default1
 
@@ -77,3 +79,5 @@ type Bisum with
     static member inline Bisum (x: '``Bifoldable<'T,'T>``, [<Optional>]_impl: Default2) = BifoldMap.InvokeOnInstance id id x : 'T
     static member inline Bisum (x: '``Bifoldable<'T,'T>``, [<Optional>]_impl: Default1) = Bisum.InvokeOnInstance x : 'T
     static member inline Bisum (_: '``Bifoldable<'T,'T>`` when '``Bifoldable<'T,'T>`` : null and '``Bifoldable<'T,'T>``: struct, _: Default1) = ()
+
+#endif

--- a/src/FSharpPlus/Control/Category.fs
+++ b/src/FSharpPlus/Control/Category.fs
@@ -12,6 +12,8 @@ open FSharpPlus.Internals
 open FSharpPlus.Internals.Prelude
 open FSharpPlus
 
+#if !FABLE_COMPILER
+
 // Category class ---------------------------------------------------------
 
 #nowarn "0077"
@@ -27,11 +29,9 @@ type Id =
 
     static member inline InvokeOnInstance () : '``Category<'T,'T>`` = (^``Category<'T,'T>`` : (static member Id : _) ())
 
-#if !FABLE_COMPILER
 type Id with
     static member inline Id (_output:  '``Category<'T,'T>``        , _mthd: Default1) = Id.InvokeOnInstance () : '``Category<'T,'T>``
     static member inline Id (_output: ^t when ^t:null and ^t:struct, _mthd: Default1) = id                       
-#endif
 
 
 type Comp =
@@ -46,7 +46,6 @@ type Comp =
     static member inline InvokeOnInstance  (f: '``Category<'U,'V>``) (g: '``Category<'T,'U>``) : '``Category<'T,'V>`` = ( ^``Category<'T,'V>`` : (static member (<<<) : _*_ -> _) f, g)
     static member inline InvokeOnInstance' (f: '``Category<'U,'V>``) (g: '``Category<'T,'U>``) : '``Category<'T,'V>`` = ((^``Category<'U,'V>`` or ^``Category<'T,'U>``) : (static member (<<<) : _*_ -> _) f, g) : '``Category<'T,'V>``
 
-#if !FABLE_COMPILER
 type Comp with
     static member inline ``<<<`` (f: '``Category<'U,'V>``, g: '``Category<'T,'U>``, _output (* : '``Category<'T,'V>``   *) , _mthd : Default1) = Comp.InvokeOnInstance' f g : '``Category<'T,'V>``
     static member inline ``<<<`` (f: 'F, g: 'G, _, _mthd: Default1) =         
@@ -56,4 +55,5 @@ type Comp with
             ivk g i
         let _ = h f g
         Unchecked.defaultof<ComposedStaticInvokable<'F, 'G>>
+
 #endif

--- a/src/FSharpPlus/Control/Collection.fs
+++ b/src/FSharpPlus/Control/Collection.fs
@@ -9,47 +9,40 @@ open System.Runtime.InteropServices
 open FSharpPlus
 open FSharpPlus.Internals
 
+#if !FABLE_COMPILER
 
 type OfSeq =
     inherit Default1
-    #if !FABLE_COMPILER
+    
     static member inline OfSeq (x: seq<'t>                 , _: '``Foldable'<T>``               , _: Default5) = x |> Seq.map Return.Invoke |> Sum.Invoke : '``Foldable'<T>``
-    #endif
+    
     static member        OfSeq (x: seq<'t>                 , _: seq<'t>                         , _: Default4) = x
     static member        OfSeq (x: seq<'t>                 , _: ICollection<'t>                 , _: Default4) = let d = ResizeArray () in Seq.iter d.Add x; d :> ICollection<'t>
     static member        OfSeq (x: seq<'t>                 , _: IList<'t>                       , _: Default4) = let d = ResizeArray () in Seq.iter d.Add x; d :> IList<'t>
-    static member        OfSeq (x: seq<'t>                 , _: IList                           , _: Default4) = let d = ResizeArray () in Seq.iter d.Add x; d :> IList
-    
-    #if !FABLE_COMPILER
+    static member        OfSeq (x: seq<'t>                 , _: IList                           , _: Default4) = let d = ResizeArray () in Seq.iter d.Add x; d :> IList    
     static member        OfSeq (x: seq<'k*'v>              , _: IReadOnlyDictionary<'k,'v>      , _: Default4) = Dict.toIReadOnlyDictionary (dict x)
-    static member        OfSeq (x: seq<KeyValuePair<'k,'v>>, _: IReadOnlyDictionary<'k,'v>      , _: Default4) = x |> Seq.map (|KeyValue|) |> dict |> Dict.toIReadOnlyDictionary
-    #endif
-    
+    static member        OfSeq (x: seq<KeyValuePair<'k,'v>>, _: IReadOnlyDictionary<'k,'v>      , _: Default4) = x |> Seq.map (|KeyValue|) |> dict |> Dict.toIReadOnlyDictionary    
     static member        OfSeq (x: seq<'k*'v>              , _: IDictionary<'k,'v>              , _: Default4) = dict x
     static member        OfSeq (x: seq<KeyValuePair<'k,'v>>, _: IDictionary<'k,'v>              , _: Default4) = x |> Seq.map (|KeyValue|) |> dict
-    #if !FABLE_COMPILER
     static member        OfSeq (x: seq<'k*'v>              , _: IDictionary                     , _: Default4) = let d = Hashtable () in x |> Seq.iter d.Add; d :> IDictionary
     static member        OfSeq (x: seq<KeyValuePair<'k,'v>>, _: IDictionary                     , _: Default4) = let d = Hashtable () in x |> Seq.iter (function (KeyValue x) -> d.Add x); d :> IDictionary
-    #endif
+
     static member inline OfSeq (x: seq<'t>                 , _: 'R                              , _: Default3) = (^R : (new : seq<'t> -> ^R) x) : 'R
     static member inline OfSeq (x: seq<KeyValuePair<'k,'v>>, _: 'R                              , _: Default3) = (^R : (new : seq<'k*'v> -> ^R) (Seq.map (|KeyValue|) x)) : 'R
     static member inline OfSeq (x: seq<'t>                 , _: 'F                              , _: Default2) = let c = new 'F () in (Seq.iter (fun t -> ( ^F : (member Add : 't -> ^R) c, t) |> ignore) x); c
-    #if !FABLE_COMPILER
+
     static member        OfSeq (x: seq<'t>                 , _: 'T when 'T :> ICollection<'t>   , _: Default1) = let d = new 'T () in x |> Seq.iter d.Add; d
     static member        OfSeq (x: seq<'k*'v>              , _: 'T when 'T :> IDictionary       , _: Default1) = let d = new 'T () in x |> Seq.iter d.Add; d
     static member        OfSeq (x: seq<KeyValuePair<'k,'v>>, _: 'T when 'T :> IDictionary       , _: Default1) = let d = new 'T () in x |> Seq.iter (function (KeyValue x) -> d.Add x); d
     static member        OfSeq (x: seq<'k*'v>              , _: 'T when 'T :> IDictionary<'k,'v>, _: OfSeq   ) = let d = new 'T () in x |> Seq.iter d.Add; d
     static member        OfSeq (x: seq<KeyValuePair<'k,'v>>, _: 'T when 'T :> IDictionary<'k,'v>, _: OfSeq   ) = let d = new 'T () in x |> Seq.iter d.Add; d
-    #endif
 
     static member inline OfSeq (x: seq<'t>                 , _: 'UserType                       , _: OfSeq   ) = (^UserType : (static member OfSeq : seq<'t> -> ^UserType) x)
     static member        OfSeq (x                          , _: 't []                           , _: OfSeq   ) = Array.ofSeq<'t> x
     static member        OfSeq (x                          , _: 't list                         , _: OfSeq   ) = List.ofSeq<'t> x
     static member        OfSeq (x: seq<char>               , _: string                          , _: OfSeq   ) = String.ofSeq x
     static member        OfSeq (x: seq<char>               , _: Text.StringBuilder              , _: OfSeq   ) = (StringBuilder (), x) ||> Seq.fold (fun x -> x.Append)
-    #if !FABLE_COMPILER
     static member        OfSeq (x: seq<'t>                 , _: Stack<'t>                       , _: OfSeq   ) = Generic.Stack x
-    #endif
 
     static member inline Invoke (value: seq<'t>) = 
         let inline call_2 (a: ^a, b: ^b, s) = ((^a or ^b) : (static member OfSeq : _*_*_ -> _) s, b, a)
@@ -59,44 +52,36 @@ type OfSeq =
 
 type OfList =
     inherit Default1
-    #if !FABLE_COMPILER
+
     static member inline OfList (x: list<'t>                 , _: '``Foldable'<T>``               , _: Default5) = x |> List.map Return.Invoke |> Sum.Invoke : '``Foldable'<T>``
-    #endif
+
     static member        OfList (x: list<'t>                 , _: seq<'t>                         , _: Default4) = List.toSeq x
     static member        OfList (x: list<'t>                 , _: ICollection<'t>                 , _: Default4) = let d = ResizeArray () in List.iter d.Add x; d :> ICollection<'t>
     static member        OfList (x: list<'t>                 , _: IList<'t>                       , _: Default4) = let d = ResizeArray () in List.iter d.Add x; d :> IList<'t>
     static member        OfList (x: list<'t>                 , _: IList                           , _: Default4) = let d = ResizeArray () in List.iter d.Add x; d :> IList
-
-    #if !FABLE_COMPILER
     static member        OfList (x: list<'k*'v>              , _: IReadOnlyDictionary<'k,'v>      , _: Default4) = Dict.toIReadOnlyDictionary (dict x)
     static member        OfList (x: list<KeyValuePair<'k,'v>>, _: IReadOnlyDictionary<'k,'v>      , _: Default4) = x |> List.map (|KeyValue|) |> dict |> Dict.toIReadOnlyDictionary
-    #endif
-
     static member        OfList (x: list<'k*'v>              , _: IDictionary<'k,'v>              , _: Default4) = dict x
     static member        OfList (x: list<KeyValuePair<'k,'v>>, _: IDictionary<'k,'v>              , _: Default4) = x |> List.map (|KeyValue|) |> dict
-    #if !FABLE_COMPILER
     static member        OfList (x: list<'k*'v>              , _: IDictionary                     , _: Default4) = let d = Hashtable () in x |> List.iter d.Add; d :> IDictionary
     static member        OfList (x: list<KeyValuePair<'k,'v>>, _: IDictionary                     , _: Default4) = let d = Hashtable () in x |> List.iter (function (KeyValue x) -> d.Add x); d :> IDictionary
-    #endif
+
     static member inline OfList (x: list<'t>                 , _: 'R                              , _: Default3) = (^R : (new : seq<'t> -> ^R) (List.toSeq x)) : 'R
     static member inline OfList (x: list<KeyValuePair<'k,'v>>, _: 'R                              , _: Default3) = (^R : (new : seq<'k*'v> -> ^R) (Seq.map (|KeyValue|) x)) : 'R
     static member inline OfList (x: list<'t>                 , _: 'F                              , _: Default2) = let c = new 'F () in (List.iter (fun t -> ( ^F : (member Add : 't -> ^R) c, t) |> ignore) x); c
-    #if !FABLE_COMPILER
+
     static member        OfList (x: list<'t>                 , _: 'T when 'T :> ICollection<'t>   , _: Default1) = let d = new 'T () in x |> List.iter d.Add; d
     static member        OfList (x: list<'k*'v>              , _: 'T when 'T :> IDictionary       , _: Default1) = let d = new 'T () in x |> List.iter d.Add; d
     static member        OfList (x: list<KeyValuePair<'k,'v>>, _: 'T when 'T :> IDictionary       , _: Default1) = let d = new 'T () in x |> List.iter (function (KeyValue x) -> d.Add x); d
     static member        OfList (x: list<'k*'v>              , _: 'T when 'T :> IDictionary<'k,'v>, _: OfList  ) = let d = new 'T () in x |> List.iter d.Add; d
     static member        OfList (x: list<KeyValuePair<'k,'v>>, _: 'T when 'T :> IDictionary<'k,'v>, _: OfList  ) = let d = new 'T () in x |> List.iter d.Add; d
-    #endif
 
     static member inline OfList (x: list<'t>                 , _: 'UserType                       , _: OfList  ) = (^UserType : (static member OfList : list<'t> -> ^UserType) x)
     static member        OfList (x                           , _: 't []                           , _: OfList  ) = Array.ofList<'t> x
     static member        OfList (x                           , _: 't list                         , _: OfList  ) = x
     static member        OfList (x: list<char>               , _: string                          , _: OfList  ) = String.ofList x
     static member        OfList (x: list<char>               , _: Text.StringBuilder              , _: OfList  ) = (StringBuilder (), x) ||> List.fold (fun x -> x.Append)
-    #if !FABLE_COMPILER
     static member        OfList (x: list<'t>                 , _: Stack<'t>                       , _: OfList  ) = Generic.Stack x
-    #endif
 
     static member inline Invoke (value: list<'t>) = 
         let inline call_2 (a: ^a, b: ^b, s) = ((^a or ^b) : (static member OfList : _*_*_ -> _) s, b, a)
@@ -243,10 +228,10 @@ type Distinct =
     static member inline InvokeOnInstance (source: '``C<'T>``) : '``C<'T>`` = (^``C<'T>`` : (static member Distinct : _->_) source) : ^``C<'T>``
 
     static member inline Distinct (x: '``Collection<'T>``  , [<Optional>]_impl: Default2) = x |> ToSeq.Invoke |> Seq.distinct |> OfSeq.Invoke         : '``Collection<'T>``
-    #if !FABLE_COMPILER
+
     static member inline Distinct (x: ^``Collection<'T>``  , [<Optional>]_impl: Default1) = (^``Collection<'T>`` : (static member Distinct : _->_) x) : '``Collection<'T>``
     static member inline Distinct (_: ^t when ^t : null and ^t : struct, _mthd: Default1) = id
-    #endif
+
 
 type DistinctBy =
     inherit Default1
@@ -317,10 +302,10 @@ type Rev =
     static member inline InvokeOnInstance (source: '``C<'T>``) : '``C<'T>`` = (^``C<'T>`` : (static member Rev : _->_) source) : ^``C<'T>``
 
     static member inline Rev (x: '``Collection<'T>``, [<Optional>]_impl: Default2) = x |> ToSeq.Invoke |> Seq.rev |> OfSeq.Invoke         : '``Collection<'T>``
-    #if !FABLE_COMPILER
+
     static member inline Rev (x: ^``Collection<'T>``, [<Optional>]_impl: Default1) = (^``Collection<'T>`` : (static member Rev : _->_) x) : '``Collection<'T>``
     static member inline Rev (_: ^t when ^t: null and ^t: struct, _mthd: Default1) = id
-    #endif
+
 
 type Scan =
     static member Scan (x: Id<'T>  , f ,z: 'S, [<Optional>]_output: Id<'S>  , [<Optional>]_impl: Scan) = Id.create (f z x.getValue)
@@ -347,10 +332,10 @@ type Sort =
     static member inline InvokeOnInstance (source: '``C<'T>``) : '``C<'T>`` = (^``C<'T>`` : (static member Sort : _->_) source) : ^``C<'T>``
 
     static member inline Sort (x: '``Collection<'T>``, [<Optional>]_impl: Default2) = x |> ToSeq.Invoke |> Seq.sort |> OfSeq.Invoke         : '``Collection<'T>``
-    #if !FABLE_COMPILER
+
     static member inline Sort (x: ^``Collection<'T>``, [<Optional>]_impl: Default1) = (^``Collection<'T>`` : (static member Sort : _->_) x) : '``Collection<'T>``
     static member inline Sort (_: ^t when ^t: null and ^t: struct, _mthd: Default1) = id
-    #endif
+
 
 type SortBy =
     inherit Default1
@@ -411,10 +396,9 @@ type Split =
 
  type Split with
     static member inline Split ((e: '``'Collection<'OrderedCollection>``, x: '``'OrderedCollection``), [<Optional>]_impl: Default2) = x |> ToSeq.Invoke |> Seq.split (ToSeq.Invoke e) |> Seq.map OfSeq.Invoke |> OfSeq.Invoke : '``'Collection<'OrderedCollection>``
-    #if !FABLE_COMPILER
+
     static member inline Split ((e: '``'Collection<'OrderedCollection>``, x: '``'OrderedCollection``), [<Optional>]_impl: Default1) = (^``'OrderedCollection`` : (static member Split : _*_->_) e, x)                          : '``'Collection<'OrderedCollection>``
     static member inline Split ((_: ^t when ^t: null and ^t: struct, _                              ),             _mthd: Default1) = id
-    #endif
 
 
 type Intersperse =
@@ -433,11 +417,11 @@ type Intersperse =
 
 type Intercalate =
     inherit Default1
-    #if !FABLE_COMPILER
+
     static member inline Intercalate (x: '``Foldable<'Monoid>``, e: 'Monoid          , [<Optional>]_impl: Default2   ) = let f t x = match t, x with (true, _), x -> false, x | (_, acc ), x -> (false, Plus.Invoke (Plus.Invoke acc e) x) in Fold.Invoke f (true, Zero.Invoke ()) x |> snd
     static member inline Intercalate (x: seq<'``Foldable<'T>``>, e: '``Foldable<'T>``, [<Optional>]_impl: Default1   ) = x |> Seq.map ToSeq.Invoke |> Seq.intercalate (ToSeq.Invoke e) |> OfSeq.Invoke : '``Foldable<'T>``
     static member inline Intercalate (_: seq<'``Foldable<'T>``>, _: ^t when ^t: null and ^t: struct  , _: Default1   ) = id
-    #endif
+
     static member        Intercalate (x: seq<list<'T>>         , e: list<'T>         , [<Optional>]_impl: Intercalate) = List.intercalate  e x
     static member        Intercalate (x: seq<'T []>            , e: 'T []            , [<Optional>]_impl: Intercalate) = Array.intercalate e x
     static member        Intercalate (x: seq<string>           , e: string           , [<Optional>]_impl: Intercalate) = String.Join (e, x)
@@ -448,3 +432,4 @@ type Intercalate =
         let inline call (a: 'a, b: 'b, s) = call_2 (a, b, s)
         call (Unchecked.defaultof<Intercalate>, source, sep) : 'Monoid
 
+#endif

--- a/src/FSharpPlus/Control/Comonad.fs
+++ b/src/FSharpPlus/Control/Comonad.fs
@@ -12,6 +12,8 @@ open FSharpPlus.Internals
 open FSharpPlus.Internals.Prelude
 open FSharpPlus
 
+#if !FABLE_COMPILER
+
 // Comonad class ----------------------------------------------------------
 
 type Extract =
@@ -20,10 +22,7 @@ type Extract =
     static member        Extract ((_: 'W, a: 'T)  ) = a
     static member inline Extract (f: 'Monoid -> 'T) = f (Zero.Invoke ())
     static member        Extract (f: 'T Id        ) = f
-
-#if !FABLE_COMPILER
     static member        Extract (f: Task<'T>     ) = f.Result
-#endif
 
     static member inline Invoke (x: '``Comonad<'T>``) : 'T =
         let inline call_2 (_mthd: ^M, x: ^I) = ((^M or ^I) : (static member Extract : _ -> _) x)
@@ -35,10 +34,7 @@ type Extend =
     static member        (=>>) ((w: 'W, a: 'T)  , f: _ -> 'U        ) = (w, f (w, a))        
     static member inline (=>>) (g: 'Monoid -> 'T, f: _ -> 'U        ) = fun a -> f (fun b -> g (Plus.Invoke a b))
     static member        (=>>) (g: Id<'T>       , f: Id<'T> -> 'U   ) = f g
-
-#if !FABLE_COMPILER
     static member        (=>>) (g: Task<'T>     , f: Task<'T> -> 'U) = g.ContinueWith (f)
-#endif
 
     // Restricted Comonads
     static member        (=>>) (s: list<'T>     , g) = List.map  g (List.tails s) : list<'U>
@@ -65,3 +61,5 @@ type Duplicate =
     static member inline Invoke (x: '``Comonad<'T>``) : '``Comonad<'Comonad<'T>>`` =
         let inline call (mthd: ^M, source: ^I, _output: ^R) = ((^M or ^I or ^R) : (static member Duplicate : _*_ -> _) source, mthd)
         call (Unchecked.defaultof<Duplicate>, x, Unchecked.defaultof<'``Comonad<'Comonad<'T>>``>)
+
+#endif

--- a/src/FSharpPlus/Control/Converter.fs
+++ b/src/FSharpPlus/Control/Converter.fs
@@ -13,13 +13,14 @@ open FSharpPlus.Internals
 open FSharpPlus.Internals.Prelude
 open FSharpPlus
 
+#if !FABLE_COMPILER
 
 type Explicit =
     inherit Default1
-    #if !FABLE_COMPILER
+    
     static member inline Explicit (_: 'R        , _: Default1) = fun (x : ^t) -> ((^R or ^t) : (static member op_Explicit : ^t -> ^R) x)
     static member inline Explicit (_: ^t when ^t: null and ^t: struct, _: Default1) = ()
-    #endif
+
     static member inline Explicit (_: byte      , _: Explicit) = fun x -> byte            x
     static member inline Explicit (_: sbyte     , _: Explicit) = fun x -> sbyte           x
     static member inline Explicit (_: int16     , _: Explicit) = fun x -> int16           x
@@ -43,22 +44,18 @@ type Explicit =
 type OfBytes =
     static member OfBytes (_: bool   , _: OfBytes) = fun (x, i, _) -> BitConverter.ToBoolean(x, i)
 
-    #if !FABLE_COMPILER
     static member OfBytes (_: char   , _: OfBytes) = fun (x, i, e) -> BitConverter.ToChar   (x, i, e)
     static member OfBytes (_: float  , _: OfBytes) = fun (x, i, e) -> BitConverter.ToDouble (x, i, e)
     static member OfBytes (_: int16  , _: OfBytes) = fun (x, i, e) -> BitConverter.ToInt16  (x, i, e)
     static member OfBytes (_: int    , _: OfBytes) = fun (x, i, e) -> BitConverter.ToInt32  (x, i, e)
     static member OfBytes (_: int64  , _: OfBytes) = fun (x, i, e) -> BitConverter.ToInt64  (x, i, e)
     static member OfBytes (_: float32, _: OfBytes) = fun (x, i, e) -> BitConverter.ToSingle (x, i, e)
-    #endif
 
     static member OfBytes (_: string , _: OfBytes) = fun (x, i, _) -> BitConverter.ToString (x, i)
 
-    #if !FABLE_COMPILER
     static member OfBytes (_: uint16 , _: OfBytes) = fun (x, i, e) -> BitConverter.ToUInt16 (x, i, e)
     static member OfBytes (_: uint32 , _: OfBytes) = fun (x, i, e) -> BitConverter.ToUInt32 (x, i, e)
     static member OfBytes (_: uint64 , _: OfBytes) = fun (x, i, e) -> BitConverter.ToUInt64 (x, i, e)
-    #endif
 
     static member inline Invoke (isLtEndian: bool) (startIndex: int) (value: byte[]) =
         let inline call_2 (a: ^a, b: ^b) = ((^a or ^b) : (static member OfBytes : _*_ -> _) b, a)
@@ -68,20 +65,16 @@ type OfBytes =
 
 type ToBytes =
     static member ToBytes (x: bool   , _, _: ToBytes) = BitConverter.GetBytes (x)
-    #if !FABLE_COMPILER
     static member ToBytes (x: char   , e, _: ToBytes) = BitConverter.GetBytes (x, BitConverter.IsLittleEndian = e)
     static member ToBytes (x: float  , e, _: ToBytes) = BitConverter.GetBytes (x, BitConverter.IsLittleEndian = e)
     static member ToBytes (x: int16  , e, _: ToBytes) = BitConverter.GetBytes (x, BitConverter.IsLittleEndian = e)
     static member ToBytes (x: int    , e, _: ToBytes) = BitConverter.GetBytes (x, BitConverter.IsLittleEndian = e)
     static member ToBytes (x: int64  , e, _: ToBytes) = BitConverter.GetBytes (x, BitConverter.IsLittleEndian = e)
     static member ToBytes (x: float32, e, _: ToBytes) = BitConverter.GetBytes (x, BitConverter.IsLittleEndian = e)
-    #endif
     static member ToBytes (x: string , _, _: ToBytes) = Array.map byte (x.ToCharArray ())
-    #if !FABLE_COMPILER
     static member ToBytes (x: uint16 , e, _: ToBytes) = BitConverter.GetBytes (x, BitConverter.IsLittleEndian = e)
     static member ToBytes (x: uint32 , e, _: ToBytes) = BitConverter.GetBytes (x, BitConverter.IsLittleEndian = e)
     static member ToBytes (x: uint64 , e, _: ToBytes) = BitConverter.GetBytes (x, BitConverter.IsLittleEndian = e)
-    #endif
 
     static member inline Invoke (isLittleEndian: bool) value : byte[] =
         let inline call_2 (a: ^a, b: ^b, e) = ((^a or ^b) : (static member ToBytes : _*_*_ -> _) b, e, a)
@@ -94,7 +87,6 @@ open System.Globalization
 type TryParse =
     inherit Default1
 
-    #if !FABLE_COMPILER
     static member TryParse (_: decimal       , _: TryParse) = fun x -> Decimal.TryParse (x, NumberStyles.Any, CultureInfo.InvariantCulture) |> tupleToOption : option<decimal>
     static member TryParse (_: float32       , _: TryParse) = fun x -> Single.TryParse  (x, NumberStyles.Any, CultureInfo.InvariantCulture) |> tupleToOption : option<float32>
     static member TryParse (_: float         , _: TryParse) = fun x -> Double.TryParse  (x, NumberStyles.Any, CultureInfo.InvariantCulture) |> tupleToOption : option<float>
@@ -104,14 +96,11 @@ type TryParse =
     static member TryParse (_: int16         , _: TryParse) = fun x -> Int16.TryParse   (x, NumberStyles.Any, CultureInfo.InvariantCulture) |> tupleToOption : option<int16>
     static member TryParse (_: int           , _: TryParse) = fun x -> Int32.TryParse   (x, NumberStyles.Any, CultureInfo.InvariantCulture) |> tupleToOption : option<int>
     static member TryParse (_: int64         , _: TryParse) = fun x -> Int64.TryParse   (x, NumberStyles.Any, CultureInfo.InvariantCulture) |> tupleToOption : option<int64>
-    #endif
 
     static member TryParse (_: string        , _: TryParse) = fun x -> Some x                               : option<string>
     static member TryParse (_: StringBuilder , _: TryParse) = fun x -> Some (new StringBuilder (x: string)) : option<StringBuilder>
-    #if !FABLE_COMPILER
     static member TryParse (_: DateTime      , _: TryParse) = fun x -> DateTime.TryParseExact       (x, [|"yyyy-MM-ddTHH:mm:ss.fffZ"; "yyyy-MM-ddTHH:mm:ssZ"|], null, DateTimeStyles.RoundtripKind) |> tupleToOption : option<DateTime>
     static member TryParse (_: DateTimeOffset, _: TryParse) = fun x -> DateTimeOffset.TryParseExact (x, [|"yyyy-MM-ddTHH:mm:ss.fffK"; "yyyy-MM-ddTHH:mm:ssK"|], null, DateTimeStyles.RoundtripKind) |> tupleToOption : option<DateTimeOffset>
-    #endif
 
     static member inline Invoke (value: string) =
         let inline call_2 (a: ^a, b: ^b) = ((^a or ^b) : (static member TryParse : _*_ -> _) b, a)
@@ -123,16 +112,13 @@ type TryParse with
         let mutable r = Unchecked.defaultof< ^R>
         if (^R: (static member TryParse : _ * _ -> _) (x, &r)) then Some r else None
 
-    #if !FABLE_COMPILER
     static member inline TryParse (_: ^t when ^t: null and ^t: struct, _: Default1) = id
     static member inline TryParse (_: 'R, _: Default1) = fun x -> (^R: (static member TryParse : string -> 'R option) x)
-    #endif
 
 type Parse =
     inherit Default1
     static member inline Parse (_: ^R                  , _: Default1) = fun (x:string) -> (^R: (static member Parse : _ -> ^R) x)
     static member inline Parse (_: ^R                  , _: Parse   ) = fun (x:string) -> (^R: (static member Parse : _ * _ -> ^R) (x, CultureInfo.InvariantCulture))
-    #if !FABLE_COMPILER
     static member        Parse (_: 'T when 'T : enum<_>, _: Parse   ) = fun x ->
         (match Enum.TryParse (x) with
             | (true, v) -> v
@@ -140,7 +126,6 @@ type Parse =
         ) : 'enum
 
     static member Parse (_: bool         , _: Parse) = fun x -> Boolean.Parse (x)
-    #endif
 
     static member Parse (_: char         , _: Parse) = fun x -> Char   .Parse (x)
     static member Parse (_: string       , _: Parse) = id : string->_
@@ -150,3 +135,5 @@ type Parse =
         let inline call_2 (a: ^a, b: ^b) = ((^a or ^b) : (static member Parse : _*_ -> _) b, a)
         let inline call (a: 'a) = fun (x: 'x) -> call_2 (a, Unchecked.defaultof<'r>) x : 'r
         call Unchecked.defaultof<Parse> value
+
+#endif

--- a/src/FSharpPlus/Control/Foldable.fs
+++ b/src/FSharpPlus/Control/Foldable.fs
@@ -6,6 +6,7 @@ namespace FSharpPlus.Internals
 
 open FSharpPlus.Control
 
+#if !FABLE_COMPILER
 
 [<Struct>]
 type _Dual<'T> =
@@ -55,10 +56,8 @@ type ToSeq =
 
 type ToSeq with
     static member inline ToSeq (x: 'S when 'S :> Collections.IEnumerable, [<Optional>]_impl: Default2) = let _f i x : 'T = (^S : (member get_Item : int -> 'T) x, i) in Seq.cast<'T> x : seq<'T>
-    #if !FABLE_COMPILER
     static member inline ToSeq (x: 'Foldable                            , [<Optional>]_impl: Default1) = ToSeq.InvokeOnInstance x
     static member inline ToSeq (_: 'T when 'T: null and 'T: struct      ,                 _: Default1) = ()
-    #endif
 
 
 type ToList =
@@ -119,23 +118,19 @@ type FoldBack =
 
 type FoldMap =
     inherit Default1
-    #if !FABLE_COMPILER
+
     static member inline FromFoldFoldBack f x = FoldBack.Invoke (Plus.Invoke << f) (Zero.Invoke ()) x
-    #endif
 
     static member inline FoldMap (x: option<_>, f, [<Optional>]_impl: FoldMap ) = match x with Some x -> f x | _ -> Zero.Invoke ()
-    #if !FABLE_COMPILER
     static member inline FoldMap (x: list<_>  , f, [<Optional>]_impl: FoldMap ) = List.fold  (fun x y -> Plus.Invoke x (f y)) (Zero.Invoke ()) x
     static member inline FoldMap (x: Set<_>   , f, [<Optional>]_impl: FoldMap ) = Seq.fold   (fun x y -> Plus.Invoke x (f y)) (Zero.Invoke ()) x
     static member inline FoldMap (x: _ []     , f, [<Optional>]_impl: FoldMap ) = Array.fold (fun x y -> Plus.Invoke x (f y)) (Zero.Invoke ()) x
-    #endif
 
     static member inline Invoke (f: 'T->'Monoid) (x: '``Foldable'<T>``) : 'Monoid =
         let inline call_2 (a: ^a, b: ^b, f) = ((^a or ^b) : (static member FoldMap : _*_*_ -> _) b, f, a)
         let inline call (a: 'a, b: 'b, f) = call_2 (a, b, f)
         call (Unchecked.defaultof<FoldMap>, x, f)
 
-#if !FABLE_COMPILER
 type FoldMap with
     static member inline FoldMap (x: seq<_>          , f, [<Optional>]_impl: Default2) = Seq.fold   (fun x y -> Plus.Invoke x (f y)) (Zero.Invoke ()) x
     static member inline FoldMap (x                  , f, [<Optional>]_impl: Default1) = (^F : (static member FoldMap : ^F -> _ -> _) x, f)
@@ -143,14 +138,12 @@ type FoldMap with
 
 type FoldBack with
     static member inline FromFoldMap f z x = let (f: _Endo<'t>) = FoldMap.Invoke (_Endo << f) x in f.Value z
-#endif
+
 
 type Fold =
     inherit Default1
 
-    #if !FABLE_COMPILER
     static member inline FromFoldMap f z t = let (f: _Dual<_Endo<'t>>) = FoldMap.Invoke (_Dual << _Endo << flip f) t in f.Value.Value z
-    #endif
 
     static member inline Fold (x           , f,             z,     [<Optional>]_impl: Default2) = Seq.fold f z (ToSeq.Invoke x)
     static member inline Fold (x: 'F       , f: 'b->'a->'b, z: 'b, [<Optional>]_impl: Default1) = (^F : (static member Fold : ^F -> _ -> _-> ^b) x, f, z)
@@ -388,3 +381,5 @@ type Length =
 
 
 type Reduce = static member inline Invoke (f: 'T->'T->'T) (x: '``Reducible<'T>``) : 'T = (^``Reducible<'T>`` : (static member Reduce : _*_ -> _) x, f)
+
+#endif

--- a/src/FSharpPlus/Control/Functor.fs
+++ b/src/FSharpPlus/Control/Functor.fs
@@ -285,9 +285,8 @@ type Dimap with
     static member inline Dimap (x: '``Profunctor<'B,'C>``, ab: 'A->'B, cd: 'C->'D, [<Optional>]_mthd: Default1) = Dimap.InvokeOnInstance ab cd x                                : '``Profunctor<'A,'D>``
     static member inline Dimap (_: ^t when ^t: null and ^t: struct,     _: 'T->'U, _: 'V->'W,  _mthd: Default1) = ()
 
+#endif
 
 // Invariant functor
 
 type Invmap = static member inline Invoke (f: 'T -> 'U) (g: 'U -> 'T) (source: '``InvariantFunctor<'T>``) = (^``InvariantFunctor<'T>`` : (static member Invmap : _*_*_ -> _) source, f, g) : '``InvariantFunctor<'U>``
-
-#endif

--- a/src/FSharpPlus/Control/Indexable.fs
+++ b/src/FSharpPlus/Control/Indexable.fs
@@ -1,5 +1,7 @@
 ﻿namespace FSharpPlus.Control
 
+#if !FABLE_COMPILER
+
 open System
 open System.Runtime.CompilerServices
 open System.Runtime.InteropServices
@@ -16,18 +18,16 @@ open FSharpPlus.Internals.Prelude
 
 type Item =
     inherit Default1
-    #if !FABLE_COMPILER
+    
     static member inline Item (x: '``Indexable<'T>`` , k        , [<Optional>]_impl: Default1) = (^``Indexable<'T>`` : (member get_Item : _ -> 'T) x, k) : 'T
     static member inline Item (_: 'T when 'T: null and 'T: struct, _,         _impl: Default1) = ()
-    #endif
+    
     static member        Item (x: string             , n        , [<Optional>]_impl: Item    ) = String.item n x
     static member        Item (x: StringBuilder      , n        , [<Optional>]_impl: Item    ) = x.ToString().[n]
-    static member        Item (x: 'T []              , n        , [<Optional>]_impl: Item    ) = x.[n]       : 'T
-    #if !FABLE_COMPILER
+    static member        Item (x: 'T []              , n        , [<Optional>]_impl: Item    ) = x.[n]       : 'T    
     static member        Item (x: 'T [,]             , (i,j)    , [<Optional>]_impl: Item    ) = x.[i,j]     : 'T
     static member        Item (x: 'T [,,]            , (i,j,k)  , [<Optional>]_impl: Item    ) = x.[i,j,k]   : 'T
     static member        Item (x: 'T [,,,]           , (i,j,k,l), [<Optional>]_impl: Item    ) = x.[i,j,k,l] : 'T
-    #endif
 
     static member inline Invoke (n: 'K) (source: '``Indexed<'T>``) : 'T =
         let inline call_2 (a: ^a, b: ^b, n) = ((^a or ^b) : (static member Item: _*_*_ -> _) b, n, a)
@@ -40,18 +40,16 @@ type TryItem =
     static member inline TryItem (x: '``Indexable<'T>``, k, [<Optional>]_impl: Default2) =
         let mutable r = Unchecked.defaultof< ^R>
         if (^``Indexable<'T>``: (member TryGetValue: _ * _ -> _) (x, k, &r)) then Some r else None
-    #if !FABLE_COMPILER
+    
     static member inline TryItem (x: '``Indexable<'T>``, k        , [<Optional>]_impl: Default1) = (^``Indexable<'T>`` : (static member TryItem : _ * _ -> _) k, x) : 'T option
     static member inline TryItem (_: 'T when 'T: null and 'T: struct, _       , _impl: Default1) = ()
-    #endif
+
     static member        TryItem (x: string            , n        , [<Optional>]_impl: TryItem ) = String.tryItem n x
     static member        TryItem (x: StringBuilder     , n        , [<Optional>]_impl: TryItem ) = if n >= 0 && n < x.Length then Some ((string x).[n]) else None
-    #if !FABLE_COMPILER
     static member        TryItem (x: 'a []             , n        , [<Optional>]_impl: TryItem ) = if n >= x.GetLowerBound 0 && n <= x.GetUpperBound 0 then Some x.[n] else None : 'a option
     static member        TryItem (x: 'a [,]            , (i,j)    , [<Optional>]_impl: TryItem ) = if (i, j)       >= (x.GetLowerBound 0, x.GetLowerBound 1                                      ) && (i, j)       <= (x.GetUpperBound 0, x.GetUpperBound 1                                      ) then Some x.[i,j]     else None : 'a option
     static member        TryItem (x: 'a [,,]           , (i,j,k)  , [<Optional>]_impl: TryItem ) = if (i, j, k)    >= (x.GetLowerBound 0, x.GetLowerBound 1, x.GetLowerBound 2)                    && (i, j, k)    <= (x.GetUpperBound 0, x.GetUpperBound 1, x.GetUpperBound 2                   ) then Some x.[i,j,k]   else None : 'a option
     static member        TryItem (x: 'a [,,,]          , (i,j,k,l), [<Optional>]_impl: TryItem ) = if (i, j, k, l) >= (x.GetLowerBound 0, x.GetLowerBound 1, x.GetLowerBound 2, x.GetLowerBound 3) && (i, j, k, l) <= (x.GetUpperBound 0, x.GetUpperBound 1, x.GetUpperBound 2, x.GetUpperBound 3) then Some x.[i,j,k,l] else None : 'a option
-    #endif
     static member        TryItem (x: 'a ResizeArray    , n        , [<Optional>]_impl: TryItem ) = if n >= 0 && n < x.Count then Some x.[n] else None
     static member        TryItem (x: list<'a>          , n        , [<Optional>]_impl: TryItem ) = List.tryItem n x
     static member        TryItem (x: IList<'a>         , n        , [<Optional>]_impl: Default2) = if n >= 0 && n < x.Count then Some x.[n] else None
@@ -109,11 +107,10 @@ type FoldIndexed =
 type TraverseIndexed =
     static member inline TraverseIndexed ((k: 'K, a: 'T), f , [<Optional>]_output: 'R, [<Optional>]_impl: TraverseIndexed) : 'R = Map.Invoke ((fun x y -> (x, y)) k) (f k a)
     static member inline TraverseIndexed (a: Tuple<_>   , f , [<Optional>]_output: 'R, [<Optional>]_impl: TraverseIndexed) : 'R = Map.Invoke Tuple (f () a.Item1)
-    #if !FABLE_COMPILER
+    
     static member inline TraverseIndexed (t: Map<_,_>   , f , [<Optional>]_output: 'R, [<Optional>]_impl: TraverseIndexed) : 'R =
         let insert_f k x ys = Map.Invoke (Map.add k) (f k x) <*> ys
         Map.foldBack insert_f t (result Map.empty)
-    #endif
 
     static member inline Invoke f t =
         let inline call_3 (a: ^a, b: ^b, c: ^c, f) = ((^a or ^b or ^c) : (static member TraverseIndexed : _*_*_*_ -> _) b, f, c, a)
@@ -153,14 +150,12 @@ type TryFindIndex =
 
 type FindSliceIndex =
     inherit Default1
-    static member        FindSliceIndex (x: string           , e                   , [<Optional>]_impl: FindSliceIndex) = String.findSliceIndex e x
-    #if !FABLE_COMPILER
+    static member        FindSliceIndex (x: string           , e                   , [<Optional>]_impl: FindSliceIndex) = String.findSliceIndex e x    
     static member        FindSliceIndex (x: 'a []            , e                   , [<Optional>]_impl: FindSliceIndex) = Array.findSliceIndex e x
     static member        FindSliceIndex (x: 'a ResizeArray   , e: 'a ResizeArray   , [<Optional>]_impl: FindSliceIndex) = Seq.findSliceIndex e x
     static member        FindSliceIndex (x: list<'a>         , e                   , [<Optional>]_impl: FindSliceIndex) = List.findSliceIndex e x
     static member        FindSliceIndex (x: seq<'a>          , e                   , [<Optional>]_impl: FindSliceIndex) = Seq.findSliceIndex e x
     static member        FindSliceIndex (x: 'a Id            , e: 'a Id            , [<Optional>]_impl: FindSliceIndex) = List.findSliceIndex [e.getValue] [x.getValue]
-    #endif
 
     static member inline Invoke (slice: '``Collection<'T>``) (source: '``Collection<'T>``) : 'Index =
         let inline call_2 (a: ^a, b: ^b, n) = ((^a or ^b) : (static member FindSliceIndex : _*_*_ -> _) b, n, a)
@@ -170,16 +165,15 @@ type FindSliceIndex =
 type TryFindSliceIndex =
     inherit Default1
     static member        TryFindSliceIndex (x: string           , e                   , [<Optional>]_impl: TryFindSliceIndex) = String.tryFindSliceIndex e x
-    #if !FABLE_COMPILER
     static member        TryFindSliceIndex (x: 'a []            , e                   , [<Optional>]_impl: TryFindSliceIndex) = Array.tryFindSliceIndex e x
     static member        TryFindSliceIndex (x: 'a ResizeArray   , e: 'a ResizeArray   , [<Optional>]_impl: TryFindSliceIndex) = Seq.tryFindSliceIndex e x
     static member        TryFindSliceIndex (x: list<'a>         , e                   , [<Optional>]_impl: TryFindSliceIndex) = List.tryFindSliceIndex e x
     static member        TryFindSliceIndex (x: seq<'a>          , e                   , [<Optional>]_impl: TryFindSliceIndex) = Seq.tryFindSliceIndex e x
     static member        TryFindSliceIndex (x: 'a Id            , e: 'a Id            , [<Optional>]_impl: TryFindSliceIndex) = List.tryFindSliceIndex [e.getValue] [x.getValue]
-    #endif
 
     static member inline Invoke (slice: '``Collection<'T>``) (source: '``Collection<'T>``) : 'Index option =
         let inline call_2 (a: ^a, b: ^b, n) = ((^a or ^b) : (static member TryFindSliceIndex : _*_*_ -> _) b, n, a)
         let inline call (a: 'a, b: 'b, n) = call_2 (a, b, n)
         call (Unchecked.defaultof<TryFindSliceIndex>, source, slice)
 
+#endif

--- a/src/FSharpPlus/Control/Invokable.fs
+++ b/src/FSharpPlus/Control/Invokable.fs
@@ -1,5 +1,7 @@
 namespace FSharpPlus.Control
 
+#if !FABLE_COMPILER
+
 open System
 open System.Runtime.CompilerServices
 open System.Runtime.InteropServices
@@ -17,10 +19,9 @@ open FSharpPlus
 type Invoke =
     inherit Default1
 
-    #if !FABLE_COMPILER
     static member inline Invoke (_: ^t when ^t : null and ^t : struct, _, _output: ^O, _mthd: Default1) = id
     static member inline Invoke (_: 'T, x, _output: ^O, _mthd: Default1) = (^T : (static member Invoke : _ -> _) x)
-    #endif
+
     static member        Invoke (g:  'T -> 'U  , x: 'T, _output: 'U, _mthd: Invoke) = g x        : 'U
     static member        Invoke (g: Func<'T,'U>, x: 'T, _output: 'U, _mthd: Invoke) = g.Invoke x : 'U
 
@@ -38,3 +39,4 @@ type ComposedStaticInvokable< ^F, ^G>  =
         let i  =  Invoke.Invoke (Unchecked.defaultof<'G>, x)
         Invoke.Invoke (Unchecked.defaultof<'F>, i)
 
+#endif

--- a/src/FSharpPlus/Control/MonadOps.fs
+++ b/src/FSharpPlus/Control/MonadOps.fs
@@ -1,12 +1,14 @@
 namespace FSharpPlus.Internals
 
+#if !FABLE_COMPILER
+
 module internal MonadOps =
     open FSharpPlus.Control
 
     let inline (>>=) x f = Bind.Invoke x f
-    #if !FABLE_COMPILER
     let inline result  x = Return.Invoke x
-    #endif
     let inline (<*>) f x = Apply.Invoke f x
     let inline (<|>) x y = Append.Invoke x y
     let inline (>=>) (f: 'a->'``Monad<'b>``) (g: 'b->'``Monad<'c>``) (x: 'a) : '``Monad<'c>`` = f x >>= g
+
+#endif

--- a/src/FSharpPlus/Control/MonadTrans.fs
+++ b/src/FSharpPlus/Control/MonadTrans.fs
@@ -1,5 +1,7 @@
 ﻿namespace FSharpPlus.Control
 
+#if !FABLE_COMPILER
+
 open FSharpPlus.Internals
 open FSharpPlus
 open FSharpPlus.Internals.MonadOps
@@ -18,9 +20,7 @@ type LiftAsync =
         call Unchecked.defaultof<LiftAsync> x
 
     static member inline LiftAsync (_: 'R) = fun (x: Async<'T>) -> (^R : (static member LiftAsync : _ -> ^R) x)
-    #if !FABLE_COMPILER
     static member inline LiftAsync (_: ^t when ^t: null and ^t: struct) = ()
-    #endif
     static member        LiftAsync (_: Async<'T>) = fun (x: Async<'T>) -> x
 
 
@@ -32,10 +32,8 @@ type Throw =
         let inline call (a: 'a, x: 'x) = call_2 (a, Unchecked.defaultof<'r>, x) : 'r
         call (Unchecked.defaultof<Throw>, x)
 
-    #if !FABLE_COMPILER
     static member inline Throw (_: 'R, x: 'E) = (^R : (static member Throw : _ -> ^R) x)
     static member inline Throw (_: ^t when ^t: null and ^t: struct, _) = id
-    #endif
     static member        Throw (_: Result<'T,'E>, x: 'E) = Error x     : Result<'T,'E>
     static member        Throw (_: Choice<'T,'E>, x: 'E) = Choice2Of2 x: Choice<'T,'E>
 
@@ -70,3 +68,5 @@ type Local = static member inline Invoke (f: 'R1->'R2) (m: ^``MonadReader<'R2,'T
 type Tell   = static member inline Invoke (w: 'Monoid)                                               : '``MonadWriter<'Monoid,unit>``           = (^``MonadWriter<'Monoid,unit>``           : (static member Tell   : _ -> _) w)
 type Listen = static member inline Invoke (m: '``MonadWriter<'Monoid,'T>``)                          : '``MonadWriter<'Monoid,('T * 'Monoid)>`` = (^``MonadWriter<'Monoid,('T * 'Monoid)>`` : (static member Listen : _ -> _) m)
 type Pass   = static member inline Invoke (m: '``MonadWriter<'Monoid,('T * ('Monoid -> 'Monoid))>``) : '``MonadWriter<'Monoid,'T>``             = (^``MonadWriter<'Monoid,'T>``             : (static member Pass   : _ -> _) m)
+
+#endif

--- a/src/FSharpPlus/Control/Monoid.fs
+++ b/src/FSharpPlus/Control/Monoid.fs
@@ -11,30 +11,29 @@ open FSharpPlus
 open FSharpPlus.Internals
 open FSharpPlus.Internals.Prelude
 
+#if !FABLE_COMPILER
 
 [<Extension; Sealed>]
 type Plus =     
     inherit Default1
     static member inline ``+`` (x: 'Plus             , y: 'Plus             ,             _mthd: Default2) = (^Plus :  (static member (<|>) : _*_ -> _) x, y) : ^Plus
-    #if !FABLE_COMPILER
+
     static member inline ``+`` (x: 'Plus             , y: 'Plus             , [<Optional>]_mthd: Default1) = x + y : ^Plus
     static member inline ``+`` (_: ^t when ^t: null and ^t: struct, _: ^t   , [<Optional>]_mthd: Default1) = id
-    #endif
+
     static member        ``+`` (x: list<_>           , y                    , [<Optional>]_mthd: Plus    ) = x @ y
     static member        ``+`` (x: array<_>          , y                    , [<Optional>]_mthd: Plus    ) = Array.append x y
     static member        ``+`` (()                   , ()                   , [<Optional>]_mthd: Plus    ) = ()
     static member        ``+`` (x: bool              , y: bool              , [<Optional>]_mthd: Plus    ) = x <> y
     static member        ``+`` (x: Set<_>            , y                    , [<Optional>]_mthd: Plus    ) = Set.union x y
     static member        ``+`` (x: StringBuilder     , y: StringBuilder     , [<Optional>]_mthd: Plus    ) = StringBuilder().Append(x).Append(y)    
-    #if !FABLE_COMPILER
     static member        ``+`` (x: AggregateException, y: AggregateException, [<Optional>]_mthd: Plus    ) = new AggregateException (seq {yield! x.InnerExceptions; yield! y.InnerExceptions})
-    #endif
     static member        ``+`` (_: Id0               , _: Id0               , [<Optional>]_mthd: Plus    ) = Id0 ""    
-    #if !FABLE_COMPILER
+
     static member        ``+`` (x: exn               , y: exn               , [<Optional>]_mthd: Plus    ) =
         let f (e: exn) = match e with :? AggregateException as a -> a.InnerExceptions :> seq<_> | _ -> Seq.singleton e
         new AggregateException (seq {yield! f x; yield! f y}) :> exn
-    #endif
+
     static member inline Invoke (x: 'Plus) (y: 'Plus) : 'Plus =
         let inline call (mthd : ^M, input1 : ^I, input2 : ^I) = ((^M or ^I) : (static member ``+`` : _*_*_ -> _) input1, input2, mthd)
         call (Unchecked.defaultof<Plus>, x, y)
@@ -114,9 +113,7 @@ type Plus with
     static member        ``+`` (x: _ ResizeArray             , y: _ ResizeArray             , [<Optional>]_mthd: Plus    ) = ResizeArray (Seq.append x y)
     static member        ``+`` (x: _ IObservable             , y                            , [<Optional>]_mthd: Default3) = Observable.merge x y
     static member        ``+`` (x: _ seq                     , y                            , [<Optional>]_mthd: Default3) = Seq.append x y
-    #if !FABLE_COMPILER
     static member        ``+`` (x: _ IEnumerator             , y                            , [<Optional>]_mthd: Default3) = Enumerator.concat <| (seq {yield x; yield y}).GetEnumerator ()
-    #endif
     static member inline ``+`` (x: IDictionary<'K,'V>        , y: IDictionary<'K,'V>        , [<Optional>]_mthd: Default3) = Dict.unionWith Plus.Invoke x y
     static member inline ``+`` (x: IReadOnlyDictionary<'K,'V>, y: IReadOnlyDictionary<'K,'V>, [<Optional>]_mthd: Default3) = IReadOnlyDictionary.unionWith Plus.Invoke x y
 
@@ -172,11 +169,11 @@ type Sum with
                     Sum.Invoke (Seq.map (fun (_,_,x,_) -> x) x),
                     Sum.Invoke (Seq.map (fun (_,_,_,x) -> x) x)
 
-#if !FABLE_COMPILER
 type Sum with
     static member inline Sum (x: seq< 'a>, [<Optional>]_output: 'a           , _: Default2) = Seq.fold Plus.Invoke (Zero.Invoke ()) x : 'a
     
 type Sum with
     static member inline Sum (x: seq< ^R>, [<Optional>]_output: ^R           , _: Default1) = Sum.InvokeOnInstance x
     static member inline Sum (_: seq< ^R>, _: ^t when ^t: null and ^t: struct, _: Default1) = fun () -> id
+
 #endif

--- a/src/FSharpPlus/Control/Numeric.fs
+++ b/src/FSharpPlus/Control/Numeric.fs
@@ -8,6 +8,7 @@ open FSharpPlus.Internals
 open System.Runtime.CompilerServices
 open System.Runtime.InteropServices
 
+#if !FABLE_COMPILER
 
 type FromBigInt =
     inherit Default1
@@ -17,11 +18,9 @@ type FromBigInt =
     static member inline FromBigInt (_: ^R        , _: Default1  ) = fun (x: bigint) -> (^R : (static member FromBigInt : _ -> ^R) x)
     static member inline FromBigInt (_: Default1  , _: Default1  ) = fun (x: bigint) -> (^R : (static member FromBigInt : _ -> ^R) x)
     static member        FromBigInt (_: int32     , _: FromBigInt) = fun (x: bigint) -> int             x
-    #if !FABLE_COMPILER
     static member        FromBigInt (_: int64     , _: FromBigInt) = fun (x: bigint) -> int64           x
     static member        FromBigInt (_: nativeint , _: FromBigInt) = fun (x: bigint) -> nativeint  (int x)
     static member        FromBigInt (_: unativeint, _: FromBigInt) = fun (x: bigint) -> unativeint (int x)
-    #endif
     static member        FromBigInt (_: bigint    , _: FromBigInt) = fun (x: bigint) ->                 x
     static member        FromBigInt (_: float     , _: FromBigInt) = fun (x: bigint) -> float           x
     static member        FromBigInt (_: sbyte     , _: FromBigInt) = fun (x: bigint) -> sbyte           x
@@ -47,10 +46,8 @@ type FromInt64 =
     static member inline FromInt64 (_: Default1  , _: Default1 ) = fun (x: int64) -> (^R : (static member FromInt64 : _ -> ^R) x)
     static member        FromInt64 (_: int32     , _: FromInt64) = fun (x: int64) -> int32           x
     static member        FromInt64 (_: int64     , _: FromInt64) = fun (x: int64) ->                 x
-    #if !FABLE_COMPILER
     static member        FromInt64 (_: nativeint , _: FromInt64) = fun (x: int64) -> nativeint  (int x)
     static member        FromInt64 (_: unativeint, _: FromInt64) = fun (x: int64) -> unativeint (int x)
-    #endif
     static member        FromInt64 (_: bigint    , _: FromInt64) = fun (x: int64) -> bigint          x
     static member        FromInt64 (_: float     , _: FromInt64) = fun (x: int64) -> float           x
     static member        FromInt64 (_: float32   , _: FromInt64) = fun (x: int64) -> float32         x
@@ -77,10 +74,8 @@ type FromInt32 =
     static member inline FromInt32 (_: Default1  , _: Default1 ) = fun (x: int32) -> (^R : (static member FromInt32 : _ -> ^R) x)
     static member        FromInt32 (_: int32     , _: FromInt32) = fun (x: int32) ->                 x
     static member        FromInt32 (_: int64     , _: FromInt32) = fun (x: int32) -> int64           x
-    #if !FABLE_COMPILER
     static member        FromInt32 (_: nativeint , _: FromInt32) = fun (x: int32) -> nativeint  (int x)
     static member        FromInt32 (_: unativeint, _: FromInt32) = fun (x: int32) -> unativeint (int x)
-    #endif
     static member        FromInt32 (_: bigint    , _: FromInt32) = fun (x: int32) -> bigint          x
     static member        FromInt32 (_: float     , _: FromInt32) = fun (x: int32) -> float           x
     static member        FromInt32 (_: sbyte     , _: FromInt32) = fun (x: int32) -> sbyte           x
@@ -103,10 +98,8 @@ type FromInt32 =
 type One =
     inherit Default1
     static member inline One (_: 't, _: Default1) = FromInt32.Invoke 1            : 't
-    static member inline One (_: 't, _: One     ) = LanguagePrimitives.GenericOne : 't
-    #if !FABLE_COMPILER
+    static member inline One (_: 't, _: One     ) = LanguagePrimitives.GenericOne : 't    
     static member inline One (_: ^t when ^t: null and ^t: struct, _: One) = id
-    #endif
 
     static member inline Invoke () : 'Num =
         let inline call_2 (a: ^a, b: ^b) = ((^a or ^b) : (static member One : _*_ -> _) b, a)
@@ -123,13 +116,15 @@ open FSharpPlus.Internals.Prelude
 
 type Zero =
     inherit Default1
+
     static member inline Zero (_: 't                             , _: Default3) = (^t : (static member Empty : ^t) ()) : 't
-    #if !FABLE_COMPILER
+    
     static member inline Zero (_: 't                             , _: Default2) = FromInt32.Invoke 0             : 't
     static member inline Zero (_: ^t when ^t: null and ^t: struct, _: Default2) = id
+
     static member inline Zero (_: 't                             , _: Default1) = LanguagePrimitives.GenericZero : 't
     static member inline Zero (_: ^t when ^t: null and ^t: struct, _: Default1) = id
-    #endif
+
     static member        Zero (_: System.TimeSpan                , _: Zero    ) = System.TimeSpan ()
     static member        Zero (_: DmStruct                       , _: Zero    ) = Unchecked.defaultof<DmStruct>
     static member        Zero (_: list<'a>                       , _: Zero    ) = []   :   list<'a>
@@ -186,9 +181,7 @@ type Zero with
     static member        Zero (_: ResizeArray<'a>           , _: Zero) = ResizeArray () : ResizeArray<'a>
     static member        Zero (_: seq<'a>                   , _: Zero) = Seq.empty      : seq<'a>
     
-    #if !FABLE_COMPILER
     static member        Zero (_: IEnumerator<'a>           , _: Zero) = FSharpPlus.Enumerator.Empty () : IEnumerator<'a>
-    #endif
     
     static member        Zero (_: IDictionary<'a,'b>        , _: Zero) = Dictionary<'a,'b> () :> IDictionary<'a,'b>
     static member        Zero (_: IReadOnlyDictionary<'a,'b>, _: Zero) = Dictionary<'a,'b> () :> IReadOnlyDictionary<'a,'b>
@@ -226,16 +219,14 @@ type Signum =
         let zero = Zero.Invoke ()
         if x = zero then zero
         else x / Abs.Invoke x :'t
-    #if !FABLE_COMPILER
+    
     static member inline Signum (_: ^t when ^t: null and ^t: struct, _: Default1) = id
     static member inline Signum (x: 't                             , _: Default1) = FromInt32.Invoke (sign x) : 't
-    #endif
 
     static member inline Invoke (x: 'Num) : 'Num =
         let inline call_2 (a: ^a, b: ^b) = ((^a or ^b) : (static member Signum : _*_ -> _) b, a)
         call_2 (Unchecked.defaultof<Signum>, x)
 
-#if !FABLE_COMPILER
 type Signum' =
     inherit Signum
     static member        Signum (x: byte      , _: Signum') = if x = 0uy then 0uy else 1uy
@@ -279,7 +270,6 @@ type DivRem =
         let inline call_3 (a: ^a, b: ^b, c: ^c) = ((^a or ^b or ^c) : (static member DivRem : _*_*_ -> _) b, c, a)
         let inline call (a: 'a, b: 'b, c: 'c) = call_3 (a, b, c)
         call (Unchecked.defaultof<DivRem>, D, d)
-#endif
 
 
 
@@ -341,13 +331,11 @@ type Pi =
         call Unchecked.defaultof<Pi>
 
 type Subtract =
-    static member inline Subtract (x, y) = x - y
-    #if !FABLE_COMPILER
+    static member inline Subtract (x, y) = x - y    
     static member inline Subtract (x, y) =
             match (^Num : (static member TrySubtract : ^Num * ^Num -> Result<'Num, exn>) x, y) with
             | Ok x    -> x
             | Error e -> raise e
-    #endif
 
     static member        Subtract (x: byte      , y) = if y > x then raise Errors.exnNoSubtraction else (x-y) 
     static member        Subtract (x: uint16    , y) = if y > x then raise Errors.exnNoSubtraction else (x-y) 
@@ -378,12 +366,10 @@ type TrySubtract =
 
 type Divide =
     static member inline Divide (x, y) = let c = x / y in if c * y = x then c else raise Errors.exnNoDivision
-    #if !FABLE_COMPILER
     static member inline Divide (x, y) =
             match (^Num : (static member TryDivide : ^Num * ^Num -> Result< ^Num, exn>) (x, y)) with
             | Ok x    -> x
             | Error e -> raise e
-    #endif
     static member        Divide (x: float  , y) = (/) x y
     static member        Divide (x: float32, y) = (/) x y
     static member inline Invoke (x: 'Num) (y: 'Num) : 'Num =
@@ -415,14 +401,9 @@ type TrySqrtRem =
     static member TrySqrtRem (x: uint16    ) = let c = x |> float |> sqrt |> uint16     in Ok (c, x - c*c)
     static member TrySqrtRem (x: uint32    ) = let c = x |> float |> sqrt |> uint32     in Ok (c, x - c*c)
     static member TrySqrtRem (x: uint64    ) = let c = x |> float |> sqrt |> uint64     in Ok (c, x - c*c)
-    #if !FABLE_COMPILER
     static member TrySqrtRem (x: nativeint ) = let c = x |> float |> sqrt |> nativeint  in Ok (c, x - c*c)
-    #endif
     static member TrySqrtRem (x: byte      ) = let c = x |> float |> sqrt |> byte       in Ok (c, x - c*c)
-    #if !FABLE_COMPILER
     static member TrySqrtRem (x: unativeint) = let c = x |> float |> sqrt |> unativeint in c, x - c*c
-    #endif
-
 
     static member inline Invoke (x: 'Integral) : Result<'Integral*'Integral, exn> =
         let inline call_2 (_: ^a, b: ^b) = ((^a or ^b) : (static member TrySqrtRem : _ -> _) b)
@@ -434,7 +415,6 @@ type TrySqrt =
         let inline call_2 (_: ^a, b: ^b) = ((^a or ^b) : (static member TrySqrt : _ -> _) b)
         call_2 (Unchecked.defaultof<TrySqrt>, x)
 
-    #if !FABLE_COMPILER
     static member inline TrySqrt (x: 'T) = 
         try Ok (sqrt x)
         with e -> Error e
@@ -453,7 +433,6 @@ type TrySqrt =
             match TrySqrt.Invoke n, TrySqrt.Invoke d with
             | Ok n, Ok d -> Ok (toRational n / toRational d)
             | _          -> Error Errors.exnNoSqrt
-    #endif
 
     static member inline TrySqrt (x: float    ) = if x < 0.  then Error Errors.exnSqrtOfNegative else let c = sqrt x in Ok c //if Double.IsNaN c then Error exnNoSqrt else Ok c
     static member inline TrySqrt (x: float32  ) = if x < 0.f then Error Errors.exnSqrtOfNegative else let c = sqrt x in Ok c //if Single.IsNaN c then Error exnNoSqrt else Ok c
@@ -466,7 +445,6 @@ type Sqrt =
             | Ok x    -> x
             | Error e -> raise e
 
-    #if !FABLE_COMPILER
     static member inline Sqrt (x: 'T, _: Default1) = sqrt x
     static member inline Sqrt (x: 'Z, _: Default1) =
         if x < Zero.Invoke () then raise Errors.exnSqrtOfNegative
@@ -474,7 +452,6 @@ type Sqrt =
             match TrySqrtRem.Invoke x with
             | Ok (c, r) -> if r = Zero.Invoke () then c else raise Errors.exnNoSqrt
             | Error x   -> raise x
-    #endif
 
     static member inline Sqrt (x: float32, _:Sqrt) = sqrt x
     static member inline Sqrt (x: decimal, _:Sqrt) = x |> Decimal.trySqrt |> function Ok x -> x | Error e ->  raise e
@@ -520,9 +497,7 @@ type MinValue =
     static member        MinValue (_: decimal       , _: MinValue) = Decimal.MinValue
     static member        MinValue (_: DateTime      , _: MinValue) = DateTime.MinValue
     static member        MinValue (_: DateTimeOffset, _: MinValue) = DateTimeOffset.MinValue
-    #if !FABLE_COMPILER
     static member        MinValue (_: TimeSpan      , _: MinValue) = TimeSpan.MinValue
-    #endif
 
 
     static member inline Invoke () =
@@ -571,9 +546,7 @@ type MaxValue =
     static member        MaxValue (_: decimal       , _: MaxValue) = Decimal.MaxValue
     static member        MaxValue (_: DateTime      , _: MaxValue) = DateTime.MaxValue
     static member        MaxValue (_: DateTimeOffset, _: MaxValue) = DateTimeOffset.MaxValue
-    #if !FABLE_COMPILER
     static member        MaxValue (_: TimeSpan      , _: MaxValue) = TimeSpan.MaxValue
-    #endif
 
     static member inline Invoke () =
         let inline call_2 (a: ^a, b: ^b) = ((^a or ^b) : (static member MaxValue : _*_ -> _) b, a)
@@ -601,3 +574,5 @@ type MaxValue =
     static member inline MaxValue (_: 'a*'b*'c*'d*'e      , _: MaxValue) = (MaxValue.Invoke (), MaxValue.Invoke (), MaxValue.Invoke (), MaxValue.Invoke (), MaxValue.Invoke ())
     static member inline MaxValue (_: 'a*'b*'c*'d*'e*'f   , _: MaxValue) = (MaxValue.Invoke (), MaxValue.Invoke (), MaxValue.Invoke (), MaxValue.Invoke (), MaxValue.Invoke (), MaxValue.Invoke ())
     static member inline MaxValue (_: 'a*'b*'c*'d*'e*'f*'g, _: MaxValue) = (MaxValue.Invoke (), MaxValue.Invoke (), MaxValue.Invoke (), MaxValue.Invoke (), MaxValue.Invoke (), MaxValue.Invoke (), MaxValue.Invoke ())
+
+    #endif

--- a/src/FSharpPlus/Control/Tuple.fs
+++ b/src/FSharpPlus/Control/Tuple.fs
@@ -6,6 +6,7 @@ open System.Runtime.CompilerServices
 open System.Runtime.InteropServices
 open FSharpPlus.Internals
 
+#if !FABLE_COMPILER
 
 type Item1 = static member inline Invoke value = (^t : (member Item1 : _) value)
 type Item2 = static member inline Invoke value = (^t : (member Item2 : _) value)
@@ -26,9 +27,7 @@ type MapItem1 =
         let x1 = (^t : (member Item1: 't1) t)
         Tuple<_,_,_,_,_,_,_,_> (fn x1, x2, x3, x4, x5, x6, x7, xr)
 
-    #if !FABLE_COMPILER
     static member MapItem1 ( x: Tuple<_>         , fn) = Tuple<_> (fn x.Item1)
-    #endif
     static member MapItem1 ((a, b)               , fn) = (fn a, b)
     static member MapItem1 ((a, b, c)            , fn) = (fn a, b, c)
     static member MapItem1 ((a, b, c, d)         , fn) = (fn a, b, c, d)
@@ -147,10 +146,8 @@ type Curry =
         Curry.Invoke (fun tr ->
             let _f _ = Constraints.whenNestedTuple t : ('t1*'t2*'t3*'t4*'t5*'t6*'t7*'tr)
             f (Tuple<'t1,'t2,'t3,'t4,'t5,'t6,'t7,'tr> (t1, t2, t3, t4, t5, t6, t7, tr) |> retype))
-
-    #if !FABLE_COMPILER
+    
     static member Curry (_: Tuple<'t1>        , _: Curry) = fun f t1                   -> f (Tuple<_> t1)
-    #endif
     static member Curry ((_, _)               , _: Curry) = fun f t1 t2                -> f (t1, t2)
     static member Curry ((_, _, _)            , _: Curry) = fun f t1 t2 t3             -> f (t1, t2, t3)
     static member Curry ((_, _, _, _)         , _: Curry) = fun f t1 t2 t3 t4          -> f (t1, t2, t3, t4)
@@ -174,12 +171,12 @@ type Uncurry =
         let (t1: 't1) = (^t : (member Item1 : 't1) t)
         Uncurry.Invoke (f t1 t2 t3 t4 t5 t6 t7) tr
 
-    #if !FABLE_COMPILER
     static member Uncurry (x: Tuple<'t1>               , _: Uncurry) = fun f -> f x.Item1
-    #endif
     static member Uncurry ((t1, t2)                    , _: Uncurry) = fun f -> f t1 t2
     static member Uncurry ((t1, t2, t3)                , _: Uncurry) = fun f -> f t1 t2 t3
     static member Uncurry ((t1, t2, t3, t4)            , _: Uncurry) = fun f -> f t1 t2 t3 t4
     static member Uncurry ((t1, t2, t3, t4, t5)        , _: Uncurry) = fun f -> f t1 t2 t3 t4 t5
     static member Uncurry ((t1, t2, t3, t4, t5, t6)    , _: Uncurry) = fun f -> f t1 t2 t3 t4 t5 t6
     static member Uncurry ((t1, t2, t3, t4, t5, t6, t7), _: Uncurry) = fun f -> f t1 t2 t3 t4 t5 t6 t7
+
+#endif

--- a/src/FSharpPlus/Data/Cont.fs
+++ b/src/FSharpPlus/Data/Cont.fs
@@ -13,7 +13,7 @@ type Cont<'r,'t> = Cont of (('t->'r)->'r)
 [<RequireQualifiedAccess>]
 module Cont =
     let run (Cont x) = x : ('T->'R)->'R
-    
+
     /// (call-with-current-continuation) calls a function with the current continuation as its argument.
     let callCC (f: ('T->Cont<'R,'U>)->_) = Cont (fun k -> run (f (fun a -> Cont(fun _ -> k a))) k)
 
@@ -43,12 +43,10 @@ type Cont<'r,'t> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member CallCC (f: ('T -> Cont<'R,'U>) -> _) = Cont.callCC f : Cont<'R,'T>
 
-    static member inline Lift (m: '``Monad<'T>``) = Cont ((>>=) m) : ContT<'``Monad<'R>``,'T>    
+#if !FABLE_COMPILER
+    static member inline Lift (m: '``Monad<'T>``) = Cont ((>>=) m) : ContT<'``Monad<'R>``,'T>
 
-
-    #if !FABLE_COMPILER
     static member inline LiftAsync (x: Async<'T>) = lift (liftAsync x) : ContT<Async<'R>,'T>
-    #endif
     
     static member inline get_Ask () = lift ask             : '``ContT<'MonadReader<'R,'T>,'R>``
     static member inline Local (Cont m, f: 'R1 -> 'R2)     : ContT<_,'``MonadReader<R1,'T>,'U``> =
@@ -56,6 +54,8 @@ type Cont<'r,'t> with
     
     static member inline get_Get () = lift get          : '``ContT<'MonadState<'S, 'T>, 'S>``
     static member inline Put (x: 'S) = x |> put |> lift : '``ContT<'MonadState<'S, 'T>, unit>``
+
+#endif
 
 /// Basic operations on ContT
 module ContT =

--- a/src/FSharpPlus/Data/Coproduct.fs
+++ b/src/FSharpPlus/Data/Coproduct.fs
@@ -1,5 +1,7 @@
 ﻿namespace FSharpPlus.Data
 
+#if !FABLE_COMPILER
+
 open FSharpPlus
 open FSharpPlus.Control
 
@@ -35,3 +37,5 @@ type Coproduct<'``functorL<'t>``,'``functorR<'t>``> with
         let (l, r, isL) =  a.getContents ()
         if isL then InL (Map.InvokeOnInstance f l)
         else        InR (Map.InvokeOnInstance f r)
+
+#endif

--- a/src/FSharpPlus/Data/Error.fs
+++ b/src/FSharpPlus/Data/Error.fs
@@ -30,6 +30,8 @@ module ResultOrException =
     let Exception : Result<_,exn>   -> _ = function Error e -> e | _ -> exn ()
 
 
+#if !FABLE_COMPILER
+
 /// Monad Transformer for Result<'T, 'E>
 [<Struct>]
 type ResultT<'``monad<'result<'t,'e>>``> = ResultT of '``monad<'result<'t,'e>>``
@@ -39,8 +41,6 @@ type ResultT<'``monad<'result<'t,'e>>``> = ResultT of '``monad<'result<'t,'e>>``
 module ResultT =
     let run (ResultT x) = x : '``Monad<'Result<'T,'E>>``
 
-    #if !FABLE_COMPILER
-
     /// Embed a Monad<'T> into a ChoiceT<'Monad<Choice<'T,'Error>>>
     let inline lift (x: '``Monad<'T>``) : ResultT<'``Monad<Result<'T,'Error>>``> =
         if opaqueId false then x |> liftM Ok |> ResultT
@@ -49,37 +49,31 @@ module ResultT =
     /// Transform a Result<'T,'Error> to a ResultT<'Monad<Result<'T,'Error>>>
     let inline hoist (x: Result<'T,'TError>) = ResultT (result x) : ResultT<'``Monad<Result<'T,'TError>>``>
 
-    let inline bind (f: 'T->ResultT<'``Monad<'Result<'U,'E>>``>) (ResultT m: ResultT<'``Monad<'Result<'T,'E>>``>) = (ResultT (m >>= (fun a -> match a with Error l -> result (Error l) | Ok r -> run (f r))))
-    #endif
+    let inline bind (f: 'T->ResultT<'``Monad<'Result<'U,'E>>``>) (ResultT m: ResultT<'``Monad<'Result<'T,'E>>``>) = (ResultT (m >>= (fun a -> match a with Error l -> result (Error l) | Ok r -> run (f r))))    
 
     let inline apply (ResultT f:ResultT<'``Monad<'Result<('T -> 'U),'E>>``>) (ResultT x: ResultT<'``Monad<'Result<'T,'E>>``>) = ResultT (map Result.apply f <*> x) : ResultT<'``Monad<'Result<'U,'E>>``>
     let inline map (f: 'T->'U) (ResultT m: ResultT<'``Monad<'Result<'T,'E>>``>) = ResultT (map (Result.map f) m) : ResultT<'``Monad<'Result<('T -> 'U),'E>>``>
 
 type ResultT<'``monad<'result<'t,'e>>``> with
-    #if !FABLE_COMPILER
+    
     static member inline Return (x: 'T) = ResultT (result (Ok x))                                                                           : ResultT<'``Monad<'Result<'T,'E>>``>
-    #endif
     
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Map   (x: ResultT<'``Monad<'Result<'T,'E>>``>, f: 'T->'U) = ResultT.map f x                                        : ResultT<'``Monad<'Result<'U,'E>>``>
 
-    static member inline (<*>) (f: ResultT<'``Monad<'Result<('T -> 'U),'E>>``>, x: ResultT<'``Monad<'Result<'T,'E>>``>) = ResultT.apply f x : ResultT<'``Monad<'Result<'U,'E>>``>
-    #if !FABLE_COMPILER
+    static member inline (<*>) (f: ResultT<'``Monad<'Result<('T -> 'U),'E>>``>, x: ResultT<'``Monad<'Result<'T,'E>>``>) = ResultT.apply f x : ResultT<'``Monad<'Result<'U,'E>>``>    
     static member inline (>>=) (x: ResultT<'``Monad<'Result<'T,'E>>``>, f: 'T->ResultT<'``Monad<'Result<'U,'E>>``>)     = ResultT.bind  f x
-    #endif
 
     static member inline TryWith (source: ResultT<'``Monad<'Result<'T,'E>>``>, f: exn -> ResultT<'``Monad<'Result<'T,'E>>``>) = ResultT (TryWith.Invoke (ResultT.run source) (ResultT.run << f))
     static member inline TryFinally (computation: ResultT<'``Monad<'Result<'T,'E>>``>, f) = ResultT (TryFinally.Invoke     (ResultT.run computation) f)
     static member inline Using (resource, f: _ -> ResultT<'``Monad<'Result<'T,'E>>``>)    = ResultT (Using.Invoke resource (ResultT.run << f))
     static member inline Delay (body : unit   ->  ResultT<'``Monad<'Result<'T,'E>>``>)    = ResultT (Delay.Invoke (fun _ -> ResultT.run (body ())))
 
-    #if !FABLE_COMPILER
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Lift (x: '``Monad<'T>``) : ResultT<'``Monad<Result<'T,'E>>``> = ResultT.lift x
 
     static member inline Throw (x: 'E) = x |> Error |> result |> ResultT : ResultT<'``Monad<Result<'T,'E>>``>
-    static member inline Catch (ResultT x: ResultT<'``MonadError<'E1,'T>``>, f: 'E1 -> _) = (ResultT (x >>= (fun a -> match a with Error l -> ResultT.run (f l) | Ok r -> result (Ok r)))) : ResultT<'``Monad<Result<'T,'E2>>``>
-    #endif
+    static member inline Catch (ResultT x: ResultT<'``MonadError<'E1,'T>``>, f: 'E1 -> _) = (ResultT (x >>= (fun a -> match a with Error l -> ResultT.run (f l) | Ok r -> result (Ok r)))) : ResultT<'``Monad<Result<'T,'E2>>``>    
 
     static member inline LiftAsync (x: Async<'T>) = ResultT.lift (liftAsync x) : ResultT<'``MonadAsync<'T>``>
 
@@ -89,13 +83,12 @@ type ResultT<'``monad<'result<'t,'e>>``> with
     static member inline Local (ResultT m : ResultT<'``MonadReader<'R2,Result<'R2,'E>>``>, f: 'R1->'R2) = ResultT (local f m)
 
     static member inline Tell (w: 'Monoid) = w |> tell |> ResultT.lift : ResultT<'``Writer<'Monoid,Result<unit,'E>>``>
-    #if !FABLE_COMPILER
+    
     static member inline Listen m : ResultT<'``MonadWriter<'Monoid,Result<'T*'Monoid,'E>>``> =
         let liftError (m, w) = Result.map (fun x -> (x, w)) m
         ResultT (listen (ResultT.run m) >>= (result << liftError))
 
     static member inline Pass m = ResultT (ResultT.run m >>= either (map Ok << pass << result) (result << Error)) : ResultT<'``MonadWriter<'Monoid,Result<'T,'E>>``>
-    #endif
 
     static member inline get_Get ()  = ResultT.lift get         : ResultT<'``MonadState<'S,Result<_,'E>>``>
     static member inline Put (x: 'S) = x |> put |> ResultT.lift : ResultT<'``MonadState<'S,Result<_,'E>>``>
@@ -109,8 +102,6 @@ type ChoiceT<'``monad<'choice<'t,'e>>``> = ChoiceT of '``monad<'choice<'t,'e>>``
 module ChoiceT =
     let run (ChoiceT x) = x : '``Monad<'Choice<'T,'E>>``
 
-    #if !FABLE_COMPILER
-
     /// Embed a Monad<'T> into a ChoiceT<'Monad<Choice<'T,'Error>>>
     let inline lift (x: '``Monad<'T>``) : ChoiceT<'``Monad<Choice<'T,'Error>>``> =
         if opaqueId false then x |> liftM Choice1Of2 |> ChoiceT
@@ -121,29 +112,24 @@ module ChoiceT =
 
     let inline bind (f: 'T->ChoiceT<'``Monad<'ChoiceT<'U,'E>>``>) (ChoiceT m: ChoiceT<'``Monad<'Choice<'T,'E>>``>) = (ChoiceT (m >>= (fun a -> match a with Choice2Of2 l -> result (Choice2Of2 l) | Choice1Of2 r -> run (f r))))
 
-    #endif
-
     let inline apply (ChoiceT f: ChoiceT<'``Monad<'Choice<('T -> 'U),'E>>``>) (ChoiceT x: ChoiceT<'``Monad<'Choice<'T,'E>>``>) = ChoiceT (map Choice.apply f <*> x) : ChoiceT<'``Monad<'Choice<'U,'E>>``>
     let inline map  (f: 'T->'U) (ChoiceT m: ChoiceT<'``Monad<'Choice<'T,'E>>``>) = ChoiceT (map (Choice.map f) m) : ChoiceT<'``Monad<'Choice<('T -> 'U),'E>>``>
 
 type ChoiceT<'``monad<'choice<'t,'e>>``> with
-    #if !FABLE_COMPILER
+    
     static member inline Return (x: 'T) = ChoiceT (result (Choice1Of2 x))                                                                   : ChoiceT<'``Monad<'Choice<'T,'E>>``>
-    #endif
 
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Map   (x: ChoiceT<'``Monad<'Choice<'T,'E>>``>, f: 'T->'U) = ChoiceT.map f x                                        : ChoiceT<'``Monad<'Choice<'U,'E>>``>
 
     static member inline (<*>) (f: ChoiceT<'``Monad<'Choice<('T -> 'U),'E>>``>, x: ChoiceT<'``Monad<'Choice<'T,'E>>``>) = ChoiceT.apply f x : ChoiceT<'``Monad<'Choice<'U,'E>>``>
-    #if !FABLE_COMPILER
     static member inline (>>=) (x: ChoiceT<'``Monad<'Choice<'T,'E>>``>, f: 'T->ChoiceT<'``Monad<'Choice<'U,'E>>``>)     = ChoiceT.bind f x
 
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Lift (x: '``Monad<'T>``) : ChoiceT<'``Monad<Choice<'T,'E>>``> = ChoiceT.lift x
 
     static member inline Throw (x: 'E) = x |> Choice2Of2 |> result |> ChoiceT : ChoiceT<'``Monad<Choice<'T,'E>>``>
-    static member inline Catch (ChoiceT x: ChoiceT<'``MonadError<'E1,'T>``>, f: 'E1 -> _) = (ChoiceT (x >>= (fun a -> match a with Choice2Of2 l -> ChoiceT.run (f l) | Choice1Of2 r -> result (Choice1Of2 r)))) : ChoiceT<'``Monad<Choice<'T,'E2>>``>
-    #endif
+    static member inline Catch (ChoiceT x: ChoiceT<'``MonadError<'E1,'T>``>, f: 'E1 -> _) = (ChoiceT (x >>= (fun a -> match a with Choice2Of2 l -> ChoiceT.run (f l) | Choice1Of2 r -> result (Choice1Of2 r)))) : ChoiceT<'``Monad<Choice<'T,'E2>>``>    
 
     static member inline LiftAsync (x: Async<'T>) = ChoiceT.lift (liftAsync x) : ChoiceT<'``MonadAsync<'T>``>
 
@@ -153,13 +139,14 @@ type ChoiceT<'``monad<'choice<'t,'e>>``> with
     static member inline Local (ChoiceT m: ChoiceT<'``MonadReader<'R2,Choice<'R2,'E>>``>, f: 'R1->'R2) = ChoiceT (local f m)
 
     static member inline Tell (w: 'Monoid) = w |> tell |> ChoiceT.lift : ChoiceT<'``Writer<'Monoid,Choice<unit,'E>>``>
-    #if !FABLE_COMPILER
+    
     static member inline Listen m : ChoiceT<'``MonadWriter<'Monoid,Choice<'T*'Monoid,'E>>``> =
         let liftError (m, w) = Choice.map (fun x -> (x, w)) m
         ChoiceT (listen (ChoiceT.run m) >>= (result << liftError))
 
-    static member inline Pass m = ChoiceT (ChoiceT.run m >>= either (map Choice1Of2 << pass << result) (result << Error)) : ChoiceT<'``MonadWriter<'Monoid,Choice<'T,'E>>``>
-    #endif
+    static member inline Pass m = ChoiceT (ChoiceT.run m >>= either (map Choice1Of2 << pass << result) (result << Error)) : ChoiceT<'``MonadWriter<'Monoid,Choice<'T,'E>>``>    
 
     static member inline get_Get ()  = ChoiceT.lift get         : ChoiceT<'``MonadState<'S,Choice<_,'E>>``>
     static member inline Put (x: 'S) = x |> put |> ChoiceT.lift : ChoiceT<'``MonadState<'S,Choice<_,'E>>``>
+
+#endif

--- a/src/FSharpPlus/Data/Free.fs
+++ b/src/FSharpPlus/Data/Free.fs
@@ -1,4 +1,7 @@
 namespace FSharpPlus.Data
+
+#if !FABLE_COMPILER
+
 open System.ComponentModel
 
 open FSharpPlus
@@ -81,3 +84,5 @@ type Free<'``functor<'t>``,'t> with
     static member inline (>>=) (x: Free<'``Functor<'T>``,'T>, f: 'T -> Free<'``Functor<'U>``,'U>)   = Free.bind  f x : Free<'``Functor<'U>``,'U>
     static member inline (<*>) (f: Free<'``Functor<'T->'U>``,'T->'U>, x: Free<'``Functor<'T>``,'T>) = Free.apply f x : Free<'``Functor<'U>``,'U>
     static member        Delay (x: unit -> Free<'``Functor<'T>``,'T>) = x ()
+
+#endif

--- a/src/FSharpPlus/Data/Free.fs
+++ b/src/FSharpPlus/Data/Free.fs
@@ -1,6 +1,6 @@
 namespace FSharpPlus.Data
 
-#if !FABLE_COMPILER
+
 
 open System.ComponentModel
 
@@ -85,4 +85,3 @@ type Free<'``functor<'t>``,'t> with
     static member inline (<*>) (f: Free<'``Functor<'T->'U>``,'T->'U>, x: Free<'``Functor<'T>``,'T>) = Free.apply f x : Free<'``Functor<'U>``,'U>
     static member        Delay (x: unit -> Free<'``Functor<'T>``,'T>) = x ()
 
-#endif

--- a/src/FSharpPlus/Data/Free.fs
+++ b/src/FSharpPlus/Data/Free.fs
@@ -1,6 +1,6 @@
 namespace FSharpPlus.Data
 
-
+#if !FABLE_COMPILER
 
 open System.ComponentModel
 
@@ -85,3 +85,4 @@ type Free<'``functor<'t>``,'t> with
     static member inline (<*>) (f: Free<'``Functor<'T->'U>``,'T->'U>, x: Free<'``Functor<'T>``,'T>) = Free.apply f x : Free<'``Functor<'U>``,'U>
     static member        Delay (x: unit -> Free<'``Functor<'T>``,'T>) = x ()
 
+#endif

--- a/src/FSharpPlus/Data/Kleisli.fs
+++ b/src/FSharpPlus/Data/Kleisli.fs
@@ -1,5 +1,7 @@
 ﻿namespace FSharpPlus.Data
 
+#if !FABLE_COMPILER
+
 open FSharpPlus
 open FSharpPlus.Control
 
@@ -12,24 +14,19 @@ type Kleisli<'t, '``monad<'u>``> = Kleisli of ('t -> '``monad<'u>``) with
     static member        Contramap (Kleisli f : Kleisli<'B,'``Monad<'C>``>, k: 'A->'B) = Kleisli (k >> f)      : Kleisli<'A,'``Monad<'C>``>
     static member inline Map (Kleisli f : Kleisli<'B,'``Monad<'C>``>, cd: 'C->'D     ) = Kleisli (map cd << f) : Kleisli<'B,'``Monad<'D>``>
     
-    #if !FABLE_COMPILER
+    
     // Category
     static member inline get_Id () = Kleisli result : Kleisli<'a,'b>
-    #endif
     static member inline (<<<) (Kleisli f, Kleisli g) = Kleisli (g >=> f)
 
-    #if !FABLE_COMPILER
     // Arrow
     static member inline Arr f = Kleisli ((<<) result f)
     static member inline First  (Kleisli f) = Kleisli (fun (b, d) -> f b >>= fun c -> result (c, d))
     static member inline Second (Kleisli f) = Kleisli (fun (d, b) -> f b >>= fun c -> result (d, c))
-    #endif
     static member inline (|||) (Kleisli f, Kleisli g) = Kleisli (Choice.either g f)
 
-    #if !FABLE_COMPILER
     static member inline (+++) (Kleisli (f: 'T->'u), Kleisli (g: 'v->'w)) =
         Fanin.InvokeOnInstance (Kleisli (f >=> ((<<) result Choice2Of2))) (Kleisli (g >=> ((<<) result Choice1Of2))) : Kleisli<Choice<'v,'T>,'z>
-    #endif
 
     static member inline Left  (Kleisli f) = AcMerge.Invoke (Kleisli f) (Arr.Invoke (Id.Invoke ()))
     static member inline Right (Kleisli f) =
@@ -43,3 +40,5 @@ type Kleisli<'t, '``monad<'u>``> = Kleisli of ('t -> '``monad<'u>``) with
 
 /// Basic operations on Kleisli
 [<RequireQualifiedAccess>]module Kleisli = let run (Kleisli f) = f
+
+#endif

--- a/src/FSharpPlus/Data/List.fs
+++ b/src/FSharpPlus/Data/List.fs
@@ -28,7 +28,6 @@ module List =
         loopM xs
 
     let inline replicateM count (initial: '``Applicative<'T>``)  = sequence (List.replicate count initial)
-#endif
 
 
 open FSharpPlus.Control
@@ -42,7 +41,6 @@ type ListT<'``monad<list<'t>>``> = ListT of '``monad<list<'t>>``
 module ListT =
     let run (ListT m) = m : '``Monad<list<'T>>``
 
-    #if !FABLE_COMPILER
     /// Embed a Monad<'T> into a ListT<'Monad<list<'T>>>
     let inline lift (x: '``Monad<'T>``) : ListT<'``Monad<list<'T>>``> =
         if opaqueId false then x |> liftM List.singleton |> ListT
@@ -57,10 +55,9 @@ module ListT =
     let inline bind (f: 'T-> ListT<'``Monad<list<'U>``>) (ListT m: ListT<'``Monad<list<'T>``>) = (ListT (m >>= mapM (run << f) >>= ((List.concat: list<_>->_) >> result)))
     let inline apply (ListT f: ListT<'``Monad<list<('T -> 'U)>``>) (ListT x: ListT<'``Monad<list<'T>``>) = ListT (map List.apply f <*> x) : ListT<'``Monad<list<'U>``>
     let inline map  (f: 'T->'U) (ListT m: ListT<'``Monad<list<'T>``>) =  ListT (map (List.map f) m) : ListT<'``Monad<list<'U>``>
-    #endif
 
 type ListT<'``monad<list<'t>>``> with
-    #if !FABLE_COMPILER
+
     static member inline Return (x: 'T) = [x] |> result |> ListT                                                      : ListT<'``Monad<seq<'T>``>
 
     [<EditorBrowsable(EditorBrowsableState.Never)>]
@@ -71,24 +68,20 @@ type ListT<'``monad<list<'t>>``> with
 
     static member inline get_Empty () = ListT <| result [] : ListT<'``MonadPlus<list<'T>``>
     static member inline (<|>) (ListT x, ListT y) = ListT (x >>= (fun a -> y >>= (fun b -> result (a @ b)))) : ListT<'``MonadPlus<list<'T>``>
-    #endif
 
     static member inline TryWith (source: ListT<'``Monad<list<'T>>``>, f: exn -> ListT<'``Monad<list<'T>>``>) = ListT (TryWith.Invoke (ListT.run source) (ListT.run << f))
     static member inline TryFinally (computation: ListT<'``Monad<list<'T>>``>, f) = ListT (TryFinally.Invoke     (ListT.run computation) f)
     static member inline Using (resource, f: _ -> ListT<'``Monad<list<'T>>``>)    = ListT (Using.Invoke resource (ListT.run << f))
     static member inline Delay (body : unit   ->  ListT<'``Monad<list<'T>>``>)    = ListT (Delay.Invoke (fun _ -> ListT.run (body ()))) : ListT<'``Monad<list<'T>>``>
 
-    #if !FABLE_COMPILER
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Lift (x: '``Monad<'T>``) : ListT<'``Monad<list<'T>>``> = ListT.lift x
     
     static member inline LiftAsync (x: Async<'T>) = ListT.lift (liftAsync x) : ListT<'``MonadAsync<'T>``>
     
     static member inline Throw (x: 'E) = x |> throw |> ListT.lift
-    #endif
     static member inline Catch (m: ListT<'``MonadError<'E1,'T>``>, h: 'E1 -> ListT<'``MonadError<'E2,'T>``>) = ListT ((fun v h -> Catch.Invoke v h) (ListT.run m) (ListT.run << h)) : ListT<'``MonadError<'E2,'T>``>
     
-    #if !FABLE_COMPILER
     static member inline CallCC (f: (('T -> ListT<'``MonadCont<'R,list<'U>>``>) -> _)) = ListT (callCC <| fun c -> ListT.run (f (ListT << c << List.singleton))) : ListT<'``MonadCont<'R, list<'T>>``>
     
     static member inline get_Get ()  = ListT.lift get         : ListT<'``MonadState<'S,'S>``>
@@ -96,4 +89,5 @@ type ListT<'``monad<list<'t>>``> with
     
     static member inline get_Ask () = ListT.lift ask          : ListT<'``MonadReader<'R,  list<'R>>``>
     static member inline Local (ListT (m: '``MonadReader<'R2,'T>``), f: 'R1->'R2) = ListT (local f m)
-    #endif
+
+#endif

--- a/src/FSharpPlus/Data/Monoids.fs
+++ b/src/FSharpPlus/Data/Monoids.fs
@@ -1,5 +1,7 @@
 ﻿namespace FSharpPlus.Data
 
+#if !FABLE_COMPILER
+
 open FSharpPlus.Operators
 
 /// The dual of a monoid, obtained by swapping the arguments of append.
@@ -11,6 +13,8 @@ type Dual<'t> = Dual of 't with
 /// Basic operations on Dual
 [<RequireQualifiedAccess>]
 module Dual = let run (Dual x) = x : 'T
+
+#endif
 
 /// The monoid of endomorphisms under composition.
 [<Struct; NoEquality; NoComparison>]
@@ -35,6 +39,8 @@ type Any = Any of bool with
     static member Zero = Any false
     static member (+) (Any x, Any y) = Any (x || y)
 
+
+#if !FABLE_COMPILER
 
 /// <summary> The Const functor, defined as Const&lt;&#39;T, &#39;U&gt; where &#39;U is a phantom type. Useful for: Lens getters Its applicative instance plays a fundamental role in Lens.
 /// <para/>   Useful for: Lens getters.
@@ -70,6 +76,7 @@ type Const<'t,'u> = Const of 't with
 module Const =
     let run (Const t) = t
 
+#endif
 
 /// Option<'T> monoid returning the leftmost non-None value.
 [<Struct>]
@@ -86,12 +93,12 @@ type Last<'t> = Last of Option<'t> with
     static member run (Last a) = a                                            : 't option
 
 
+#if !FABLE_COMPILER
+
 /// Numeric wrapper for multiplication monoid (*, 1)
 [<Struct>]
-type Mult<'a> = Mult of 'a with
-    #if !FABLE_COMPILER
+type Mult<'a> = Mult of 'a with    
     static member inline get_Zero () = Mult one
-    #endif
     static member inline (+) (Mult (x: 'n), Mult (y: 'n)) = Mult (x * y)
 
 
@@ -102,10 +109,8 @@ type Compose<'``functorF<'functorG<'t>>``> = Compose of '``functorF<'functorG<'t
     // Functor
     static member inline Map (Compose (x: '``FunctorF<'FunctorG<'T>>``), f: 'T->'U) = Compose (map (map f: '``FunctorG<'T>`` -> '``FunctorG<'U>``) x : '``FunctorF<'FunctorG<'U>>``)
 
-    #if !FABLE_COMPILER
     // Applicative
     static member inline Return (x: 'T) = Compose (result (result x: '``ApplicativeG<'T>``)) : Compose<'``ApplicativeF<'ApplicativeG<'T>``>
-    #endif
     static member inline (<*>) (Compose (f: '``ApplicativeF<'ApplicativeG<'T->'U>``), Compose (x: '``ApplicativeF<'ApplicativeG<'T>``)) =
         Compose ((((<*>) : '``ApplicativeG<'T->'U>`` -> '``ApplicativeG<'T>`` -> '``ApplicativeG<'U>``) <!> f: '``ApplicativeF<'ApplicativeG<'T>->'ApplicativeG<'U>`` ) <*> x: '``ApplicativeF<'ApplicativeG<'U>``)
 
@@ -118,3 +123,5 @@ type Compose<'``functorF<'functorG<'t>>``> = Compose of '``functorF<'functorG<'t
 [<RequireQualifiedAccess>]
 module Compose =
     let run (Compose t) = t
+
+#endif

--- a/src/FSharpPlus/Data/Option.fs
+++ b/src/FSharpPlus/Data/Option.fs
@@ -6,11 +6,11 @@ open System.ComponentModel
 open FSharpPlus.Internals.Prelude
 
 #if !FABLE_COMPILER
+
 /// Additional operations on Option
 [<RequireQualifiedAccess>]
 module Option =
-    let inline traverse f = function Some x -> Map.Invoke Some (f x) | _ -> result None   
-#endif
+    let inline traverse f = function Some x -> Map.Invoke Some (f x) | _ -> result None
 
 /// Monad Transformer for Option<'T>
 [<Struct>]
@@ -20,8 +20,6 @@ type OptionT<'``monad<option<'t>>``> = OptionT of '``monad<option<'t>>``
 [<RequireQualifiedAccess>]
 module OptionT =
     let run   (OptionT m) = m : '``Monad<option<'T>>``
-
-    #if !FABLE_COMPILER
 
     /// Embed a Monad<'T> into an OptionT<'Monad<option<'T>>>
     let inline lift (x: '``Monad<'T>``) : OptionT<'``Monad<option<'T>>``> =
@@ -34,10 +32,9 @@ module OptionT =
     let inline bind (f: 'T-> OptionT<'``Monad<option<'U>``>) (OptionT m: OptionT<'``Monad<option<'T>``>)             = (OptionT <| (m  >>= (fun maybe_value -> match maybe_value with Some value -> run (f value) | _ -> result None)))
     let inline apply (OptionT f: OptionT<'``Monad<option<('T -> 'U)>``>) (OptionT x: OptionT<'``Monad<option<'T>``>) = OptionT (map Option.apply f <*> x) : OptionT<'``Monad<option<'U>``>
     let inline map  (f: 'T->'U) (OptionT m: OptionT<'``Monad<option<'T>``>)                                          = OptionT (map (Option.map f) m) : OptionT<'``Monad<option<'U>``>
-    #endif
 
 type OptionT<'``monad<option<'t>>``> with
-    #if !FABLE_COMPILER
+    
     static member inline Return (x: 'T) = Some x |> result |> OptionT                                                        : OptionT<'``Monad<seq<'T>``>
 
     [<EditorBrowsable(EditorBrowsableState.Never)>]
@@ -47,18 +44,15 @@ type OptionT<'``monad<option<'t>>``> with
     static member inline (>>=)  (x: OptionT<'``Monad<seq<'T>``>, f: 'T -> OptionT<'``Monad<seq<'U>``>)   = OptionT.bind  f x
 
     static member inline get_Empty () = OptionT <| result None : OptionT<'``MonadPlus<option<'T>``>
-    static member inline (<|>) (OptionT x, OptionT y) = OptionT <| (x  >>= (fun maybe_value -> match maybe_value with Some value -> result (Some value) | _ -> y)) : OptionT<'``MonadPlus<option<'T>``>
-    #endif
+    static member inline (<|>) (OptionT x, OptionT y) = OptionT <| (x  >>= (fun maybe_value -> match maybe_value with Some value -> result (Some value) | _ -> y)) : OptionT<'``MonadPlus<option<'T>``>    
 
     static member inline TryWith (source: OptionT<'``Monad<option<'T>>``>, f: exn -> OptionT<'``Monad<option<'T>>``>) = OptionT (TryWith.Invoke (OptionT.run source) (OptionT.run << f))
     static member inline TryFinally (computation: OptionT<'``Monad<option<'T>>``>, f) = OptionT (TryFinally.Invoke     (OptionT.run computation) f)
     static member inline Using (resource, f: _ -> OptionT<'``Monad<option<'T>>``>)    = OptionT (Using.Invoke resource (OptionT.run << f))
     static member inline Delay (body : unit   ->  OptionT<'``Monad<option<'T>>``>)    = OptionT (Delay.Invoke (fun _ -> OptionT.run (body ()))) : OptionT<'``Monad<option<'T>>``>
 
-    #if !FABLE_COMPILER
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Lift (x: '``Monad<'T>``) : OptionT<'``Monad<option<'T>>``> = OptionT.lift x
-    #endif
 
     static member inline LiftAsync (x : Async<'T>) = OptionT.lift (liftAsync x) : OptionT<'``MonadAsync<'T>``>
 
@@ -74,10 +68,11 @@ type OptionT<'``monad<option<'t>>``> with
     static member inline Local (OptionT (m: '``MonadReader<'R2,'T>``), f: 'R1->'R2) = OptionT (local f m)
 
     static member inline Tell (w: 'Monoid) = w |> tell |> OptionT.lift : OptionT<'``MonadWriter<'Monoid, unit>``>
-    #if !FABLE_COMPILER
+
     static member inline Listen m                              : OptionT<'``'MonadWriter<'Monoid, option<'T>>``> =
         let liftMaybe (m, w) = Option.map (fun x -> (x, w)) m
         OptionT (listen (OptionT.run m) >>= (result << liftMaybe))
 
     static member inline Pass m : OptionT<'``MonadWriter<'Monoid, option<'T>>``> = OptionT (OptionT.run m >>= option (map Some << pass << result) (result None))
-    #endif
+
+#endif

--- a/src/FSharpPlus/Data/ParallelArray.fs
+++ b/src/FSharpPlus/Data/ParallelArray.fs
@@ -49,8 +49,6 @@ type ParallelArray<'t> with
     static member Return (x: 'a) = Infinite x
     #if !FABLE_COMPILER
     static member (<*>) (f: parray<'a->'b>, x: parray<_>) = ParallelArray.ap f x : parray<'b>
-    #endif
     static member inline get_Zero () = Bounded (getZero ()) : parray<'m>
-    #if !FABLE_COMPILER
     static member inline (+) (x: parray<'m>, y: parray<'m>) = lift2 plus x y : parray<'m>
     #endif

--- a/src/FSharpPlus/Data/State.fs
+++ b/src/FSharpPlus/Data/State.fs
@@ -14,6 +14,7 @@ type State<'s,'t> = State of ('s->('t * 's))
 [<RequireQualifiedAccess>]
 module State =
     let run (State x) = x                                                                                         : 'S->('T * 'S)
+
     let map   f (State m) = State (fun s -> let (a: 'T, s') = m s in (f a, s'))                                   : State<'S,'U>
     let bind  f (State m) = State (fun s -> let (a: 'T, s') = m s in run (f a) s')                                : State<'S,'U>
     let apply (State f) (State x) = State (fun s -> let (f', s1) = f s in let (x': 'T, s2) = x s1 in (f' x', s2)) : State<'S,'U>
@@ -33,8 +34,10 @@ module State =
     /// Modify the state inside the monad by applying a function.
     let modify f = State (fun s -> ((), f s))                                                                     : State<'S,unit>
 
+    #if !FABLE_COMPILER
     /// Zips two States into one.
     let zip (x: State<'S,'T>) (y: State<'S,'U>) = lift2 tuple2 x y : State<'S, ('T * 'U)>
+    #endif
 
 type State<'s,'t> with
 
@@ -49,14 +52,18 @@ type State<'s,'t> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Put x     = State.put x                      : State<'S,unit>
 
+    #if !FABLE_COMPILER
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Zip (x, y) = State.zip x y
+    #endif
 
     static member TryWith (State computation, h)    = State (fun s -> try computation s with e -> (h e) s) : State<'S,'T>
     static member TryFinally (State computation, f) = State (fun s -> try computation s finally f ()) : State<'S,'T>
     static member Using (resource, f: _ -> State<'S,'T>) = State.TryFinally (f resource, fun () -> dispose resource)
     static member Delay (body: unit->State<'S,'T>)  = State (fun s -> State.run (body ()) s) : State<'S,'T>
 
+
+#if !FABLE_COMPILER
 
 open FSharpPlus.Control
 open FSharpPlus.Internals.Prelude
@@ -70,8 +77,6 @@ type StateT<'s,'``monad<'t * 's>``> = StateT of ('s -> '``monad<'t * 's>``)
 module StateT =
     let run (StateT x) = x : 'S -> '``Monad<'T * 'S>``
 
-    #if !FABLE_COMPILER
-
     /// Embed a Monad<'T> into a StateT<'S,'``Monad<'T * 'S>``>
     let inline lift (m: '``Monad<'T>``) : StateT<'S,'``Monad<'T * 'S>``> =
         if opaqueId false then StateT <| fun s -> (m |> liftM (fun a -> (a, s)))
@@ -80,10 +85,7 @@ module StateT =
     /// Transform a State<'S, 'T> to a StateT<'S, '``Monad<'T * 'S>``>
     let inline hoist (x: State<'S, 'T>) = (StateT << (fun a -> result << a) << State.run) x : StateT<'S, '``Monad<'T * 'S>``>
 
-    #endif
-
     let inline map (f: 'T->'U) (StateT (m :_->'``Monad<'T * 'S>``)) = StateT (m >> Map.Invoke (fun (a, s') -> (f a, s'))) : StateT<'S,'``Monad<'U * 'S>``>
-
     let inline apply (StateT f: StateT<'S,'``Monad<('T -> 'U) * 'S>``>) (StateT a: StateT<'S,'``Monad<'T * 'S>``>) = StateT (fun s -> f s >>= fun (g, t) -> Map.Invoke (fun (z: 'T, u: 'S) -> ((g z: 'U), u)) (a t)) : StateT<'S,'``Monad<'U * 'S>``>
 
     /// Zips two StateTs into one.
@@ -92,9 +94,8 @@ module StateT =
     let inline bind (f: 'T->StateT<'S,'``Monad<'U * 'S>``>) (StateT m: StateT<'S,'``Monad<'T * 'S>``>) = StateT <| fun s -> m s >>= (fun (a, s') -> run (f a) s')
 
 type StateT<'s,'``monad<'t * 's>``> with
-    #if !FABLE_COMPILER
-    static member inline Return (x: 'T) = StateT (fun s -> result (x, s))                                                         : StateT<'S,'``Monad<'T * 'S>``>
-    #endif
+
+    static member inline Return (x: 'T) = StateT (fun s -> result (x, s)) : StateT<'S,'``Monad<'T * 'S>``>
 
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Map    (x: StateT<'S,'``Monad<'T * 'S>``>, f : 'T->'U)                                = StateT.map   f x : StateT<'S,'``Monad<'U * 'S>``>
@@ -113,18 +114,16 @@ type StateT<'s,'``monad<'t * 's>``> with
     static member inline Using (resource, f: _ -> StateT<'S,'``Monad<'T * 'S>``>)    = StateT (fun s -> Using.Invoke resource (fun x -> StateT.run (f x) s))
     static member inline Delay (body : unit   ->  StateT<'S,'``Monad<'T * 'S>``>)    = StateT (fun s -> Delay.Invoke (fun _ -> StateT.run (body ()) s)) : StateT<'S,'``Monad<'T * 'S>``>
 
-    #if !FABLE_COMPILER
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Lift (m: '``Monad<'T>``) : StateT<'S,'``Monad<'T * 'S>``> = StateT.lift m
-    #endif
 
     static member inline LiftAsync (x :Async<'T>) = StateT.lift (liftAsync x) : StateT<'S,'``MonadAsync<'T>``>
     
-    #if !FABLE_COMPILER
     static member inline get_Get ()  = StateT (fun s -> result (s , s)) : StateT<'S, '``Monad<'S * 'S>``>
     static member inline Put (x: 'S) = StateT (fun _ -> result ((), x)) : StateT<'S, '``Monad<unit * 'S>``>
-    #endif
 
     static member inline Throw (x: 'E) = x |> throw |> StateT.lift
     static member inline Catch (m: StateT<'S,'``MonadError<'E1,'T * 'S>``>, h: 'E1 -> _) =
         StateT (fun s -> catch (StateT.run m s) (fun e -> StateT.run (h e) s)) : StateT<'S,'``MonadError<'E2, 'T * 'S>``>
+
+#endif

--- a/src/FSharpPlus/Data/ZipList.fs
+++ b/src/FSharpPlus/Data/ZipList.fs
@@ -36,14 +36,15 @@ type ZipList<'s> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Zip (x, y) = ZipList.zip x y
 
-    #if !FABLE_COMPILER
-    static member inline get_Zero () = result (getZero ()) : ZipList<'a>
-    #endif
-    static member inline (+) (x: ZipList<'a>, y: ZipList<'a>) = lift2 plus x y : ZipList<'a>
     static member ToSeq (ZipList x) = x
 
-    #if !FABLE_COMPILER
+#if !FABLE_COMPILER
+
+    static member inline get_Zero () = result (getZero ()) : ZipList<'a>
+    static member inline (+) (x: ZipList<'a>, y: ZipList<'a>) = lift2 plus x y : ZipList<'a>
+    
     static member inline Traverse (ZipList (x: seq<'T>), f: 'T->'``Functor<'U>``) =
         let lst = traverse f x : '``Functor<List<'U>>``
         ZipList <!> lst : '``Functor<ZipList<'U>>``
-    #endif
+
+#endif

--- a/src/FSharpPlus/Lens.fs
+++ b/src/FSharpPlus/Lens.fs
@@ -1,5 +1,7 @@
 ﻿namespace FSharpPlus
 
+#if !FABLE_COMPILER
+
 open FSharpPlus.Operators
 open FSharpPlus.Data
 
@@ -147,12 +149,10 @@ module Lens =
     /// Prism providing a Traversal for targeting the 'None' part of an Option<'T>
     let inline _None x = (prism' (konst None) <| option (konst None) (Some ())) x
 
-    #if !FABLE_COMPILER
     // Traversal
     let inline _all ref f s =
         let update old = if old = ref then f old else Return.InvokeOnInstance old
         traverse update s
-    #endif
 
     // functions
     let inline to' k = dimap k (Contramap.InvokeOnInstance k)
@@ -227,3 +227,5 @@ module Lens =
     /// <param name="f">The mapper function.</param>
     /// <returns>The mapped Functor.</returns>
     let inline (<&>) (x: '``F<'t>``) (f: 't -> 'u) : '``F<'u>`` = Map.InvokeOnInstance f x
+
+#endif

--- a/src/FSharpPlus/Math/Applicative.fs
+++ b/src/FSharpPlus/Math/Applicative.fs
@@ -3,6 +3,8 @@ namespace FSharpPlus.Math
 open FSharpPlus
 open FSharpPlus.Control
 
+#if !FABLE_COMPILER
+
 /// <summary>Math Operators ready to use over Applicative Functors.</summary>
 module Applicative =
 
@@ -47,3 +49,5 @@ module Applicative =
     let inline (.&& ) (x: '``Functor<bool>``)     (y: bool)                   = map ((&&)/> y) x : '``Functor<bool>``
     let inline ( &&.) (x: bool)                   (y: '``Functor<bool>``)     = map ((&&)   x) y : '``Functor<bool>``
     let inline (.&&.) (x: '``Applicative<bool>``) (y: '``Applicative<bool>``) = (&&) <!> x <*> y : '``Applicative<bool>``
+
+#endif

--- a/src/FSharpPlus/Math/Generic.fs
+++ b/src/FSharpPlus/Math/Generic.fs
@@ -3,6 +3,8 @@ namespace FSharpPlus.Math
 open FSharpPlus
 open FSharpPlus.Control
 
+#if !FABLE_COMPILER
+
 /// <summary>
 /// Generic numbers, functions and operators.
 /// By opening this module some common operators become restricted, like (+) to 'T->'T->'T
@@ -30,13 +32,11 @@ module Generic =
     /// Integer division. Same as (/) for Integral types.
     let inline div (a: 'Integral) (b: 'Integral) : 'Integral = whenIntegral a; a / b
 
-    #if !FABLE_COMPILER
     /// Euclidean integer division, following the mathematical convention where the mod is always positive.
     let inline divE (a: 'Integral) b : 'Integral =
         whenIntegral a
         let (a, b) = if b < 0G then (-a, -b) else (a, b)
         (if a < 0G then (a - b + 1G) else a) / b
-    #endif
 
     /// Remainder of Integer division. Same as (%).
     let inline rem (a: 'Integral) (b: 'Integral) : 'Integral = whenIntegral a; a % b
@@ -44,7 +44,6 @@ module Generic =
     /// Euclidean remainder of integer division, following the mathematical convention where the mod is always positive.
     let inline remE (a: 'Integral) (b: 'Integral) : 'Integral = whenIntegral a; ((a % b) + b) % b
 
-    #if !FABLE_COMPILER
     /// Euclidean division-remainder, following the mathematical convention where the mod is always positive.
     let inline divRemE D d =
         let q, r = divRem D d
@@ -52,7 +51,6 @@ module Generic =
             if d > 0G then q - 1G, r + d
             else           q + 1G, r - d
         else q, r
-    #endif
 
     /// Greatest Common Divisor.
     let inline gcd x y : 'Integral =
@@ -63,3 +61,5 @@ module Generic =
         match x, y with
         | t when t = (zero, zero) -> failwith "gcd 0 0 is undefined"
         | _                       -> loop (abs x) (abs y)
+
+#endif

--- a/src/FSharpPlus/Operators.fs
+++ b/src/FSharpPlus/Operators.fs
@@ -69,7 +69,7 @@ module Operators =
     let inline tuple8 a b c d e f g h = a,b,c,d,e,f,g,h
 
 
-#if !FABLE_COMPILER
+    #if !FABLE_COMPILER
 
     // Functor ----------------------------------------------------------------
 
@@ -527,6 +527,8 @@ module Operators =
 
     // Comonads
 
+    #endif
+
     /// Extracts a value from a comonadic context.
     let inline extract (x: '``Comonad<'T>``) : 'T = Extract.Invoke x
 
@@ -538,8 +540,14 @@ module Operators =
     let inline (=>>) (s: '``Comonad<'T>``) (g: '``Comonad<'T>``->'U) : '``Comonad<'U>`` = Extend.Invoke g s
 
     /// Duplicates a comonadic context.
+    #if !FABLE_COMPILER
     let inline duplicate (x: '``Comonad<'T>``) : '``Comonad<'Comonad<'T>>`` = Duplicate.Invoke x
+    #else
+    let inline duplicate (x: '``Comonad<'T>``) : '``Comonad<'Comonad<'T>>`` = Extend.Invoke id x
+    #endif
 
+
+    #if !FABLE_COMPILER
 
     // Monad Transformers
 
@@ -1010,12 +1018,12 @@ module Operators =
     /// An active recognizer for a generic value parser.
     let inline (|Parse|_|) str : 'T option = tryParse str
 
-#endif
+    #endif
 
     /// Safely dispose a resource (includes null-checking).
     let dispose (resource: System.IDisposable) = match resource with null -> () | x -> x.Dispose ()
 
-#if !FABLE_COMPILER
+    #if !FABLE_COMPILER
 
     /// <summary>Additional operators for Arrows related functions which shadows some F# operators for bitwise functions.</summary>
     module Arrows =
@@ -1032,4 +1040,4 @@ module Operators =
         /// Splits the input between the two argument arrows and merge their outputs. Also known as fanin.
         let inline (|||) (f: '``ArrowChoice<'T,'V>``) (g: '``ArrowChoice<'U,'V>``) : '``ArrowChoice<Choice<'U,'T>,'V>`` = Fanin.Invoke f g
 
-#endif
+    #endif

--- a/src/FSharpPlus/Operators.fs
+++ b/src/FSharpPlus/Operators.fs
@@ -134,6 +134,8 @@ module Operators =
 
     // Monad -----------------------------------------------------------
     
+#endif
+
     /// Takes a function from a plain type to a monadic value and a monadic value, and returns a new monadic value.
     let inline bind (f:'T->'``Monad<'U>``) (x:'``Monad<'T>``) :'``Monad<'U>`` = Bind.Invoke x f
     
@@ -150,7 +152,13 @@ module Operators =
     let inline (<=<) (g: 'b->'``Monad<'V>``) (f: 'T->'``Monad<'U>``) : 'T -> '``Monad<'V>`` = fun x -> Bind.Invoke (f x) g
 
     /// Flattens two layers of monadic information into one.
+    #if !FABLE_COMPILER
     let inline join (x: '``Monad<Monad<'T>>``) : '``Monad<'T>`` = Join.Invoke x
+    #else
+    let inline join (x: '``Monad<Monad<'T>>``) : '``Monad<'T>`` = Bind.Invoke x id
+    #endif
+
+#if !FABLE_COMPILER
 
     /// Equivalent to map but only for Monads.
     let inline liftM (f: 'T->'U) (m1: '``Monad<'T>``) : '``Monad<'U>``= m1 >>= (result << f)

--- a/src/FSharpPlus/Operators.fs
+++ b/src/FSharpPlus/Operators.fs
@@ -20,14 +20,18 @@ module Operators =
     /// Takes a function expecting a tuple of two elements and returns a function expecting two curried arguments.
     let inline curry f (x: 'T1) (y: 'T2) : 'Result = f (x, y)
     
+    #if !FABLE_COMPILER
     /// Takes a function expecting a tuple of any N number of elements and returns a function expecting N curried arguments.
     let inline curryN (f: (^``T1 * ^T2 * ... * ^Tn``) -> 'Result) : 'T1 -> '``T2 -> ... -> 'Tn -> 'Result`` = fun t -> Curry.Invoke f t
+    #endif
 
     /// Takes a function expecting two curried arguments and returns a function expecting a tuple of two elements. Same as (<||).
     let inline uncurry f (x: 'T1, y: 'T2) : 'Result = f x y
     
+    #if !FABLE_COMPILER
     /// Takes a function expecting any N number of curried arguments and returns a function expecting a tuple of N elements.
     let inline uncurryN (f: 'T1 -> '``T2 -> ... -> 'Tn -> 'Result``) (t: (^``T1 * ^T2 * ... * ^Tn``)) = Uncurry.Invoke f t : 'Result
+    #endif
 
     /// Used in conjunction with /> to make an ad-hoc binary operator out of a function (x </f/> y).
     let inline (</) x = (|>) x
@@ -65,6 +69,8 @@ module Operators =
     let inline tuple8 a b c d e f g h = a,b,c,d,e,f,g,h
 
 
+#if !FABLE_COMPILER
+
     // Functor ----------------------------------------------------------------
 
     /// Lifts a function into a Functor.
@@ -93,12 +99,10 @@ module Operators =
 
     // Applicative ------------------------------------------------------------
 
-    #if !FABLE_COMPILER
+    
 
     /// Lifts a value into a Functor. Same as return in Computation Expressions.
     let inline result (x: 'T) : '``Functor<'T>`` = Return.Invoke x
-
-    #endif
 
     /// Apply a lifted argument to a lifted function: f <*> arg
     let inline (<*>) (f: '``Applicative<'T -> 'U>``) (x: '``Applicative<'T>``) : '``Applicative<'U>`` = Apply.Invoke f x : '``Applicative<'U>``
@@ -119,8 +123,6 @@ module Operators =
     /// Apply a lifted argument to a lifted function (flipped): arg <**> f
     let inline (<**>) (x: '``Applicative<'T>``) : '``Applicative<'T -> 'U>``->'``Applicative<'U>`` = flip (<*>) x
     
-    #if !FABLE_COMPILER
-
     [<System.Obsolete("Use opt instead.")>]
     let inline optional v = Some <!> v </Append.Invoke/> result None
 
@@ -128,7 +130,6 @@ module Operators =
     /// that always succeed, wrapping the original value into an option to signify success/failure of the original alternative.
     let inline opt (v: '``Alternative<'T>``) : '``Alternative<option<'T>>`` = (Some : 'T -> _) <!> v </Append.Invoke/> result (None: option<'T>)
 
-    #endif
 
 
     // Monad -----------------------------------------------------------
@@ -151,10 +152,8 @@ module Operators =
     /// Flattens two layers of monadic information into one.
     let inline join (x: '``Monad<Monad<'T>>``) : '``Monad<'T>`` = Join.Invoke x
 
-    #if !FABLE_COMPILER
     /// Equivalent to map but only for Monads.
     let inline liftM (f: 'T->'U) (m1: '``Monad<'T>``) : '``Monad<'U>``= m1 >>= (result << f)
-    #endif
 
 
     // Monoid -----------------------------------------------------------------
@@ -181,24 +180,18 @@ module Operators =
     /// Gets a functor representing the empty value.
     let inline getEmpty () : '``Functor<'T>`` = Empty.Invoke ()
 
-    #if !FABLE_COMPILER
-
     /// A functor representing the empty value.
     [<GeneralizableValue>]
     let inline empty< ^``Functor<'T>`` when (Empty or ^``Functor<'T>``) : (static member Empty : ^``Functor<'T>`` * Empty -> ^``Functor<'T>``) > : ^``Functor<'T>`` = Empty.Invoke ()
 
-    #endif
-
     /// Combines two Alternatives
     let inline (<|>) (x: '``Functor<'T>``) (y: '``Functor<'T>``) : '``Functor<'T>`` = Append.Invoke x y
 
-    #if !FABLE_COMPILER
     /// Conditional failure of Alternative computations.
     /// If true it lifts the unit value, else it returns empty.
     ///
     /// Common uses of guard include conditionally signaling an error in an error monad and conditionally rejecting the current choice in an Alternative-based parser.
     let inline guard x: '``MonadPlus<unit>`` = if x then Return.Invoke () else Empty.Invoke ()
-    #endif
 
    
     // Contravariant/Bifunctor/Profunctor/Invariant ---------------------------
@@ -899,13 +892,11 @@ module Operators =
     /// Gets a value that represents the number 1 (one).
     let inline getOne () = One.Invoke ()
 
-    #if !FABLE_COMPILER
     /// A value that represents the 1 element.
     let inline one< ^Num when (One or ^Num) : (static member One : ^Num * One -> ^Num) > : ^Num = One.Invoke ()
 
     /// Divides one number by another, returns a tuple with the result and the remainder.
     let inline divRem (D: 'T) (d: 'T) : 'T*'T = DivRem.Invoke D d
-    #endif
 
     /// Gets the smallest possible value.
     let inline getMinValue () = MinValue.Invoke ()
@@ -931,7 +922,6 @@ module Operators =
     /// The pi number.
     let inline pi< ^Num when (Pi or ^Num) : (static member Pi : ^Num * Pi -> ^Num) > : ^Num = Pi.Invoke ()
 
-    #if !FABLE_COMPILER
     /// Additive inverse of the number.
     let inline negate (x: 'Num) : 'Num = x |> TryNegate.Invoke |> function Ok x -> x | Error e -> raise e
 
@@ -945,15 +935,12 @@ module Operators =
 
     /// Subtraction between two numbers. Throws an error if the result is negative on unsigned types.
     let inline subtract (x: 'Num) (y: 'Num) : 'Num = Subtract.Invoke x y
-    #endif
 
     /// Subtraction between two numbers. Returns None if the result is negative on unsigned types.
     let inline trySubtract (x: 'Num) (y: 'Num) : 'Num option = y |> TrySubtract.Invoke x |> function Ok x -> Some x | Error _ -> None
 
-    #if !FABLE_COMPILER
     /// Division between two numbers. If the numbers are not divisible throws an error.
     let inline div (dividend: 'Num) (divisor: 'Num) : 'Num = Divide.Invoke dividend divisor
-    #endif
     
     /// Division between two numbers. Returns None if the numbers are not divisible.
     let inline tryDiv (dividend: 'Num) (divisor: 'Num) : 'Num option = divisor |> TryDivide.Invoke dividend |> function Ok x -> Some x | Error _ -> None
@@ -976,14 +963,12 @@ module Operators =
     /// <returns>-1, 0, or 1 depending on the sign of the input.</returns>
     let inline signum (value: 'Num) : 'Num = Signum.Invoke value
 
-    #if !FABLE_COMPILER
     /// <summary>Sign of the given number
     ///           Works also for unsigned types. 
     /// <para/>   Rule: signum x * abs x = x </summary>
     /// <param name="value">The input value.</param>
     /// <returns>-1, 0, or 1 depending on the sign of the input.</returns>
     let inline signum' (value: 'Num) : 'Num = Signum'.Invoke value
-    #endif
 
     /// <summary> Gets the absolute value of the given number.
     /// <para/>   Rule: signum x * abs x = x </summary>
@@ -1005,13 +990,11 @@ module Operators =
     /// Reduces using alternative operator `<|>`.
     let inline choice (x: '``Foldable<'Alternative<'T>>``) = Choice.Invoke x : '``Alternative<'T>>``
 
-    #if !FABLE_COMPILER
     /// Generic filter operation for MonadZero. It returns all values satisfying the predicate, if the predicate returns false will use the empty value.
     let inline mfilter (predicate: 'T->bool) (m: '``MonadZero<'T>``) : '``MonadZero<'T>`` = m >>= fun a -> if predicate a then result a else Empty.Invoke ()
 
     /// Folds the sum of all monoid elements in the Foldable.
     let inline sum (x: '``Foldable<'Monoid>``) : 'Monoid = fold (++) (getZero () : 'Monoid) x
-    #endif
 
     /// Converts using the implicit operator. 
     let inline implicit (x: ^T) = ((^R or ^T) : (static member op_Implicit : ^T -> ^R) x) : ^R
@@ -1019,8 +1002,12 @@ module Operators =
     /// An active recognizer for a generic value parser.
     let inline (|Parse|_|) str : 'T option = tryParse str
 
+#endif
+
     /// Safely dispose a resource (includes null-checking).
     let dispose (resource: System.IDisposable) = match resource with null -> () | x -> x.Dispose ()
+
+#if !FABLE_COMPILER
 
     /// <summary>Additional operators for Arrows related functions which shadows some F# operators for bitwise functions.</summary>
     module Arrows =
@@ -1037,3 +1024,4 @@ module Operators =
         /// Splits the input between the two argument arrows and merge their outputs. Also known as fanin.
         let inline (|||) (f: '``ArrowChoice<'T,'V>``) (g: '``ArrowChoice<'U,'V>``) : '``ArrowChoice<Choice<'U,'T>,'V>`` = Fanin.Invoke f g
 
+#endif

--- a/src/FSharpPlus/Operators.fs
+++ b/src/FSharpPlus/Operators.fs
@@ -134,7 +134,7 @@ module Operators =
 
     // Monad -----------------------------------------------------------
     
-#endif
+    #endif
 
     /// Takes a function from a plain type to a monadic value and a monadic value, and returns a new monadic value.
     let inline bind (f:'T->'``Monad<'U>``) (x:'``Monad<'T>``) :'``Monad<'U>`` = Bind.Invoke x f
@@ -158,7 +158,7 @@ module Operators =
     let inline join (x: '``Monad<Monad<'T>>``) : '``Monad<'T>`` = Bind.Invoke x id
     #endif
 
-#if !FABLE_COMPILER
+    #if !FABLE_COMPILER
 
     /// Equivalent to map but only for Monads.
     let inline liftM (f: 'T->'U) (m1: '``Monad<'T>``) : '``Monad<'U>``= m1 >>= (result << f)
@@ -225,9 +225,13 @@ module Operators =
     /// Maps over the right part of a Profunctor.
     let inline rmap (f: 'C->'D) (source: '``Profunctor<'B,'C>``) : '``Profunctor<'B,'D>`` = Map.Invoke f source
 
+    #endif
+
     /// Maps a pair of functions over an Invariant Functor
     let inline invmap (f: 'T -> 'U) (g: 'U -> 'T) (source: '``InvariantFunctor<'T>``) = Invmap.Invoke f g source : '``InvariantFunctor<'U>``
 
+
+    #if !FABLE_COMPILER
 
     // Category ---------------------------------------------------------------
 

--- a/src/FSharpPlus/Parsing.fs
+++ b/src/FSharpPlus/Parsing.fs
@@ -2,6 +2,7 @@
 
 open FSharpPlus.Internals
 
+#if !FABLE_COMPILER
 
 [<AutoOpen>]
 module Parsing =
@@ -18,7 +19,6 @@ module Parsing =
 
         let formatters = [|"%b"; "%d"; "%i"; "%s"; "%u"; "%x"; "%X"; "%o"; "%e"; "%E"; "%f"; "%F"; "%g"; "%G"; "%M"; "%c"; "%A"|]
 
-        #if !FABLE_COMPILER
         let getGroups (pf: PrintfFormat<_,_,_,_,_>) s =
           let formatStr = replace "%%" "%" pf.Value
           let constants = split formatters formatStr
@@ -30,7 +30,6 @@ module Parsing =
           groups
             |> Seq.map (fun g  -> g.Value)
             |> Seq.toArray
-        #endif
         
         type ParseArray =
             static member inline ParseArray (_: 't  , _: obj) = fun (g: string []) -> (parse (g.[0])) : 't
@@ -90,7 +89,6 @@ module Parsing =
 
             static member inline TryParseArray (_: unit                        , _: TryParseArray) = fun (_: string []) -> ()
 
-            #if !FABLE_COMPILER
             static member inline TryParseArray (_: Tuple<'t1>                  , _: TryParseArray) = fun (g: string []) -> Tuple<_> <!> tryParseElemAt 0 g : Tuple<'t1> option
             static member inline TryParseArray (_: Id<'t1>                     , _: TryParseArray) = fun (g: string []) -> Id<_>    <!> tryParseElemAt 0 g
             static member inline TryParseArray (_: 't1*'t2                     , _: TryParseArray) = fun (g: string []) -> tuple2 <!> tryParseElemAt 0 g <*> tryParseElemAt 1 g
@@ -99,7 +97,6 @@ module Parsing =
             static member inline TryParseArray (_: 't1*'t2'*'t3*'t4*'t5        , _: TryParseArray) = fun (g: string []) -> tuple5 <!> tryParseElemAt 0 g <*> tryParseElemAt 1 g <*> tryParseElemAt 2 g <*> tryParseElemAt 3 g <*> tryParseElemAt 4 g
             static member inline TryParseArray (_: 't1*'t2'*'t3*'t4*'t5*'t6    , _: TryParseArray) = fun (g: string []) -> tuple6 <!> tryParseElemAt 0 g <*> tryParseElemAt 1 g <*> tryParseElemAt 2 g <*> tryParseElemAt 3 g <*> tryParseElemAt 4 g <*> tryParseElemAt 5 g
             static member inline TryParseArray (_: 't1*'t2'*'t3*'t4*'t5*'t6*'t7, _: TryParseArray) = fun (g: string []) -> tuple7 <!> tryParseElemAt 0 g <*> tryParseElemAt 1 g <*> tryParseElemAt 2 g <*> tryParseElemAt 3 g <*> tryParseElemAt 4 g <*> tryParseElemAt 5 g <*> tryParseElemAt 6 g
-            #endif
 
 
     open Internals
@@ -108,21 +105,19 @@ module Parsing =
     /// Gets a tuple with the result of parsing each element of a string array.
     let inline parseArray (source: string[]) : '``(T1 * T2 * ... * Tn)`` = ParseArray.Invoke source
 
-    #if !FABLE_COMPILER
     /// Gets a tuple with the result of parsing each element of a formatted text.
     let inline sscanf (pf: PrintfFormat<_,_,_,_,'``(T1 * T2 * ... * Tn)``>) s : '``(T1 * T2 * ... * Tn)`` = getGroups pf s |> parseArray
 
     /// Gets a tuple with the result of parsing each element of a formatted text from the Console.
     let inline scanfn pf : '``(T1 * T2 * ... * Tn)`` = sscanf pf (Console.ReadLine ())
-    #endif
 
     /// Gets a tuple with the result of parsing each element of a string array. Returns None in case of failure.
     let inline tryParseArray g : '``(T1 * T2 * ... * Tn)`` option = TryParseArray.Invoke g
 
-    #if !FABLE_COMPILER
     /// Gets a tuple with the result of parsing each element of a formatted text. Returns None in case of failure.
     let inline trySscanf (pf: PrintfFormat<_,_,_,_,'``(T1 * T2 * ... * Tn)``>) s : '``(T1 * T2 * ... * Tn)`` option = getGroups pf s |> tryParseArray
 
     /// Gets a tuple with the result of parsing each element of a formatted text from the Console. Returns None in case of failure.
     let inline tryScanfn pf : '``(T1 * T2 * ... * Tn)`` option = trySscanf pf (Console.ReadLine ())
-    #endif
+
+#endif

--- a/tests/FSharpPlusFable.Tests/FSharpTests/Extensions.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/Extensions.fs
@@ -4,6 +4,7 @@ open Testing
 open FSharpPlus
 open System.Collections.Generic
 
+open FSharpPlus.Data
 
 
 let ExtensionsTest = 
@@ -36,4 +37,13 @@ let ExtensionsTest =
                    let r1 = m1 |> Map.union m2
                    let r2 = m1 |> Map.unionWith konst m2
                    equalMap r1 r2)
-  ]
+
+
+      testCase "Bind" 
+        (fun () ->  let x = [1;2] >>= fun x -> [string x ; string (x + 1000) ]
+                    let y = { Head = 1; Tail = [2] } >>= fun x -> { Head = string x ; Tail = [string (x + 1000)] }
+                    let z = ("a", 1) >>= fun x -> (string x, x + 10)
+                    equal ["1"; "1001"; "2"; "1002"] x
+                    equal { Head = "1"; Tail = ["1001"; "2"; "1002"] } y
+                    equal ("a1", 11) z)
+]

--- a/tests/FSharpPlusFable.Tests/FSharpTests/Extensions.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/Extensions.fs
@@ -46,4 +46,14 @@ let ExtensionsTest =
                     equal ["1"; "1001"; "2"; "1002"] x
                     equal { Head = "1"; Tail = ["1001"; "2"; "1002"] } y
                     equal ("a1", 11) z)
+
+      testCase "Comonad" 
+        (fun () ->  let x = [1;2;3;4;5]
+                    let y = { Head = 1 ; Tail = [2;3;4;5] }
+                    equal (List.head x) 1
+                    equal (y.Head) 1
+                    equal (duplicate x) [[1; 2; 3; 4; 5]; [2; 3; 4; 5]; [3; 4; 5]; [4; 5]; [5]]
+                    equal (duplicate y) { Head = { Head = 1; Tail = [2; 3; 4; 5] }; Tail = [{ Head = 2; Tail = [3; 4; 5] }; { Head = 3; Tail = [4; 5] }; { Head = 4; Tail = [5] }; { Head = 5; Tail = [] }] }
+                    equal (extend List.head x) x
+                    equal (extend (fun x -> x.Head) y) y)
 ]

--- a/tests/FSharpPlusFable.Tests/build.fsx
+++ b/tests/FSharpPlusFable.Tests/build.fsx
@@ -87,7 +87,7 @@ let runSimpleCommand com repositoryDir command =
             if msg.Length = 0 then "" else
             msg |> Seq.iter (logfn "%s")
             msg.[0]
-        with exn -> failwithf "Could not run \"git %s\".\r\nError: %s" command exn.Message
+        with exn -> failwithf "Could not run \"%s %s\" in dir: %s .\r\nError: %s" com command repositoryDir exn.Message
 
 
 


### PR DESCRIPTION
Currently the project doesn't compile for Fable.

The main problem are the complex trait calls, those ones involving dummy parameters to control the overload resolution, Fable doesn't resolve them.

They have a double requirement: they have to pass the F# compiler, then Fable has to be able to resolve them. 

So, Fable expects to see a simple set of overloads (no DefaultX stuff) but F# doesn’t like it (fails with ambiguity or default to one of them).

This PR restricts Fable compatibility back to Extensions, plus stuff from FSharpPlus.Data and simple trait calls like `>>=`.

It would also add Fable tests and CI (thanks to @wallymathieu ) to make sure from now we don't break anything in Fable and that we can keep  supporting at least our Fable test code.