### PR TITLE
+ String.tryHead and tryLast, test tryHead, simplify

### DIFF
--- a/src/FSharpPlus/Control/Foldable.fs
+++ b/src/FSharpPlus/Control/Foldable.fs
@@ -243,17 +243,16 @@ type Head =
         let inline call (a: 'a, b: 'b) = call_2 (a, b)
         call (Unchecked.defaultof<Head>, source) : 'T
 
-
 type TryHead =
     inherit Default1
-    static member inline TryHead (x               , [<Optional>]_impl: Default1) = let x = ToSeq.Invoke x in if Seq.isEmpty x then None else Some (Seq.head x) : 'T option  
-    static member        TryHead (x: 't list      , [<Optional>]_impl: TryHead ) = match x with [] -> None | _ -> Some (List.head x)
-    static member        TryHead (x: 't []        , [<Optional>]_impl: TryHead ) = if Array.length x = 0 then None else Some x.[0]
+    static member inline TryHead (x               , [<Optional>]_impl: Default1) = Seq.tryHead <| ToSeq.Invoke x
+    static member        TryHead (x: 't list      , [<Optional>]_impl: TryHead ) = List.tryHead x
+    static member        TryHead (x: 't []        , [<Optional>]_impl: TryHead ) = Array.tryHead x
     static member        TryHead (x: NonEmptySeq<'T>,[<Optional>]_impl: TryHead) = Some x.First
     static member        TryHead (x: Id<'T>       , [<Optional>]_impl: TryHead ) = Some x.getValue
-    static member        TryHead (x: string       , [<Optional>]_impl: TryHead ) = if String.length x = 0 then None else Some x.[0]   
+    static member        TryHead (x: string       , [<Optional>]_impl: TryHead ) = String.tryHead x 
     static member        TryHead (x: StringBuilder, [<Optional>]_impl: TryHead ) = if x.Length = 0 then None else Some (x.ToString().[0])
-    static member        TryHead (x: 't seq       , [<Optional>]_impl: TryHead ) = if Seq.isEmpty x then None else Some (Seq.head x)
+    static member        TryHead (x: 't seq       , [<Optional>]_impl: TryHead ) = Seq.tryHead x
 
     static member inline Invoke (source: '``Foldable'<T>``)        =
         let inline call_2 (a: ^a, b: ^b) = ((^a or ^b) : (static member TryHead : _*_ -> _) b, a)
@@ -267,7 +266,7 @@ type TryLast =
     static member        TryLast (x: 't []          , [<Optional>]_impl: TryLast)  = Array.tryLast x
     static member        TryLast (x: NonEmptySeq<'T>, [<Optional>]_impl: TryLast)  = Some <| Seq.last x
     static member        TryLast (x: Id<'T>         , [<Optional>]_impl: TryLast ) = Some x.getValue
-    static member        TryLast (x: string         , [<Optional>]_impl: TryLast ) = if String.length x = 0 then None else Some x.[String.length x - 1]
+    static member        TryLast (x: string         , [<Optional>]_impl: TryLast ) = String.tryLast x 
     static member        TryLast (x: StringBuilder  , [<Optional>]_impl: TryLast ) = if x.Length = 0 then None else Some (x.ToString().[x.Length - 1])
     static member        TryLast (x: 't seq         , [<Optional>]_impl: TryLast ) = Seq.tryLast x
 

--- a/src/FSharpPlus/Extensions/String.fs
+++ b/src/FSharpPlus/Extensions/String.fs
@@ -159,6 +159,17 @@ module String =
             if i = 0 then ""
             else source |> skip i
 
+    /// <summary>Gets the first char of the string, or
+    /// <c>None</c> if the string is empty.</summary>
+    let tryHead (source: string) =
+        if String.length source = 0 then None else Some source.[0]
+
+    /// <summary>Gets the last char of the string, or
+    /// <c>None</c> if the string is empty.</summary>
+    let tryLast (source: string) =
+        let length = String.length source
+        if length = 0 then None else Some source.[length-1]
+
     /// Returns a string that has at most N characters from the beginning of the original string.
     /// It returns the original string if it is shorter than count.
     let truncate count (source: string) =

--- a/tests/FSharpPlus.Tests/General.fs
+++ b/tests/FSharpPlus.Tests/General.fs
@@ -886,6 +886,37 @@ module Foldable =
         ()
 
     [<Test>]
+    let tryHead () =
+        let s                = tryHead <| seq [1;2]
+        let s': int option   = tryHead <| seq []
+        areEqual s (Some 1)
+        areEqual s' None
+
+        let l                = tryHead [1;2;3]
+        let l': int option   = tryHead []
+        areEqual l (Some 1)
+        areEqual l' None
+
+        let a                = tryHead [|1|]
+        let a': int option   = tryHead [||]
+        areEqual a (Some 1)
+        areEqual a' None
+
+        let nes              = tryHead <| NonEmptySeq.ofList [1;2]
+        areEqual nes (Some 1)
+
+        let str                = tryHead "string"
+        let str': char option  = tryHead ""
+        areEqual str (Some 's')
+        areEqual str' None
+
+        let sb               = tryHead (System.Text.StringBuilder("string"))
+        let sb'              = tryHead (System.Text.StringBuilder())
+        areEqual sb (Some 's')
+        areEqual sb' None
+        ()
+
+    [<Test>]
     let tryLast () =
         let s                = tryLast <| seq [1;2]
         let s': int option   = tryLast <| seq []


### PR DESCRIPTION
Add `tryHead` and `tryLast` to String.
Add tests to generic tryHead and simplify it using FSharp.Core instead of hand-written implementation.