### PR TITLE
Add IReadOnlyCollection to OfSeq, OfList, Map and Iter

### DIFF
--- a/src/FSharpPlus/Control/Collection.fs
+++ b/src/FSharpPlus/Control/Collection.fs
@@ -28,6 +28,7 @@ type OfSeq =
     static member        OfSeq ((x: seq<KeyValuePair<'k,'v>>, _: IDictionary<'k,'v>              ), _: Default3) = x |> Seq.map (|KeyValue|) |> dict
     static member        OfSeq ((x: seq<'k*'v>              , _: IDictionary                     ), _: Default3) = let d = Hashtable () in x |> Seq.iter d.Add; d :> IDictionary
     static member        OfSeq ((x: seq<KeyValuePair<'k,'v>>, _: IDictionary                     ), _: Default3) = let d = Hashtable () in x |> Seq.iter (function (KeyValue x) -> d.Add x); d :> IDictionary
+    static member        OfSeq ((x: seq<'t>                 , _: IReadOnlyCollection<'t>         ), _: Default3) = IReadOnlyCollection.ofSeq x
 
     static member inline OfSeq ((x: seq<'t>                 , _: 'F                              ), _: Default2) = let c = new 'F () in (Seq.iter (fun t -> ( ^F : (member Add : 't -> ^R) c, t) |> ignore) x); c
 
@@ -69,6 +70,7 @@ type OfList =
     static member        OfList ((x: list<KeyValuePair<'k,'v>>, _: IDictionary<'k,'v>              ), _: Default4) = x |> List.map (|KeyValue|) |> dict
     static member        OfList ((x: list<'k*'v>              , _: IDictionary                     ), _: Default4) = let d = Hashtable () in x |> List.iter d.Add; d :> IDictionary
     static member        OfList ((x: list<KeyValuePair<'k,'v>>, _: IDictionary                     ), _: Default4) = let d = Hashtable () in x |> List.iter (function (KeyValue x) -> d.Add x); d :> IDictionary
+    static member        OfList ((x: list<'t>                 , _: IReadOnlyCollection<'t>         ), _: Default4) = IReadOnlyCollection.ofSeq x
 
     static member inline OfList ((x: list<'t>                 , _: 'F                              ), _: Default2) = let c = new 'F () in (List.iter (fun t -> ( ^F : (member Add : 't -> ^R) c, t) |> ignore) x); c
 

--- a/src/FSharpPlus/Control/Functor.fs
+++ b/src/FSharpPlus/Control/Functor.fs
@@ -33,13 +33,14 @@ type Iterate =
                                 for l = 0 to Array4D.length4 x - 1 do
                                     action x.[i,j,k,l]
 
