### PR TITLE
Quotation Monad

### DIFF
--- a/src/FSharpPlus/Control/Monad.fs
+++ b/src/FSharpPlus/Control/Monad.fs
@@ -35,6 +35,8 @@ type Bind =
     static member        (>>=) (source             , k: 'T -> _           ) = Result.bind k source                                          : Result<'U,'E>
     static member        (>>=) (source             , k: 'T -> _           ) = Choice.bind k source                                          : Choice<'U,'E>
 
+    static member        (>>=) (source: Expr<'T>   , f: 'T -> Expr<'U>    ) = Expr.bind f source                                            : Expr<'U>
+
     static member (>>=) (source: Map<'Key,'T>, f: 'T -> Map<'Key,'U>) = Map (seq {
                    for KeyValue(k, v) in source do
                        match Map.tryFind k (f v) with
@@ -158,7 +160,7 @@ type Delay =
     static member        Delay (_mthd: Default2, x: unit-> 'R -> _                                        , _          ) = (fun s -> x () s): 'R -> _
     static member        Delay (_mthd: Delay   , x: unit-> _                                              , _          ) = async.Delay x    : Async<'T>
     static member        Delay (_mthd: Delay   , x: unit-> Lazy<_>                                        , _          ) = lazy (x().Value) : Lazy<'T>
-    
+    static member        Delay (_mthd: Delay   , x: unit-> Expr<_>                                        , _          ) = Expr.bind x (Return.Invoke ()) : Expr<'T>
 
     static member inline Invoke source : 'R =
         let inline call (mthd: ^M, input: unit -> ^I) = ((^M or ^I) : (static member Delay : _*_*_ -> _) mthd, input, Unchecked.defaultof<Delay>)

--- a/src/FSharpPlus/Extensions/Expr.fs
+++ b/src/FSharpPlus/Extensions/Expr.fs
@@ -1,0 +1,36 @@
+﻿namespace FSharpPlus
+
+/// Additional operations on Quotations.Expr
+[<RequireQualifiedAccess>]
+module Expr =
+    
+    open System
+    open Microsoft.FSharp.Quotations
+    open Microsoft.FSharp.Quotations.Patterns
+    open Microsoft.FSharp.Quotations.ExprShape
+
+    let [<Literal>] private fsNamespace = "Microsoft.FSharp.Core"
+
+    let [<Literal>] private opSliceName = "SpliceExpression"
+    let [<Literal>] private opSliceType = "ExtraTopLevelOperators"
+
+    let private fsCoreAs = AppDomain.CurrentDomain.GetAssemblies () |> Seq.find (fun a -> a.GetName().Name = "FSharp.Core")
+    let private miSplice = fsCoreAs.GetType(fsNamespace + "." + opSliceType).GetMethod opSliceName
+        
+    let bind (f: 'T -> Expr<'U>) (x: Expr<'T>) : Expr<'U> =
+        Expr.Coerce (Expr.Call (miSplice.MakeGenericMethod typeof<'U>, [Expr.Application (Expr.Value f, x)]), typeof<'U>)
+        |> Expr.Cast
+
+    let rec runWithUntyped (eval: Expr -> obj) (exp: Expr) s =
+        let m = if isNull s then let x = Reflection.MethodInfo.GetCurrentMethod () in x.DeclaringType.GetMethod x.Name else s
+        let rec subsExpr = function
+            | Call (None, mi, exprLst) 
+                when (mi.Name, mi.DeclaringType.Name, mi.DeclaringType.Namespace) = (opSliceName, opSliceType, fsNamespace)
+                -> Expr.Call (m, [Expr.Value eval; subsExpr exprLst.Head; Expr.Value m])
+            | ShapeVar var                        -> Expr.Var var
+            | ShapeLambda (var, expr)             -> Expr.Lambda (var, subsExpr expr)
+            | ShapeCombination (shpComb, exprLst) -> RebuildShapeCombination (shpComb, List.map subsExpr exprLst)
+        eval (subsExpr exp)
+    
+    /// Executes quoted expression, given a quotation evaluator function.
+    let run (eval: Expr -> obj) (exp: Expr<'T>) : 'T = runWithUntyped eval exp.Raw null :?> 'T

--- a/src/FSharpPlus/FSharpPlus.fsproj
+++ b/src/FSharpPlus/FSharpPlus.fsproj
@@ -47,6 +47,7 @@
     <Compile Include="Extensions/Task.fs" />
     <Compile Include="Extensions/Async.fs" />
     <Compile Include="Extensions/Extensions.fs" />
+    <Compile Include="Extensions/Expr.fs" />
     <Compile Include="Extensions/Tuple.fs" />
     <Compile Include="TypeLevel/TypeLevelOperators.fs" />
     <Compile Include="TypeLevel/TypeBool.fs" />

--- a/tests/FSharpPlus.Tests/Expr.fs
+++ b/tests/FSharpPlus.Tests/Expr.fs
@@ -1,0 +1,31 @@
+﻿namespace FSharpPlus.Tests
+
+open System
+open NUnit.Framework
+open FSharpPlus
+open FSharpPlus.Tests.Helpers
+
+module Expr =
+
+    let ``Simple quotation combination`` evaluator =
+        let one = <@ 1 @>
+        let add10AndToString x =
+            let a = string (x + 10)
+            <@ a @>
+
+        let expr = one >>= add10AndToString
+        let res = Expr.run evaluator expr
+
+        areEqual "11" res
+
+    [<Test>]
+    let ``Simple quotation combination (QuotationEvaluator)`` () =
+        ``Simple quotation combination`` FSharp.Quotations.Evaluator.QuotationEvaluator.EvaluateUntyped
+
+    [<Test>]
+    let ``Simple quotation combination (Unquote)`` () =
+        ``Simple quotation combination`` Swensen.Unquote.Operators.evalRaw
+    
+    [<Test>]
+    let ``Simple quotation combination (PowerPack)`` () =
+        ``Simple quotation combination`` Microsoft.FSharp.Linq.QuotationEvaluator.EvaluateUntyped 

--- a/tests/FSharpPlus.Tests/FSharpPlus.Tests.fsproj
+++ b/tests/FSharpPlus.Tests/FSharpPlus.Tests.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="General.fs" />
     <Compile Include="Validations.fs" />
     <Compile Include="Free.fs" />
+    <Compile Include="Expr.fs" />
     <Compile Include="ComputationExpressions.fs" />
     <Compile Include="Lens.fs" />
     <Compile Include="Extensions.fs" />
@@ -32,12 +33,19 @@
     <ProjectReference Include="..\CSharpLib\CSharpLib.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="FSPowerPack.Linq.Community" Version="3.0.0" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />
+    <PackageReference Include="Unquote" Version="5.0.0" />
     <PackageReference Update="FSharp.Core" Version="4.6.2" />
     <PackageReference Include="MathNet.Numerics.FSharp" Version="4.8.1" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="FsCheck" Version="2.14" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <PackageReference Include="FSharp.Quotations.Evaluator">
+      <Version>2.1.0</Version>
+    </PackageReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This will implement #44 

A quotation monad allow us to compose function returning expressions.

At the end of the composition we get a single expression, internally containing markers where an evaluate function needs to run  a sub-expression.

Since F# doesn't support the "run" expression, we can't directly run this expressions in existing quotation evaluators, but we include an `Expr.run` function which takes any normal quotation evaluator and takes care of handling the internal marker. So, instead of doing `evaluator expr` we do `Expr.run evaluator expr`.