### PR TITLE
+ `yield!` to monad.plus

### DIFF
--- a/src/FSharpPlus/Builders.fs
+++ b/src/FSharpPlus/Builders.fs
@@ -85,6 +85,7 @@ module Builders =
 
     type MonadPlusStrictBuilder () =
         inherit StrictBuilder ()
+        member        __.YieldFrom  (expr) = expr                        : '``Monad<'T>``
         member inline __.Zero () = Empty.Invoke ()                       : '``MonadPlus<'T>``
         member inline __.Combine (a: '``MonadPlus<'T>``, b) = a <|> b () : '``MonadPlus<'T>``
         member inline __.While (guard, body: unit -> '``MonadPlus<'T>``) : '``MonadPlus<'T>`` =
@@ -115,6 +116,7 @@ module Builders =
 
     type MonadPlusBuilder () =
         inherit DelayedBuilder()
+        member        __.YieldFrom  (expr) = expr                     : '``Monad<'T>``
         member        __.strict = new MonadPlusStrictBuilder ()
         member inline __.Zero () = Empty.Invoke ()                    : '``MonadPlus<'T>``
         member inline __.Combine (a: '``MonadPlus<'T>``, b) = a <|> b : '``MonadPlus<'T>``

--- a/tests/FSharpPlus.Tests/ComputationExpressions.fs
+++ b/tests/FSharpPlus.Tests/ComputationExpressions.fs
@@ -78,6 +78,23 @@ module ComputationExpressions =
         // Check the result
         areEquivalent [42] seqValue
 
+    open FsCheck
+
+    [<Test>]
+    let monadPlusReturnAndYieldEquality () =
+        let yieldFromEqualsReturnFrom (l1: int list, l2: int list) =
+            let r1 = monad.plus { yield!  l1; yield!  l2 }
+            let r2 = monad.plus { return! l1; return! l2 }
+            r1 = r2
+
+        Check.QuickThrowOnFailure yieldFromEqualsReturnFrom
+
+        let yieldsEqualsReturns (l1: int list, i1: int, i2: int) =
+            let r1 = monad.plus { yield  i1; yield!  l1; yield  i2 }
+            let r2 = monad.plus { return i1; return! l1; return i2 }
+            r1 = r2
+
+        Check.QuickThrowOnFailure yieldsEqualsReturns
 
     [<Test>]
     let delayedMonadTransformers() =


### PR DESCRIPTION
Added `yield!` operator to monad.plus, so that yield behavior is consistent with return behavior and with FSharp.Core collections expressions.