-    static member Iterate (x: Async<'T>            , action) = action (Async.RunSynchronously x) : unit
-    static member Iterate (x: Result<'T, 'E>       , action) = match x with Ok x         -> action x | _ -> ()
-    static member Iterate (x: Choice<'T, 'E>       , action) = match x with Choice1Of2 x -> action x | _ -> ()
-    static member Iterate (KeyValue(_: 'Key, x: 'T), action) = action x : unit
-    static member Iterate (x: Map<'Key,'T>         , action) = Map.iter (const' action) x 
-    static member Iterate (x: Dictionary<'Key, 'T> , action) = Seq.iter action x.Values
-    static member Iterate (x: _ ResizeArray        , action) = Seq.iter action x
+    static member Iterate (x: Async<'T>              , action) = action (Async.RunSynchronously x) : unit
+    static member Iterate (x: Result<'T, 'E>         , action) = match x with Ok x         -> action x | _ -> ()
+    static member Iterate (x: Choice<'T, 'E>         , action) = match x with Choice1Of2 x -> action x | _ -> ()
+    static member Iterate (KeyValue(_: 'Key, x: 'T)  , action) = action x : unit
+    static member Iterate (x: Map<'Key,'T>           , action) = Map.iter (const' action) x 
+    static member Iterate (x: Dictionary<'Key, 'T>   , action) = Seq.iter action x.Values
+    static member Iterate (x: IReadOnlyCollection<'T>, action) = IReadOnlyCollection.iter action x
+    static member Iterate (x: _ ResizeArray          , action) = Seq.iter action x
 
     // Restricted
     static member Iterate (x:string         , action) = String.iter action x
@@ -112,6 +113,7 @@ type Map with
     static member        Map ((x: IReadOnlyDictionary<_,_>, f: 'T->'U), _mthd: Default2) = IReadOnlyDictionary.map f x : IReadOnlyDictionary<'Key,_>
     static member        Map ((x: IObservable<'T>         , f: 'T->'U), _mthd: Default2) = Observable.map f x       : IObservable<'U>
     static member        Map ((x: Nullable<_>             , f: 'T->'U), _mthd: Default2) = Nullable.map f x         : Nullable<'U>
+    static member        Map ((x: IReadOnlyCollection<'T> , f: 'T->'U), _mthd: Default1) = IReadOnlyCollection.map f x : IReadOnlyCollection<'U>
     static member inline Map ((x: '``Functor<'T>``        , f: 'T->'U), _mthd: Default1) = Map.InvokeOnInstance f x : '``Functor<'U>``
     static member inline Map ((_: ^t when ^t: null and ^t: struct, _ ), _mthd: Default1) = ()
 

--- a/src/FSharpPlus/Control/Functor.fs
+++ b/src/FSharpPlus/Control/Functor.fs
@@ -33,14 +33,13 @@ type Iterate =
                                 for l = 0 to Array4D.length4 x - 1 do
                                     action x.[i,j,k,l]
 
-    static member Iterate (x: Async<'T>              , action) = action (Async.RunSynchronously x) : unit
-    static member Iterate (x: Result<'T, 'E>         , action) = match x with Ok x         -> action x | _ -> ()
-    static member Iterate (x: Choice<'T, 'E>         , action) = match x with Choice1Of2 x -> action x | _ -> ()
-    static member Iterate (KeyValue(_: 'Key, x: 'T)  , action) = action x : unit
-    static member Iterate (x: Map<'Key,'T>           , action) = Map.iter (const' action) x 
-    static member Iterate (x: Dictionary<'Key, 'T>   , action) = Seq.iter action x.Values
-    static member Iterate (x: IReadOnlyCollection<'T>, action) = IReadOnlyCollection.iter action x
-    static member Iterate (x: _ ResizeArray          , action) = Seq.iter action x
+    static member Iterate (x: Async<'T>            , action) = action (Async.RunSynchronously x) : unit
+    static member Iterate (x: Result<'T, 'E>       , action) = match x with Ok x         -> action x | _ -> ()
+    static member Iterate (x: Choice<'T, 'E>       , action) = match x with Choice1Of2 x -> action x | _ -> ()
+    static member Iterate (KeyValue(_: 'Key, x: 'T), action) = action x : unit
+    static member Iterate (x: Map<'Key,'T>         , action) = Map.iter (const' action) x 
+    static member Iterate (x: Dictionary<'Key, 'T> , action) = Seq.iter action x.Values
+    static member Iterate (x: _ ResizeArray        , action) = Seq.iter action x
 
     // Restricted
     static member Iterate (x:string         , action) = String.iter action x

--- a/src/FSharpPlus/Extensions/IReadOnlyCollection.fs
+++ b/src/FSharpPlus/Extensions/IReadOnlyCollection.fs
@@ -8,4 +8,5 @@ module IReadOnlyCollection =
     let ofArray (source: 'T[]   ) = source                :> IReadOnlyCollection<'T>
     let ofList  (source: 'T list) = source                :> IReadOnlyCollection<'T>
     let ofSeq   (source: seq<'T>) = source |> Array.ofSeq :> IReadOnlyCollection<'T>
-    let map mapping (source: IReadOnlyCollection<'T>) = Seq.map mapping source |> Seq.toArray :> IReadOnlyCollection<'U>
+    let map  mapping (source: IReadOnlyCollection<'T>) = Seq.map  mapping source |> Seq.toArray :> IReadOnlyCollection<'U>
+    let iter mapping (source: IReadOnlyCollection<'T>) = Seq.iter mapping source

--- a/tests/FSharpPlus.Tests/General.fs
+++ b/tests/FSharpPlus.Tests/General.fs
@@ -416,6 +416,9 @@ module Functor =
         Assert.AreEqual (["Using TestNonEmptyCollection's Head"], SideEffects.get ())
         let testVal8 = testVal7 >>= fun i -> result (string i)
         Assert.IsInstanceOf<Option<NonEmptySeq<string>>> (Some testVal8)
+        
+        let testVal9 = map ((+) 1) (IReadOnlyCollection.ofList [1..3])
+        Assert.IsInstanceOf<Option<IReadOnlyCollection<int>>> (Some testVal9)
 
     [<Test>]
     let unzip () = 
@@ -535,6 +538,7 @@ module Collections =
         let _d: Generic.IDictionary<_,_>  = ofSeq (seq [KeyValuePair(1, "One"); KeyValuePair(2, "Two")])
         let r : IReadOnlyDictionary<_,_>  = ofSeq (seq [("One", 1)])             // but it will come back as ...
         let _r: IReadOnlyDictionary<_,_>  = ofSeq (seq [KeyValuePair(1, "One"); KeyValuePair(2, "Two")])
+        let rc: IReadOnlyCollection<_>    = ofSeq (seq [2..7])
         let ut: Hashtable                 = ofSeq (seq [1,'1';2, '2';3,'3'])     // but it will come back as seq<obj>
         let al: ArrayList                 = ofSeq (seq ["1";"2";"3"])            // but it will come back as seq<obj>
         let us: SortedList                = ofSeq (seq [4,'2';3,'4'])            // but it will come back as seq<obj>
@@ -562,6 +566,7 @@ module Collections =
         let _mp'  = toSeq mp 
         let _d'   = toSeq d  
         let _r'   = toSeq r
+        let _rc'  = toSeq rc
         let _ut'  = toSeq ut 
         let _al'  = toSeq al 
         let _us'  = toSeq us 
@@ -611,6 +616,7 @@ module Collections =
         let _d: Generic.IDictionary<_,_>  = ofList ([KeyValuePair(1, "One"); KeyValuePair(2, "Two")])
         let r : IReadOnlyDictionary<_,_>  = ofList ([("One", 1)])             // but it will come back as ...
         let _r: IReadOnlyDictionary<_,_>  = ofList ([KeyValuePair(1, "One"); KeyValuePair(2, "Two")])
+        let rc: IReadOnlyCollection<_>    = ofList ([2..5])
         let ut: Hashtable                 = ofList ([1,'1';2, '2';3,'3'])     // but it will come back as seq<obj>
         let al: ArrayList                 = ofList (["1";"2";"3"])            // but it will come back as seq<obj>
         let us: SortedList                = ofList ([4,'2';3,'4'])            // but it will come back as seq<obj>
@@ -638,6 +644,7 @@ module Collections =
         let _mp'  = toList mp
         let _d'   = toList d
         let _r'   = toList r
+        let _rc'  = toList rc
         let _ut'  = toList ut
         let _al'  = toList al
         let _us'  = toList us


### PR DESCRIPTION
Recently I've been using F#+ to interop with some C# stuff, and I came across the IReadonlyCollection case.
It was described in RFC: https://github.com/fsprojects/FSharpPlus/issues/109
The conclusion was, that PRs that introduce ReadOnly methods will be accepted.

I've introduced IReadOnlyCollection in OfSeq, OfList, Map and Iter