### PR TITLE
Fix traverse for seq of asyncs

### DIFF
--- a/tests/FSharpPlus.Tests/General.fs
+++ b/tests/FSharpPlus.Tests/General.fs
@@ -1064,6 +1064,21 @@ module Traversable =
         ()
 
     [<Test>]
+    let traverseAsyncSequences =
+        SideEffects.reset ()
+
+        let doSomething v =
+            SideEffects.add (sprintf "doSomething: %A" v)
+            sprintf "some: %A" v
+            |> async.Return
+        
+        seq [1..10] 
+        |> traverse doSomething
+        |> map  (head >> printfn "%A")
+        |> Async.RunSynchronously
+        CollectionAssert.AreEqual (["doSomething: 1"], SideEffects.get ())
+
+    [<Test>]
     let traverseInfiniteAsyncSequences =
         let s = Seq.initInfinite async.Return
         let s' = sequence s


### PR DESCRIPTION
This is a fix for a regression detected in v1.1.0

Closes #316 