### PR TITLE
Add type alias for non-empty collections and builder for NonEmptySeq

### DIFF
--- a/src/FSharpPlus/Data/NonEmptyList.fs
+++ b/src/FSharpPlus/Data/NonEmptyList.fs
@@ -33,6 +33,9 @@ type NonEmptyList<'t> = {Head: 't; Tail: 't list} with
     member this.Length = 1 + List.length this.Tail
 
 
+/// A type alias for NonEmptyList<'t>
+type nelist<'t> = NonEmptyList<'t>
+
 /// Basic operations on NonEmptyList
 [<RequireQualifiedAccess>]
 module NonEmptyList =
@@ -262,6 +265,7 @@ module NonEmptyListBuilder =
         member __.Delay expr = expr ()
         member __.Run (x: NonEmptyList<_>) = x
     let nel = NelBuilder ()
+    let nelist = NelBuilder ()
 
 [<AutoOpen>]
 module NonEmptyListBuilderExtensions =

--- a/src/FSharpPlus/Data/NonEmptyList.fs
+++ b/src/FSharpPlus/Data/NonEmptyList.fs
@@ -264,7 +264,10 @@ module NonEmptyListBuilder =
         member __.Yield x = x
         member __.Delay expr = expr ()
         member __.Run (x: NonEmptyList<_>) = x
+        
+    [<System.Obsolete("Use nelist instead.")>]
     let nel = NelBuilder ()
+    
     let nelist = NelBuilder ()
 
 [<AutoOpen>]

--- a/src/FSharpPlus/Data/NonEmptyMap.fs
+++ b/src/FSharpPlus/Data/NonEmptyMap.fs
@@ -33,12 +33,15 @@ type NonEmptyMap<[<EqualityConditionalOn>]'Key,[<EqualityConditionalOn;Compariso
       member x.Values = (x.Value :> IReadOnlyDictionary<_, _>).Values
       member x.ContainsKey key = x.ContainsKey key
 
+/// A type alias for NonEmptyMap<'Key,'Value>
+type nemap<'Key,'Value when 'Key : comparison> = NonEmptyMap<'Key,'Value>
+
 /// Basic operations on NonEmptyMap
 [<RequireQualifiedAccess>]
 module NonEmptyMap =
     /// <summary>Builds a non empty map.</summary>
-    let create (k, v) (rest: ('k * 'v) seq) : NonEmptyMap<_, _> =
-      { Value = Map.ofSeq rest |> Map.add k v }
+    let create (k, v) (rest: ('k * 'v) seq) : NonEmptyMap<_, _> = { Value = Map.ofSeq rest |> Map.add k v }
+
     /// <summary>Builds a non empty map with a single element.</summary>
     let singleton key value : NonEmptyMap<_, _> = { Value = Map.ofList [key, value] }
 

--- a/src/FSharpPlus/Data/NonEmptySeq.fs
+++ b/src/FSharpPlus/Data/NonEmptySeq.fs
@@ -30,6 +30,13 @@ module NonEmptySeq =
     /// <summary>Builds a non empty sequence.</summary>
     let create x xs = seq { yield x; yield! xs } |> unsafeOfSeq
     
+    /// Creates a NonEmptySeq range, containing at least the first element of the range
+    let (|..) starting ending = (if starting < ending then { starting .. ending } else Seq.singleton starting) |> unsafeOfSeq
+
+    /// Creates a NonEmptySeq range, containing at least the last element of the range
+    let (..|) starting ending = (if starting < ending then { starting .. ending } else Seq.singleton ending)   |> unsafeOfSeq
+    
+    
     /// <summary>Returns a new sequence that contains all pairings of elements from the first and second sequences.</summary>
     /// <param name="source1">The first sequence.</param>
     /// <param name="source2">The second sequence.</param>

