### PR TITLE
Display warning for while loops inside lazy computation expressions for non-lazy types

### DIFF
--- a/src/FSharpPlus/Builders.fs
+++ b/src/FSharpPlus/Builders.fs
@@ -111,20 +111,22 @@ module Builders =
         member inline __.Zero () = Empty.Invoke ()                    : '``MonadPlus<'T>``
         member inline __.Combine (a: '``MonadPlus<'T>``, b) = a <|> b : '``MonadPlus<'T>``
 
-        member inline __.While (guard, body: '``MonadPlus<'T>``)      : '``MonadPlus<'T>`` =
-
+        member inline __.WhileImpl (guard, body: '``MonadPlus<'T>``)  : '``MonadPlus<'T>`` =
+            let rec fix () = Delay.Invoke (fun () -> if guard () then body <|> fix () else Empty.Invoke ())
+            fix ()
+        
+        member inline this.While (guard, body: '``MonadPlus<'T>``) : '``MonadPlus<'T>`` =
             // Check the type is lazy, otherwise display a warning.
             let __ ()  = TryWith.InvokeForWhile (Unchecked.defaultof<'``MonadPlus<'T>``>) (fun (_: exn) -> Unchecked.defaultof<'``MonadPlus<'T>``>) : '``MonadPlus<'T>``
 
