### PR TITLE
No equality for ZipList

### DIFF
--- a/src/FSharpPlus/Data/ZipList.fs
+++ b/src/FSharpPlus/Data/ZipList.fs
@@ -5,7 +5,7 @@ open FSharpPlus
 
 
 /// A sequence with an Applicative functor based on zipping.
-[<NoComparison>]
+[<NoEquality;NoComparison>]
 type ZipList<'s> = ZipList of 's seq with
     member this.Item n = let (ZipList s) = this in Seq.item n s
 


### PR DESCRIPTION
ZipList is implemented with sequences which have (unfortunate) referential equality.

Ideally sequences don't implement equality as that present many problems, including enumerating infinite sequences.

We can't fix sequences, but we can fix ZipList.

As an example of what potential problems this would bring, imagine an optimization like the one used for IsLeftZero which defaults to comparing to the empty element, it would fail, but not having comparison would skip that overload.