### PR TITLE
Fix intercalate's generic overload

### DIFF
--- a/src/FSharpPlus/Control/Collection.fs
+++ b/src/FSharpPlus/Control/Collection.fs
@@ -421,8 +421,7 @@ type Intersperse =
 type Intercalate =
     inherit Default1
 
-    static member inline Intercalate (x: '``Foldable<'Monoid>``, e: 'Monoid          , [<Optional>]_impl: Default2   ) = let f t x = match t, x with (true, _), x -> false, x | (_, acc ), x -> (false, Plus.Invoke (Plus.Invoke acc e) x) in Fold.Invoke f (true, Zero.Invoke ()) x |> snd
-    static member inline Intercalate (x: seq<'``Foldable<'T>``>, e: '``Foldable<'T>``, [<Optional>]_impl: Default1   ) = x |> Seq.map ToSeq.Invoke |> Seq.intercalate (ToSeq.Invoke e) |> OfSeq.Invoke : '``Foldable<'T>``
+    static member inline Intercalate (x: '``Foldable<'Monoid>``, e: 'Monoid          , [<Optional>]_impl: Default1   ) = let f t x = match t, x with (true, _), x -> false, x | (_, acc ), x -> (false, Plus.Invoke (Plus.Invoke acc e) x) in Fold.Invoke f (true, Zero.Invoke ()) x |> snd
     static member inline Intercalate (_: seq<'``Foldable<'T>``>, _: ^t when ^t: null and ^t: struct  , _: Default1   ) = id
 
     static member        Intercalate (x: seq<list<'T>>         , e: list<'T>         , [<Optional>]_impl: Intercalate) = List.intercalate  e x

--- a/tests/FSharpPlus.Tests/General.fs
+++ b/tests/FSharpPlus.Tests/General.fs
@@ -1676,11 +1676,9 @@ module Splits =
 
         let b = [WrappedListB [1;2]; WrappedListB [3;4]; WrappedListB [6;7]] |> intercalate (WrappedListB [0;1])
 
-        // Fails to compile but works in F#4.1
-        // let c = [| Sum 1; Sum 2 |] |> intercalate (Sum 10)
-        // 
-
-        let d = WrappedListB [Sum 1; Sum 2] |> intercalate (Sum 10)
+        let _c = [| Sum 1; Sum 2 |] |> intercalate (Sum 10)
+        let d  = WrappedListB [Sum 1; Sum 2] |> intercalate (Sum 10)
+        let _e = intercalate 10 (seq [1; 2; 3])
 
         Assert.IsTrue((a1 = a2))
         Assert.IsTrue((b = WrappedListB [1; 2; 0; 1; 3; 4; 0; 1; 6; 7]))


### PR DESCRIPTION
This will fix #320 for F# versions 4.7 and lower by removing the Default1 overload which is an optimization.

It is expected that future versions of the F# compiler will fix this issue, so this patch won't be needed anymore.

Therefore in the future event of a release of this library which targets a min compiler version which doesn't have this issue, this patch can be revisited and removed.