-            let rec fix () = Delay.Invoke (fun () -> if guard () then body <|> fix () else Empty.Invoke ())
-            fix ()
+            this.WhileImpl (guard, body)
 
         member inline this.For (p: #seq<'T>, rest: 'T->'``MonadPlus<'U>``) : '``MonadPlus<'U>`` =
             let mutable isReallyDelayed = true
             Delay.Invoke (fun () -> isReallyDelayed <- false; Empty.Invoke () : '``MonadPlus<'U>``) |> ignore
             Using.Invoke (p.GetEnumerator () :> IDisposable) (fun enum ->
                 let enum = enum :?> IEnumerator<_>
-                if isReallyDelayed then this.While (enum.MoveNext, Delay.Invoke (fun () -> rest enum.Current))
+                if isReallyDelayed then this.WhileImpl (enum.MoveNext, Delay.Invoke (fun () -> rest enum.Current))
                 else this.strict.While (enum.MoveNext, fun () -> rest enum.Current))
 
     type MonadFxBuilder () =
@@ -147,22 +149,23 @@ module Builders =
 
         member inline __.Combine (a: '``Monad<unit>``, b) = a >>= (fun () -> b) : '``Monad<'T>``
         
-        member inline __.While (guard, body: '``Monad<unit>``)                  : '``Monad<unit>`` =
-
-            // Check the type is lazy, otherwise display a warning.
-            let __ ()  = TryWith.InvokeForWhile (Unchecked.defaultof<'``Monad<unit>``>) (fun (_: exn) -> Unchecked.defaultof<'``Monad<unit>``>) : '``Monad<unit>``
-
+        member inline __.WhileImpl (guard, body: '``Monad<unit>``) : '``Monad<unit>`` =
             let rec loop guard body =
                 if guard () then body >>= (fun () -> loop guard body)
                 else result ()
             loop guard body
+
+        member inline this.While (guard, body: '``Monad<unit>``) : '``Monad<unit>`` =
+            // Check the type is lazy, otherwise display a warning.
+            let __ ()  = TryWith.InvokeForWhile (Unchecked.defaultof<'``Monad<unit>``>) (fun (_: exn) -> Unchecked.defaultof<'``Monad<unit>``>) : '``Monad<unit>``
+            this.WhileImpl (guard, body)
 
         member inline this.For (p: #seq<'T>, rest: 'T->'``Monad<unit>``) : '``Monad<unit>``=
             let mutable isReallyDelayed = true
             Delay.Invoke (fun () -> isReallyDelayed <- false; Return.Invoke () : '``Monad<unit>``) |> ignore
             Using.Invoke (p.GetEnumerator () :> IDisposable) (fun enum ->
                 let enum = enum :?> IEnumerator<_>
-                if isReallyDelayed then this.While (enum.MoveNext, Delay.Invoke (fun () -> rest enum.Current))
+                if isReallyDelayed then this.WhileImpl (enum.MoveNext, Delay.Invoke (fun () -> rest enum.Current))
                 else this.strict.While (enum.MoveNext, fun () -> rest enum.Current))
 
 

--- a/src/FSharpPlus/Control/Monad.fs
+++ b/src/FSharpPlus/Control/Monad.fs
@@ -169,6 +169,7 @@ type Delay =
 module TryBlock =
     type True  = True
     type False = False
+    type While = While
 
     let [<Literal>]MessageTryWith = "Method TryWith not implemented. If the computation's type is not lazy use a strict monad by adding .strict, otherwise it should have a static member TryWith."
     let [<Literal>]CodeTryWith = 10708
@@ -176,11 +177,17 @@ module TryBlock =
     let [<Literal>]MessageTryFinally = "Method TryFinally not implemented. If the computation's type is not lazy use a strict monad by adding .strict, otherwise it should have a static member TryFinally."
     let [<Literal>]CodeTryFinally = 10709
 
+    let [<Literal>]MessageWhile = "This monad doesn't seem to be lazy or at least it doesn't have the try-with method implemented. Using a while loop can lead to runtime errors. Make sure this type is lazy, otherwise use a strict monad by adding .strict"
+    let [<Literal>]CodeWhile = 10710
+
 open TryBlock
 
 type TryWith =
     inherit Default1
 
+    [<CompilerMessage(MessageWhile  , CodeWhile  , IsError = false)>]
+    static member        TryWith (_:           unit -> '``Monad<'T>``, _:            exn -> '``Monad<'T>``, _: Default3, _defaults: While) = raise Internals.Errors.exnUnreachable
+    
     [<CompilerMessage(MessageTryWith, CodeTryWith, IsError = true)>]
     static member        TryWith (_:           unit -> '``Monad<'T>``, _:            exn -> '``Monad<'T>``, _: Default3, _defaults: False) = raise Internals.Errors.exnUnreachable
     static member        TryWith (computation: unit -> '``Monad<'T>``, catchHandler: exn -> '``Monad<'T>``, _: Default3, _defaults: True ) = try computation () with e -> catchHandler e
@@ -201,6 +208,10 @@ type TryWith =
     static member inline InvokeForStrict (source: unit ->'``Monad<'T>``) (f: exn -> '``Monad<'T>``) : '``Monad<'T>`` =
         let inline call (mthd: 'M, input: unit -> 'I, _output: 'R, h: exn -> 'I) = ((^M or ^I) : (static member TryWith : _*_*_*_ -> _) input, h, mthd, True)
         call (Unchecked.defaultof<TryWith>, source, Unchecked.defaultof<'``Monad<'T>``>, f)
+
+    static member inline InvokeForWhile (source: '``Monad<'T>``) (f: exn -> '``Monad<'T>``) : '``Monad<'T>`` =
+        let inline call (mthd: 'M, input: unit -> 'I, _output: 'R, h: exn -> 'I) = ((^M or ^I) : (static member TryWith : _*_*_*_ -> _) input, h, mthd, While)
+        call (Unchecked.defaultof<TryWith>, (fun () -> source), Unchecked.defaultof<'``Monad<'T>``>, f)
 
 
 type TryFinally =


### PR DESCRIPTION
With this PR we'll attempt to do as much as possible to help non-expert CE users to use generic CEs the right way.

**To recap:**

 - when using a generic CE we have to take into account whether the type involved is lazy or not. The default CE: `monad` is lazy. 
 - if we use a lazy CE with a strict type, bad things can happen, from runtime errors to infinite loops, but as long as we don't use any advanced construct (try block, using or while) everything should work fine in any case.

So, regarding the advanced constructs:

 - for loops have a run-time "auto-sense" feature that checks if the type is really lazy, if is not they call the strict version of the construct.
 - try blocks have a compile-time check, since a lazy monad needs to define them, if they are not present a compiler error tells about the problem and how to fix it.

Now while-loops are the trickiest ones, because as opposed to for-loops the body is directly an expression, not a function, so when used within a strict type but in a lazy CE which has the wrong delay signature, the body of the while will be evaluated eagerly when passed as a parameter to the While method, so no chance to the auto-sense stuff, not even to throw a nice run-time error.

Also, as opposed to try-blocks, the while method is not compulsory, actually is not customizable so far.

So, no chance to do run-time or compile-time checks here.

**The proposed solution**

In this PR, we will introduce a compile-time check inside the While function that checks whether the type has a `TryWith` static method, that would be our way to "guess" if it's a lazy monad or not. If it fails it will display a compile-time warning.

Here's the trickiest part: I think this should be good enough as all lazy monads implemented here have a corresponding `TryWith` implementation, so if you get the warning using one of those types, it is really the case of misusing the CE.

But, it could be the rare case, that a user defined its own lazy monad without a `TryWith` because he's not planning to use try blocks, note that `TryWith` is normally unrelated to while loops.

In this case the warning will display as well, but in this case we're talking about an advanced user, so he should be able to implement a basic `TryWith` just to get rid of the warning, or simply use a #nowarn "10710" directive.

**Conclusion**: with this PR we're leaning on the safe side of the story and it will complete the picture of no surprising non CE expert users of the library, on the other hand there is a small chance that it will generate a warning on a very specific situation an advanced user can eventually run into and force him to either ignore it or implement a `TryWith`.