--- a/src/FSharpPlus/Data/NonEmptySeq.fs
+++ b/src/FSharpPlus/Data/NonEmptySeq.fs
@@ -486,3 +486,14 @@ module NonEmptySeq =
     let replace (oldValue: NonEmptySeq<'T>) (newValue: NonEmptySeq<'T>) (source: NonEmptySeq<'T>) : NonEmptySeq<'T> =
         Seq.replace oldValue newValue source |> unsafeOfSeq
 
+
+[<AutoOpen>]
+module NonEmptySeqBuilder =
+    type NESeqBuilder () =
+        [<CompilerMessage("A NonEmptySeq doesn't support the Zero operation.", 708, IsError = true)>]
+        member __.Zero () = raise Internals.Errors.exnUnreachable
+        member __.Combine (a: NonEmptySeq<'T>, b) = NonEmptySeq.append a b
+        member __.Yield x = NonEmptySeq.singleton x
+        member __.Delay expr = expr () : NonEmptySeq<'T>
+
+    let neseq = NESeqBuilder ()

--- a/src/FSharpPlus/Data/NonEmptySeq.fs
+++ b/src/FSharpPlus/Data/NonEmptySeq.fs
@@ -11,6 +11,9 @@ type NonEmptySeq<'T> =
     inherit IEnumerable<'T>
     abstract member First: 'T
 
+/// A type alias for NonEmptySeq<'t>
+type neseq<'t> = NonEmptySeq<'t>
+
 module NonEmptySeq =
     let internal unsafeOfSeq (x: _ seq) =
         { new NonEmptySeq<_> with

--- a/src/FSharpPlus/Data/NonEmptySet.fs
+++ b/src/FSharpPlus/Data/NonEmptySet.fs
@@ -28,6 +28,9 @@ type NonEmptySet<[<EqualityConditionalOn>]'a when 'a: comparison> = private { Va
     member x.MinimumElement = x.Value.MinimumElement
     member x.MaximumElement = x.Value.MaximumElement
 
+/// A type alias for NonEmptySet<'t>
+type neset<'t when 't: comparison> = NonEmptySet<'t>
+
 /// Basic operations on NonEmptySet
 [<RequireQualifiedAccess>]
 module NonEmptySet =

--- a/tests/FSharpPlus.Tests/General.fs
+++ b/tests/FSharpPlus.Tests/General.fs
@@ -375,7 +375,7 @@ module Functor =
         SideEffects.reset ()
 
         // NonEmptyList<_> has Map but at the same time is a seq<_>
-        let testVal1 = map ((+) 1) (nel {10; 20; 30})
+        let testVal1 = map ((+) 1) (nelist {10; 20; 30})
         Assert.IsInstanceOf<Option<NonEmptyList<int>>> (Some testVal1)
 
         let testVal2 = map ((+) 1) ((ofSeq :seq<_*_> -> Dictionary<_,_>) (seq ["a", 1; "b", 2]))
@@ -1152,10 +1152,10 @@ module Traversable =
 
     [<Test>]
     let traversableForNonPrimitive () =
-        let nel = nel {Some 1}
-        let rs1  = traverse id nel
+        let nel = nelist { Some 1 }
+        let rs1 = traverse id nel
         Assert.IsInstanceOf<option<NonEmptyList<int>>> rs1
-        let rs2  = sequence nel
+        let rs2 = sequence nel
         Assert.IsInstanceOf<option<NonEmptyList<int>>> rs2
         let nem = NonEmptyMap.Create (("a", Some 1), ("b", Some 2), ("c", Some 3))
         let rs3 = traverse id nem
@@ -1164,6 +1164,11 @@ module Traversable =
         Assert.IsInstanceOf<option<NonEmptyMap<string, int>>> rs4
         let rs5 = traverse id (TestNonEmptyCollection.Create (Some 42))
         Assert.IsInstanceOf<option<NonEmptySeq<int>>> rs5
+        let nes = neseq { Some 1 }
+        let rs6 = traverse id nes
+        Assert.IsInstanceOf<option<NonEmptySeq<int>>> rs6
+        let rs7 = sequence nes
+        Assert.IsInstanceOf<option<NonEmptySeq<int>>> rs7
 
     let toOptions x = if x <> 4 then Some x       else None
     let toChoices x = if x <> 4 then Choice1Of2 x else Choice2Of2 "This is a failure"


### PR DESCRIPTION
This adds a type alias for all non empty collections and also a CE builder `NonEmptySeq` which will have the same identifier as its type alias.

The existing builder for `NonEmptyList` will match its type alias, aligning this way with `seq` (type alias and CE), the old `nel` remains available for backwards compatibility.

Finally this adds two range operators for non-empty sequences: `|..` and `..|`.

This will close #363 