### PR TITLE
Inverted length comparison in String.drop

### DIFF
--- a/src/FSharpPlus/Extensions/String.fs
+++ b/src/FSharpPlus/Extensions/String.fs
@@ -181,7 +181,7 @@ module String =
     /// When count exceeds the length of the string it returns an empty string.
     let drop count (source: string) =
         if count < 1 then source
-        else if String.length source >= count then String.Empty
+        else if String.length source <= count then String.Empty
         else skip count source
 
     /// Finds the first index of the char in the substring which satisfies the given predicate.


### PR DESCRIPTION
`String.drop` is a safe version of `String.skip`, which intends to protect a call to `String.skip` with arguments which would cause an exception, and instead return an empty string.

However, the comparison of the length of the input string with the number of characters to drop is inverted. When it would be safe to drop the requested number of characters from the input string, `String.drop` will instead return an empty string; and when the requested number of characters exceeds the length of the input string, `String.drop` will cause the exception from `String.skip`.

The solution is to invert the comparison.