### PR TITLE
Fix try blocks for lazy / strict monads

### DIFF
--- a/src/FSharpPlus/Control/Monad.fs
+++ b/src/FSharpPlus/Control/Monad.fs
@@ -175,6 +175,23 @@ type TryWith =
         let inline call (mthd: 'M, input: 'I, _output: 'R, h: exn -> 'I) = ((^M or ^I) : (static member TryWith : _*_*_ -> _) input, h, mthd)
         call (Unchecked.defaultof<TryWith>, source, Unchecked.defaultof<'``Monad<'T>``>, f)
 
+type TryWithStrict =
+    inherit Default1
+
+    static member        TryWith (computation: unit -> '``Monad<'T>``, catchHandler: exn -> '``Monad<'T>``, _: Default3) = try computation () with e -> catchHandler e
+    static member inline TryWith (computation: unit -> '``Monad<'T>``, catchHandler: exn -> '``Monad<'T>``, _: Default1) = (^``Monad<'T>`` : (static member TryWith : _*_->_) computation (), catchHandler) : '``Monad<'T>``
+    static member inline TryWith (_: unit -> ^t when ^t: null and ^t: struct, _    : exn -> 't            , _: Default1) = ()
+    
+    static member        TryWith (computation: unit -> seq<_>        , catchHandler: exn -> seq<_>       , _: Default2     ) = seq (try (Seq.toArray (computation ())) with e -> Seq.toArray (catchHandler e))
+    static member        TryWith (computation: unit -> 'R -> _       , catchHandler: exn -> 'R -> _      , _: Default2     ) = (fun s -> try (computation ()) s with e -> catchHandler e s) : 'R ->_
+    static member        TryWith (computation: unit -> Async<_>      , catchHandler: exn -> Async<_>     , _: TryWithStrict) = async.TryWith ((computation ()), catchHandler)
+    static member        TryWith (computation: unit -> Lazy<_>       , catchHandler: exn -> Lazy<_>      , _: TryWithStrict) = lazy (try (computation ()).Force () with e -> (catchHandler e).Force ()) : Lazy<_>
+
+    static member inline Invoke (source: unit ->'``Monad<'T>``) (f: exn -> '``Monad<'T>``) : '``Monad<'T>`` =
+        let inline call (mthd: 'M, input: unit -> 'I, _output: 'R, h: exn -> 'I) = ((^M or ^I) : (static member TryWith : _*_*_ -> _) input, h, mthd)
+        call (Unchecked.defaultof<TryWithStrict>, source, Unchecked.defaultof<'``Monad<'T>``>, f)
+
+
 
 type TryFinally =
     inherit Default1

--- a/src/FSharpPlus/Control/Monad.fs
+++ b/src/FSharpPlus/Control/Monad.fs
@@ -12,6 +12,8 @@ open FSharpPlus.Internals
 open FSharpPlus.Internals.Prelude
 
 
+
+
 // Monad class ------------------------------------------------------------
 
 type Bind =
@@ -158,15 +160,25 @@ type Delay =
         call (Unchecked.defaultof<Delay>, source)
 
 
-type True  = True
-type False = False
+[<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
+module TryBlock =
+    type True  = True
+    type False = False
+
+    let [<Literal>]MessageTryWith = "Method TryWith not implemented. If the computation's type is not lazy use a strict monad by adding .strict, otherwise it should have a static member TryWith."
+    let [<Literal>]CodeTryWith = 10708
+
+    let [<Literal>]MessageTryFinally = "Method TryFinally not implemented. If the computation's type is not lazy use a strict monad by adding .strict, otherwise it should have a static member TryFinally."
+    let [<Literal>]CodeTryFinally = 10709
+
+open TryBlock
 
 type TryWith =
     inherit Default1
 
-    [<CompilerMessage("Method TryWith not implemented. To solve this issue implement a static member TryWith or use a strict computation expression if the type is not lazy (monad.strict or monad').", 708, IsError = true)>]
-    static member        TryWith (_:           unit -> '``Monad<'T>``, _:            exn -> '``Monad<'T>``, _: Default3, _useDefaults: False) = raise Internals.Errors.exnUnreachable
-    static member        TryWith (computation: unit -> '``Monad<'T>``, catchHandler: exn -> '``Monad<'T>``, _: Default3, _useDefaults: True ) = try computation () with e -> catchHandler e
+    [<CompilerMessage(MessageTryWith, CodeTryWith, IsError = true)>]
+    static member        TryWith (_:           unit -> '``Monad<'T>``, _:            exn -> '``Monad<'T>``, _: Default3, _defaults: False) = raise Internals.Errors.exnUnreachable
+    static member        TryWith (computation: unit -> '``Monad<'T>``, catchHandler: exn -> '``Monad<'T>``, _: Default3, _defaults: True ) = try computation () with e -> catchHandler e
 
     static member inline TryWith (computation: unit -> '``Monad<'T>``, catchHandler: exn -> '``Monad<'T>``, _: Default1, _) = (^``Monad<'T>`` : (static member TryWith : _*_->_) computation (), catchHandler) : '``Monad<'T>``
     static member inline TryWith (_: unit -> ^t when ^t: null and ^t: struct, _    : exn -> 't            , _: Default1, _) = ()
@@ -190,9 +202,9 @@ type TryFinally =
 
     static member        TryFinally ((computation: unit -> seq<_>  , compensation: unit -> unit), _: Default2  , _, _) = seq (try (Seq.toArray (computation ())) finally compensation ())
 
-    [<CompilerMessage("Method TryFinally not implemented. To solve this issue implement a static member TryFinally or use a strict computation expression if the type is not lazy (monad.strict or monad').", 708, IsError = true)>]
-    static member        TryFinally ((_:           unit -> 'R -> _            , _: unit -> unit), _: Default2  , _, _useDefaults: False) = raise Internals.Errors.exnUnreachable
-    static member        TryFinally ((computation: unit -> 'R -> _ , compensation: unit -> unit), _: Default2  , _, _useDefaults: True ) = fun s -> try computation () s finally compensation ()
+    [<CompilerMessage(MessageTryFinally, CodeTryFinally, IsError = true)>]
+    static member        TryFinally ((_:           unit -> 'R -> _            , _: unit -> unit), _: Default2  , _, _defaults: False) = raise Internals.Errors.exnUnreachable
+    static member        TryFinally ((computation: unit -> 'R -> _ , compensation: unit -> unit), _: Default2  , _, _defaults: True ) = fun s -> try computation () s finally compensation ()
     
     static member        TryFinally ((computation: unit -> Id<_>   , compensation: unit -> unit), _: TryFinally, _, _) = try computation () finally compensation ()
     static member        TryFinally ((computation: unit -> Async<_>, compensation: unit -> unit), _: TryFinally, _, _) = async.TryFinally (computation (), compensation) : Async<_>
@@ -210,14 +222,14 @@ type TryFinally =
 
 type TryFinally with
 
-    [<CompilerMessage("Method TryFinally not implemented. To solve this issue implement a static member TryFinally or use a strict computation expression if the type is not lazy (monad.strict or monad').", 708, IsError = true)>]
-    static member        TryFinally ((_: unit -> '``Monad<'T>`` when '``Monad<'T>`` :     struct, _: unit -> unit), _: Default3, _: Default2  , _useDefaults: False) = raise Internals.Errors.exnUnreachable
+    [<CompilerMessage(MessageTryFinally, CodeTryFinally, IsError = true)>]
+    static member        TryFinally ((_: unit -> '``Monad<'T>`` when '``Monad<'T>`` :     struct, _: unit -> unit), _: Default3, _: Default2, _defaults: False) = raise Internals.Errors.exnUnreachable
 
-    [<CompilerMessage("Method TryFinally not implemented. To solve this issue implement a static member TryFinally or use a strict computation expression if the type is not lazy (monad.strict or monad').", 708, IsError = true)>]
-    static member        TryFinally ((_: unit -> '``Monad<'T>`` when '``Monad<'T>`` : not struct, _: unit -> unit), _: Default3, _: Default1  , _useDefaults: False) = raise Internals.Errors.exnUnreachable
+    [<CompilerMessage(MessageTryFinally, CodeTryFinally, IsError = true)>]
+    static member        TryFinally ((_: unit -> '``Monad<'T>`` when '``Monad<'T>`` : not struct, _: unit -> unit), _: Default3, _: Default1, _defaults: False) = raise Internals.Errors.exnUnreachable
 
-    static member        TryFinally ((computation: unit -> '``Monad<'T>`` when '``Monad<'T>`` :     struct, compensation: unit -> unit), _: Default3, _: Default2  , _useDefaults: True) = try computation () finally compensation ()
-    static member        TryFinally ((computation: unit -> '``Monad<'T>`` when '``Monad<'T>`` : not struct, compensation: unit -> unit), _: Default3, _: Default1  , _useDefaults: True) = try computation () finally compensation ()
+    static member        TryFinally ((computation: unit -> '``Monad<'T>`` when '``Monad<'T>`` :     struct, compensation: unit -> unit), _: Default3, _: Default2, _defaults: True) = try computation () finally compensation ()
+    static member        TryFinally ((computation: unit -> '``Monad<'T>`` when '``Monad<'T>`` : not struct, compensation: unit -> unit), _: Default3, _: Default1, _defaults: True) = try computation () finally compensation ()
     
     static member inline TryFinally ((computation: unit -> '``Monad<'T>``                                 , compensation: unit -> unit), _: Default1, _: TryFinally, _) = TryFinally.InvokeOnInstance (computation ()) compensation: '``Monad<'T>``
     static member inline TryFinally (( _         : unit -> ^t when ^t:null and ^t:struct                  , _           : unit -> unit), _: Default1, _            , _) = ()

--- a/src/FSharpPlus/Control/Monad.fs
+++ b/src/FSharpPlus/Control/Monad.fs
@@ -12,8 +12,6 @@ open FSharpPlus.Internals
 open FSharpPlus.Internals.Prelude
 
 
-
-
 // Monad class ------------------------------------------------------------
 
 type Bind =

--- a/src/FSharpPlus/Control/Monad.fs
+++ b/src/FSharpPlus/Control/Monad.fs
@@ -180,7 +180,10 @@ type TryFinally =
     inherit Default1
 
     static member        TryFinally ((computation: seq<_>  , compensation: unit -> unit), _: Default2  , _) = seq (try (Seq.toArray computation) finally compensation ())
-    static member        TryFinally ((computation: 'R -> _ , compensation: unit -> unit), _: Default2, _) = fun s -> try computation s finally compensation ()
+    
+    [<CompilerMessage("Method TryFinally not implemented. To solve this issue implement a static member TryFinally or use a strict computation expression if the type is not lazy (monad.strict or monad').", 708, IsError = true)>]
+    static member        TryFinally ((_: 'R -> _           , _: unit -> unit           ), _: Default2  , _) = raise Internals.Errors.exnUnreachable
+    
     static member        TryFinally ((computation: Id<_>   , compensation: unit -> unit), _: TryFinally, _) = try computation finally compensation()
     static member        TryFinally ((computation: Async<_>, compensation: unit -> unit), _: TryFinally, _) = async.TryFinally (computation, compensation) : Async<_>
     static member        TryFinally ((computation: Lazy<_> , compensation: unit -> unit), _: TryFinally, _) = lazy (try computation.Force () finally compensation ()) : Lazy<_>

--- a/src/FSharpPlus/Control/Monad.fs
+++ b/src/FSharpPlus/Control/Monad.fs
@@ -197,7 +197,7 @@ type TryFinally =
     inherit Default1
 
     static member        TryFinally ((computation: seq<_>  , compensation: unit -> unit), _: Default2  , _) = seq (try (Seq.toArray computation) finally compensation ())
-    
+
     [<CompilerMessage("Method TryFinally not implemented. To solve this issue implement a static member TryFinally or use a strict computation expression if the type is not lazy (monad.strict or monad').", 708, IsError = true)>]
     static member        TryFinally ((_: 'R -> _           , _: unit -> unit           ), _: Default2  , _) = raise Internals.Errors.exnUnreachable
     
@@ -212,8 +212,13 @@ type TryFinally =
     static member inline InvokeOnInstance (source: '``Monad<'T>``) (f: unit -> unit) : '``Monad<'T>`` = (^``Monad<'T>`` : (static member TryFinally : _*_->_) source, f) : '``Monad<'T>``
 
 type TryFinally with
-    static member        TryFinally ((computation: '``Monad<'T>`` when '``Monad<'T>`` :     struct, compensation: unit -> unit), _: Default3, _: Default2  ) = try computation finally compensation ()
-    static member        TryFinally ((computation: '``Monad<'T>`` when '``Monad<'T>`` : not struct, compensation: unit -> unit), _: Default3, _: Default1  ) = try computation finally compensation ()
+
+    [<CompilerMessage("Method TryFinally not implemented. To solve this issue implement a static member TryFinally or use a strict computation expression if the type is not lazy (monad.strict or monad').", 708, IsError = true)>]
+    static member        TryFinally ((_: '``Monad<'T>`` when '``Monad<'T>`` :     struct, _: unit -> unit), _: Default3, _: Default2  ) = raise Internals.Errors.exnUnreachable
+    
+    [<CompilerMessage("Method TryFinally not implemented. To solve this issue implement a static member TryFinally or use a strict computation expression if the type is not lazy (monad.strict or monad').", 708, IsError = true)>]
+    static member        TryFinally ((_: '``Monad<'T>`` when '``Monad<'T>`` : not struct, _: unit -> unit), _: Default3, _: Default1  ) = raise Internals.Errors.exnUnreachable
+    
     static member inline TryFinally ((computation: '``Monad<'T>``                                 , compensation: unit -> unit), _: Default1, _: TryFinally) = TryFinally.InvokeOnInstance computation compensation: '``Monad<'T>``
     static member inline TryFinally (( _         : ^t when ^t:null and ^t:struct                  , _           : unit -> unit), _: Default1, _            ) = ()
 

--- a/src/FSharpPlus/Control/Monad.fs
+++ b/src/FSharpPlus/Control/Monad.fs
@@ -161,7 +161,8 @@ type Delay =
 type TryWith =
     inherit Default1
 
-    static member        TryWith (computation: '``Monad<'T>``, catchHandler: exn -> '``Monad<'T>``, _: Default3) = try computation with e -> catchHandler e
+    [<CompilerMessage("Method TryWith not implemented. To solve this issue implement a static member TryWith or use a strict computation expression if the type is not lazy (monad.strict or monad').", 708, IsError = true)>]
+    static member        TryWith (_: '``Monad<'T>``          , _: exn            -> '``Monad<'T>``, _: Default3) = raise Internals.Errors.exnUnreachable
     static member inline TryWith (computation: '``Monad<'T>``, catchHandler: exn -> '``Monad<'T>``, _: Default1) = (^``Monad<'T>`` : (static member TryWith : _*_->_) computation, catchHandler) : '``Monad<'T>``
     static member inline TryWith (_: ^t when ^t: null and ^t: struct, _    : exn -> 't            , _: Default1) = ()
 

--- a/src/FSharpPlus/Data/Reader.fs
+++ b/src/FSharpPlus/Data/Reader.fs
@@ -111,7 +111,7 @@ type ReaderT<'r,'``monad<'t>``> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Zip (x: ReaderT<'S,'``Monad<'T>``>, y: ReaderT<'S,'``Monad<'U>``>) = ReaderT.zip x y
 
-    static member inline TryWith (source: ReaderT<'R,'``Monad<'T>``>, f: exn -> ReaderT<'R,'``Monad<'T>``>) = ReaderT (fun s -> TryWith.Invoke (ReaderT.run source s) (fun x -> ReaderT.run (f x) s))
+    static member inline TryWith (source: ReaderT<'R,'``Monad<'T>``>, f: exn -> ReaderT<'R,'``Monad<'T>``>) = ReaderT (fun s -> TryWithStrict.Invoke (fun () -> ReaderT.run source s) (fun x -> ReaderT.run (f x) s))
     static member inline TryFinally (computation: ReaderT<'R,'``Monad<'T>``>, f) = ReaderT (fun s -> TryFinally.Invoke     (ReaderT.run computation s) f)
     static member inline Using (resource, f: _ -> ReaderT<'R,'``Monad<'T>``>)    = ReaderT (fun s -> Using.Invoke resource (fun x -> ReaderT.run (f x) s))
     static member inline Delay (body : unit   ->  ReaderT<'R,'``Monad<'T>``>)    = ReaderT (fun s -> Delay.Invoke (fun _ -> ReaderT.run (body ()) s))

--- a/src/FSharpPlus/Data/Reader.fs
+++ b/src/FSharpPlus/Data/Reader.fs
@@ -111,8 +111,8 @@ type ReaderT<'r,'``monad<'t>``> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Zip (x: ReaderT<'S,'``Monad<'T>``>, y: ReaderT<'S,'``Monad<'U>``>) = ReaderT.zip x y
 
-    static member inline TryWith (source: ReaderT<'R,'``Monad<'T>``>, f: exn -> ReaderT<'R,'``Monad<'T>``>) = ReaderT (fun s -> TryWithStrict.Invoke (fun () -> ReaderT.run source s) (fun x -> ReaderT.run (f x) s))
-    static member inline TryFinally (computation: ReaderT<'R,'``Monad<'T>``>, f) = ReaderT (fun s -> TryFinallyStrict.Invoke (fun () -> ReaderT.run computation s) f)
+    static member inline TryWith (source: ReaderT<'R,'``Monad<'T>``>, f: exn -> ReaderT<'R,'``Monad<'T>``>) = ReaderT (fun s -> TryWith.InvokeForStrict (fun () -> ReaderT.run source s) (fun x -> ReaderT.run (f x) s))
+    static member inline TryFinally (computation: ReaderT<'R,'``Monad<'T>``>, f) = ReaderT (fun s -> TryFinally.InvokeForStrict (fun () -> ReaderT.run computation s) f)
     static member inline Using (resource, f: _ -> ReaderT<'R,'``Monad<'T>``>)    = ReaderT (fun s -> Using.Invoke resource (fun x -> ReaderT.run (f x) s))
     static member inline Delay (body : unit   ->  ReaderT<'R,'``Monad<'T>``>)    = ReaderT (fun s -> Delay.Invoke (fun _ -> ReaderT.run (body ()) s))
 

--- a/src/FSharpPlus/Data/Reader.fs
+++ b/src/FSharpPlus/Data/Reader.fs
@@ -112,7 +112,7 @@ type ReaderT<'r,'``monad<'t>``> with
     static member inline Zip (x: ReaderT<'S,'``Monad<'T>``>, y: ReaderT<'S,'``Monad<'U>``>) = ReaderT.zip x y
 
     static member inline TryWith (source: ReaderT<'R,'``Monad<'T>``>, f: exn -> ReaderT<'R,'``Monad<'T>``>) = ReaderT (fun s -> TryWithStrict.Invoke (fun () -> ReaderT.run source s) (fun x -> ReaderT.run (f x) s))
-    static member inline TryFinally (computation: ReaderT<'R,'``Monad<'T>``>, f) = ReaderT (fun s -> TryFinally.Invoke     (ReaderT.run computation s) f)
+    static member inline TryFinally (computation: ReaderT<'R,'``Monad<'T>``>, f) = ReaderT (fun s -> TryFinallyStrict.Invoke (fun () -> ReaderT.run computation s) f)
     static member inline Using (resource, f: _ -> ReaderT<'R,'``Monad<'T>``>)    = ReaderT (fun s -> Using.Invoke resource (fun x -> ReaderT.run (f x) s))
     static member inline Delay (body : unit   ->  ReaderT<'R,'``Monad<'T>``>)    = ReaderT (fun s -> Delay.Invoke (fun _ -> ReaderT.run (body ()) s))
 

--- a/src/FSharpPlus/Data/State.fs
+++ b/src/FSharpPlus/Data/State.fs
@@ -120,8 +120,8 @@ type StateT<'s,'``monad<'t * 's>``> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Zip (x: StateT<'S,'``Monad<'T * 'S>``>, y: StateT<'S,'``Monad<'U * 'S>``>) = StateT.zip x y
 
-    static member inline TryWith (source: StateT<'S,'``Monad<'T * 'S>``>, f: exn -> StateT<'S,'``Monad<'T * 'S>``>) = StateT (fun s -> TryWithStrict.Invoke (fun () -> StateT.run source s) (fun x -> StateT.run (f x) s))
-    static member inline TryFinally (computation: StateT<'S,'``Monad<'T * 'S>``>, f) = StateT (fun s -> TryFinallyStrict.Invoke (fun () -> StateT.run computation s) f)
+    static member inline TryWith (source: StateT<'S,'``Monad<'T * 'S>``>, f: exn -> StateT<'S,'``Monad<'T * 'S>``>) = StateT (fun s -> TryWith.InvokeForStrict (fun () -> StateT.run source s) (fun x -> StateT.run (f x) s))
+    static member inline TryFinally (computation: StateT<'S,'``Monad<'T * 'S>``>, f) = StateT (fun s -> TryFinally.InvokeForStrict (fun () -> StateT.run computation s) f)
     static member inline Using (resource, f: _ -> StateT<'S,'``Monad<'T * 'S>``>)    = StateT (fun s -> Using.Invoke resource (fun x -> StateT.run (f x) s))
     static member inline Delay (body : unit   ->  StateT<'S,'``Monad<'T * 'S>``>)    = StateT (fun s -> Delay.Invoke (fun _ -> StateT.run (body ()) s)) : StateT<'S,'``Monad<'T * 'S>``>
 

--- a/src/FSharpPlus/Data/State.fs
+++ b/src/FSharpPlus/Data/State.fs
@@ -120,7 +120,7 @@ type StateT<'s,'``monad<'t * 's>``> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Zip (x: StateT<'S,'``Monad<'T * 'S>``>, y: StateT<'S,'``Monad<'U * 'S>``>) = StateT.zip x y
 
-    static member inline TryWith (source: StateT<'S,'``Monad<'T * 'S>``>, f: exn -> StateT<'S,'``Monad<'T * 'S>``>) = StateT (fun s -> TryWith.Invoke (StateT.run source s) (fun x -> StateT.run (f x) s))
+    static member inline TryWith (source: StateT<'S,'``Monad<'T * 'S>``>, f: exn -> StateT<'S,'``Monad<'T * 'S>``>) = StateT (fun s -> TryWithStrict.Invoke (fun () -> StateT.run source s) (fun x -> StateT.run (f x) s))
     static member inline TryFinally (computation: StateT<'S,'``Monad<'T * 'S>``>, f) = StateT (fun s -> TryFinally.Invoke     (StateT.run computation s) f)
     static member inline Using (resource, f: _ -> StateT<'S,'``Monad<'T * 'S>``>)    = StateT (fun s -> Using.Invoke resource (fun x -> StateT.run (f x) s))
     static member inline Delay (body : unit   ->  StateT<'S,'``Monad<'T * 'S>``>)    = StateT (fun s -> Delay.Invoke (fun _ -> StateT.run (body ()) s)) : StateT<'S,'``Monad<'T * 'S>``>

--- a/src/FSharpPlus/Data/State.fs
+++ b/src/FSharpPlus/Data/State.fs
@@ -121,7 +121,7 @@ type StateT<'s,'``monad<'t * 's>``> with
     static member inline Zip (x: StateT<'S,'``Monad<'T * 'S>``>, y: StateT<'S,'``Monad<'U * 'S>``>) = StateT.zip x y
 
     static member inline TryWith (source: StateT<'S,'``Monad<'T * 'S>``>, f: exn -> StateT<'S,'``Monad<'T * 'S>``>) = StateT (fun s -> TryWithStrict.Invoke (fun () -> StateT.run source s) (fun x -> StateT.run (f x) s))
-    static member inline TryFinally (computation: StateT<'S,'``Monad<'T * 'S>``>, f) = StateT (fun s -> TryFinally.Invoke     (StateT.run computation s) f)
+    static member inline TryFinally (computation: StateT<'S,'``Monad<'T * 'S>``>, f) = StateT (fun s -> TryFinallyStrict.Invoke (fun () -> StateT.run computation s) f)
     static member inline Using (resource, f: _ -> StateT<'S,'``Monad<'T * 'S>``>)    = StateT (fun s -> Using.Invoke resource (fun x -> StateT.run (f x) s))
     static member inline Delay (body : unit   ->  StateT<'S,'``Monad<'T * 'S>``>)    = StateT (fun s -> Delay.Invoke (fun _ -> StateT.run (body ()) s)) : StateT<'S,'``Monad<'T * 'S>``>
 

--- a/tests/FSharpPlus.Tests/ComputationExpressions.fs
+++ b/tests/FSharpPlus.Tests/ComputationExpressions.fs
@@ -465,3 +465,5 @@ module ComputationExpressions =
                 with _ -> () }
             x
         let _ = ((monadTransformer3layersTest2 () |> StateT.run) "" |> ReaderT.run) 0
+        
+        ()

--- a/tests/FSharpPlus.Tests/ComputationExpressions.fs
+++ b/tests/FSharpPlus.Tests/ComputationExpressions.fs
@@ -526,6 +526,7 @@ module ComputationExpressions =
         let lazyMonadTest () =
             SideEffects.reset ()
             let x : seq<unit> = monad {
+                use disp = { new IDisposable with override __.Dispose() = SideEffects.add "Disposing" }
                 try
                     failwith "Exception in try-finally"
                     ()
@@ -533,11 +534,12 @@ module ComputationExpressions =
                     SideEffects.add "Finally goes here" }
             x
         let _ = try (lazyMonadTest () |> Seq.toList) with _ -> Unchecked.defaultof<_>
-        areEqual ["Finally goes here"] (SideEffects.get ())
+        areEqual ["Finally goes here"; "Disposing"] (SideEffects.get ())
         
         let strictMonadTest () =
             SideEffects.reset ()
             let x : list<unit> = monad.strict {
+                use disp = { new IDisposable with override __.Dispose() = SideEffects.add "Disposing" }
                 try
                     failwith "Exception in try-finally"
                     ()
@@ -545,11 +547,12 @@ module ComputationExpressions =
                     SideEffects.add "Finally goes here" }
             x
         let _ = try (strictMonadTest ()) with _ -> Unchecked.defaultof<_>
-        areEqual ["Finally goes here"] (SideEffects.get ())
+        areEqual ["Finally goes here"; "Disposing"] (SideEffects.get ())
 
         let monadTransformer3layersTest1 () =
             SideEffects.reset ()
             let x: StateT<string, ReaderT<int, seq<(unit * string)>>> = monad {
+                use disp = { new IDisposable with override __.Dispose() = SideEffects.add "Disposing" }
                 try
                     failwith "Exception in try-finally"
                     ()
@@ -557,11 +560,12 @@ module ComputationExpressions =
                     SideEffects.add "Finally goes here" }
             x
         let _ = try (((monadTransformer3layersTest1 () |> StateT.run) "" |> ReaderT.run) 0 |> Seq.toList) with _ -> Unchecked.defaultof<_>
-        areEqual ["Finally goes here"] (SideEffects.get ())
+        areEqual ["Finally goes here"; "Disposing"] (SideEffects.get ())
 
         let monadTransformer3layersTest2 () =
             SideEffects.reset ()
             let x: StateT<string, ReaderT<int, list<(unit * string)>>> = monad {
+                use disp = { new IDisposable with override __.Dispose() = SideEffects.add "Disposing" }
                 try
                     failwith "Exception in try-finally"
                     ()
@@ -569,11 +573,12 @@ module ComputationExpressions =
                     SideEffects.add "Finally goes here" }
             x
         let _ = try (((monadTransformer3layersTest2 () |> StateT.run) "" |> ReaderT.run) 0) with _ -> Unchecked.defaultof<_>
-        areEqual ["Finally goes here"] (SideEffects.get ())
+        areEqual ["Finally goes here"; "Disposing"] (SideEffects.get ())
 
         let monadTransformer3layersTest3 () =
             SideEffects.reset ()
             let x: WriterT<OptionT<seq<(unit * string) option>>> = monad {
+                use disp = { new IDisposable with override __.Dispose() = SideEffects.add "Disposing" }
                 try
                     failwith "Exception in try-finally"
                     ()
@@ -581,13 +586,14 @@ module ComputationExpressions =
                     SideEffects.add "Finally goes here" }
             x
         let _ = try (monadTransformer3layersTest3 () |> WriterT.run |> OptionT.run |> Seq.toList) with _ -> Unchecked.defaultof<_>
-        areEqual ["Finally goes here"] (SideEffects.get ())
+        areEqual ["Finally goes here"; "Disposing"] (SideEffects.get ())
 
         // Same test but with list instead of seq, which makes the whole monad strict
         // If .strict is not used it fails compilation with a nice error asking us to add it
         let monadTransformer3layersTest4 () =
             SideEffects.reset ()
             let x: WriterT<OptionT<list<(unit * string) option>>> = monad.strict {
+                use disp = { new IDisposable with override __.Dispose() = SideEffects.add "Disposing" }
                 try
                     failwith "Exception in try-finally"
                     ()
@@ -595,12 +601,13 @@ module ComputationExpressions =
                     SideEffects.add "Finally goes here" }
             x
         let _ = try (monadTransformer3layersTest4 () |> WriterT.run |> OptionT.run) with _ -> Unchecked.defaultof<_>
-        areEqual ["Finally goes here"] (SideEffects.get ())
+        areEqual ["Finally goes here"; "Disposing"] (SideEffects.get ())
 
         // ContT doesn't deal with the inner monad, so we don't need to do anything.
         let contTTest () =
             SideEffects.reset ()
             let x: ContT<list<unit>,unit> = monad {
+                use disp = { new IDisposable with override __.Dispose() = SideEffects.add "Disposing" }
                 try
                     failwith "Exception in try-finally"
                     ()
@@ -608,7 +615,7 @@ module ComputationExpressions =
                     SideEffects.add "Finally goes here" }
             x
         let _ = try ((contTTest () |> ContT.run) result) with _ -> Unchecked.defaultof<_>
-        areEqual ["Finally goes here"] (SideEffects.get ())
+        areEqual ["Finally goes here"; "Disposing"] (SideEffects.get ())
 
 
         ()

--- a/tests/FSharpPlus.Tests/ComputationExpressions.fs
+++ b/tests/FSharpPlus.Tests/ComputationExpressions.fs
@@ -537,7 +537,7 @@ module ComputationExpressions =
         
         let strictMonadTest () =
             SideEffects.reset ()
-            let x : list<unit> = monad {
+            let x : list<unit> = monad.strict {
                 try
                     failwith "Exception in try-finally"
                     ()

--- a/tests/FSharpPlus.Tests/ComputationExpressions.fs
+++ b/tests/FSharpPlus.Tests/ComputationExpressions.fs
@@ -466,4 +466,24 @@ module ComputationExpressions =
             x
         let _ = ((monadTransformer3layersTest2 () |> StateT.run) "" |> ReaderT.run) 0
         
+        let monadTransformer3layersTest3 () =
+            let x: WriterT<OptionT<seq<(unit * string) option>>> = monad {
+                try
+                    failwith "Exception in try-with not handled"
+                    ()
+                with _ -> () }
+            x
+        let _ = monadTransformer3layersTest3 () |> WriterT.run |> OptionT.run |> Seq.toList
+        
+        // Same test but with list instead of seq, which makes the whole monad strict
+        // If .strict is not used it fails compilation with a nice error asking us to add it
+        let monadTransformer3layersTest4 () =
+            let x: WriterT<OptionT<list<(unit * string) option>>> = monad.strict {
+                try
+                    failwith "Exception in try-with not handled"
+                    ()
+                with _ -> () }
+            x
+        let _ = monadTransformer3layersTest4 () |> WriterT.run |> OptionT.run
+
         ()

--- a/tests/FSharpPlus.Tests/ComputationExpressions.fs
+++ b/tests/FSharpPlus.Tests/ComputationExpressions.fs
@@ -460,7 +460,7 @@ module ComputationExpressions =
         let _ = lazyMonadTest () |> Seq.toList
         
         let strictMonadTest () =
-            let x : list<unit> = monad {
+            let x : list<unit> = monad.strict {
                 try
                     failwith "Exception in try-with not handled"
                     ()

--- a/tests/FSharpPlus.Tests/ComputationExpressions.fs
+++ b/tests/FSharpPlus.Tests/ComputationExpressions.fs
@@ -446,8 +446,28 @@ module ComputationExpressions =
         let f = Writer.run e
         areEqual strictEffects (SideEffects.get ())
 
+
     [<Test>]
     let tryWithBlocks () =
+
+        let lazyMonadTest () =
+            let x : seq<unit> = monad {
+                try
+                    failwith "Exception in try-with not handled"
+                    ()
+                with _ -> () }
+            x
+        let _ = lazyMonadTest () |> Seq.toList
+        
+        let strictMonadTest () =
+            let x : list<unit> = monad {
+                try
+                    failwith "Exception in try-with not handled"
+                    ()
+                with _ -> () }
+            x
+        let _ = strictMonadTest ()  
+    
         let monadTransformer3layersTest1 () =
             let x: StateT<string, ReaderT<int, seq<(unit * string)>>> = monad {
                 try

--- a/tests/FSharpPlus.Tests/ComputationExpressions.fs
+++ b/tests/FSharpPlus.Tests/ComputationExpressions.fs
@@ -445,3 +445,23 @@ module ComputationExpressions =
         areEqual strictEffects (SideEffects.get ())
         let f = Writer.run e
         areEqual strictEffects (SideEffects.get ())
+
+    [<Test>]
+    let tryWithBlocks () =
+        let monadTransformer3layersTest1 () =
+            let x: StateT<string, ReaderT<int, seq<(unit * string)>>> = monad {
+                try
+                    failwith "Exception in try-with not handled"
+                    ()
+                with _ -> () }
+            x
+        let _ = ((monadTransformer3layersTest1 () |> StateT.run) "" |> ReaderT.run) 0 |> Seq.toList
+        
+        let monadTransformer3layersTest2 () =
+            let x: StateT<string, ReaderT<int, list<(unit * string)>>> = monad {
+                try
+                    failwith "Exception in try-with not handled"
+                    ()
+                with _ -> () }
+            x
+        let _ = ((monadTransformer3layersTest2 () |> StateT.run) "" |> ReaderT.run) 0

--- a/tests/FSharpPlus.Tests/ComputationExpressions.fs
+++ b/tests/FSharpPlus.Tests/ComputationExpressions.fs
@@ -532,7 +532,7 @@ module ComputationExpressions =
                 finally
                     SideEffects.add "Finally goes here" }
             x
-        let _ = lazyMonadTest () |> Seq.toList
+        let _ = try (lazyMonadTest () |> Seq.toList) with _ -> Unchecked.defaultof<_>
         areEqual ["Finally goes here"] (SideEffects.get ())
         
         let strictMonadTest () =
@@ -544,7 +544,7 @@ module ComputationExpressions =
                 finally
                     SideEffects.add "Finally goes here" }
             x
-        let _ = strictMonadTest ()
+        let _ = try (strictMonadTest ()) with _ -> Unchecked.defaultof<_>
         areEqual ["Finally goes here"] (SideEffects.get ())
 
         ()

--- a/tests/FSharpPlus.Tests/ComputationExpressions.fs
+++ b/tests/FSharpPlus.Tests/ComputationExpressions.fs
@@ -505,5 +505,16 @@ module ComputationExpressions =
                 with _ -> () }
             x
         let _ = monadTransformer3layersTest4 () |> WriterT.run |> OptionT.run
+        
+
+        // ContT doesn't deal with the inner monad, so we don't need to do anything.
+        let contTTest () =
+            let x: ContT<list<unit>,unit> = monad {
+                try
+                    failwith "Exception in try-with not handled"
+                    ()
+                with _ -> () }
+            x
+        let _ = (contTTest () |> ContT.run) result        
 
         ()

--- a/tests/FSharpPlus.Tests/ComputationExpressions.fs
+++ b/tests/FSharpPlus.Tests/ComputationExpressions.fs
@@ -518,3 +518,29 @@ module ComputationExpressions =
         let _ = (contTTest () |> ContT.run) result        
 
         ()
+
+
+    [<Test>]
+    let tryFinallyBlocks () =
+
+        let lazyMonadTest () =
+            SideEffects.reset ()
+            let x : seq<unit> = monad {
+                try
+                    failwith "Exception in try-finally"
+                    ()
+                finally _ -> SideEffects.add "Finally goes here" }
+            x
+        let _ = lazyMonadTest () |> Seq.toList
+        areEqual ["Finally goes here"] (SideEffects.get ())
+        
+        let strictMonadTest () =
+            SideEffects.reset ()
+            let x : list<unit> = monad {
+                try
+                    failwith "Exception in try-finally"
+                    ()
+                finally _ -> SideEffects.add "Finally goes here" }
+            x
+        let _ = strictMonadTest ()
+        areEqual ["Finally goes here"] (SideEffects.get ())

--- a/tests/FSharpPlus.Tests/ComputationExpressions.fs
+++ b/tests/FSharpPlus.Tests/ComputationExpressions.fs
@@ -529,7 +529,8 @@ module ComputationExpressions =
                 try
                     failwith "Exception in try-finally"
                     ()
-                finally _ -> SideEffects.add "Finally goes here" }
+                finally
+                    SideEffects.add "Finally goes here" }
             x
         let _ = lazyMonadTest () |> Seq.toList
         areEqual ["Finally goes here"] (SideEffects.get ())
@@ -540,7 +541,10 @@ module ComputationExpressions =
                 try
                     failwith "Exception in try-finally"
                     ()
-                finally _ -> SideEffects.add "Finally goes here" }
+                finally
+                    SideEffects.add "Finally goes here" }
             x
         let _ = strictMonadTest ()
         areEqual ["Finally goes here"] (SideEffects.get ())
+
+        ()


### PR DESCRIPTION
This will generate a compile error when attempting to use a try .. with construction inside a non-strict computation expression over a type that doesn't provide a `TryWith` implementation.

Same applies to `TryFinally`.

For reference: http://tryjoinads.org/docs/computations/monads.html

 _For monadic computations that encapsulate untracked F# effects, the members TryWith and TryFinally cannot be implemented in terms of other operations. They need to understand the structure of the computation, in order to wrap the appropriate call that actually runs the effects with try .. with or try .. finally._ 

It also fixes the behavior of lazy monad transformers by adding a special Invoker for them, which takes strict monad defaults into consideration, allowing the composition of lazy with strict monads, only in the case where all monads in the stack are strict, user will get the above compiler error. This is the correct behavior, since a monadic composition is strict only when all composed monads are strict.

This closes #346 and closes #137

- [x] Apply compiler error when the monad is not strict
- [x] Add another Invoker to be used within Monad Transformers
- [x] Upgrade State and Reader, add tests
- [x] See if we need to upgrade Cont, add tests
- [x] Do the same for `TryFinally`, check that Using doesn't break