### PR TITLE
Fix short-circuiting Traverse

### DIFF
--- a/src/FSharpPlus/Control/Traversable.fs
+++ b/src/FSharpPlus/Control/Traversable.fs
@@ -22,7 +22,7 @@ type Sequence =
         let mutable go = true
         let mutable r = result []
         use e = t.GetEnumerator ()
-        while go && e.MoveNext () && do
+        while go && e.MoveNext () do
             if isFailure e.Current then go <- false
             r <- Map.Invoke add r <*> e.Current
         Map.Invoke (List.rev >> conversion) r

--- a/src/FSharpPlus/Control/Traversable.fs
+++ b/src/FSharpPlus/Control/Traversable.fs
@@ -24,7 +24,7 @@ type Sequence =
         use e = t.GetEnumerator ()
         while go && e.MoveNext () do
             if isFailure e.Current then go <- false
-            else r <- Map.Invoke add r <*> e.Current
+            r <- Map.Invoke add r <*> e.Current
         Map.Invoke (List.rev >> conversion) r
     
 
@@ -135,7 +135,7 @@ type Sequence with
     static member inline Sequence (t: ^a                , [<Optional>]_output: 'R                 , [<Optional>]_impl: Default1) = Sequence.InvokeOnInstance t                                               : 'R
 
     static member inline Sequence (t: option<_>         , [<Optional>]_output: 'R                 , [<Optional>]_impl: Sequence) = match t with Some x -> Map.Invoke Some x | _ -> result None               : 'R
-    static member inline Sequence (t: list<_>           , [<Optional>]_output: 'R                 , [<Optional>]_impl: Sequence) = Sequence.ForInfiniteSequences(t, const' false, id) : 'R
+    static member inline Sequence (t: list<_>           , [<Optional>]_output: 'R                 , [<Optional>]_impl: Sequence) = Sequence.ForInfiniteSequences(t, IsLeftZero.Invoke, id) : 'R
 
     static member inline Sequence (t: Map<_,_>          , [<Optional>]_output: 'R                 , [<Optional>]_impl: Sequence) : 'R =
        let insert_f k x ys = Map.Invoke (Map.add k) x <*> ys
@@ -151,7 +151,7 @@ type Sequence with
         | Choice1Of2 a -> Map.Invoke Choice<'T,'Error>.Choice1Of2 a
         | Choice2Of2 e -> Return.Invoke (Choice<'T,'Error>.Choice2Of2 e)
 
-    static member inline Sequence (t: _ []              , [<Optional>]_output: 'R                 , [<Optional>]_impl: Sequence) = Sequence.ForInfiniteSequences(t, const' false, Array.ofList) : 'R
+    static member inline Sequence (t: _ []              , [<Optional>]_output: 'R                 , [<Optional>]_impl: Sequence) = Sequence.ForInfiniteSequences(t, IsLeftZero.Invoke, Array.ofList) : 'R
  
     static member inline Sequence (t: Id<'``Functor<'T>``>         , [<Optional>]_output: '``Functor<Id<'T>>``          , [<Optional>]_impl: Sequence) = Traverse.Invoke id t : '``Functor<Id<'T>>``
  

--- a/src/FSharpPlus/Control/Traversable.fs
+++ b/src/FSharpPlus/Control/Traversable.fs
@@ -22,7 +22,7 @@ type Sequence =
         let mutable go = true
         let mutable r = result []
         use e = t.GetEnumerator ()
-        while e.MoveNext () && go do
+        while go && e.MoveNext () && do
             if isFailure e.Current then go <- false
             r <- Map.Invoke add r <*> e.Current
         Map.Invoke (List.rev >> conversion) r

--- a/src/FSharpPlus/Control/Traversable.fs
+++ b/src/FSharpPlus/Control/Traversable.fs
@@ -24,7 +24,7 @@ type Sequence =
         use e = t.GetEnumerator ()
         while go && e.MoveNext () do
             if isFailure e.Current then go <- false
-            r <- Map.Invoke add r <*> e.Current
+            else r <- Map.Invoke add r <*> e.Current
         Map.Invoke (List.rev >> conversion) r
     
 

--- a/tests/FSharpPlus.Tests/General.fs
+++ b/tests/FSharpPlus.Tests/General.fs
@@ -1352,26 +1352,26 @@ module Traversable =
         let b = sequence (Seq.initInfinite toOptions |> Seq.take 20 |> Seq.toList)
         let c = sequence (Seq.initInfinite toChoices |> Seq.take 20 |> Seq.toList)
         let d = sequence (Seq.initInfinite toLists   |> Seq.take 20 |> Seq.toList)
-        let e = sequence (Seq.initInfinite toEithers |> Seq.take 20 |> Seq.toList)
+        let e = sequence (Seq.initInfinite toEithers |> Seq.take 5 |> Seq.toList)
 
-        CollectionAssert.AreNotEqual (expectedEffects, SideEffects.get ())
+        CollectionAssert.AreEqual (expectedEffects, SideEffects.get ())
         SideEffects.reset ()
 
-        let f = sequence (Seq.initInfinite toEithers |> Seq.take 20 |> Seq.toArray)
+        let f = sequence (Seq.initInfinite toEithers |> Seq.take 5 |> Seq.toArray)
 
-        CollectionAssert.AreNotEqual (expectedEffects, SideEffects.get ())
+        CollectionAssert.AreEqual (expectedEffects, SideEffects.get ())
         SideEffects.reset ()
 
         let _a = traverse toOptions [1..20]
         let _b = traverse toOptions [1..20]
         let _c = traverse toChoices [1..20]
         let _d = traverse toLists   [1..20]
-        let _e = traverse toEithers [1..20]
+        let _e = traverse toEithers [1..4]
 
         CollectionAssert.AreNotEqual (expectedEffects, SideEffects.get ())
         SideEffects.reset ()
 
-        let _f = traverse toEithers [|1..20|]
+        let _f = traverse toEithers [|1..4|]
 
         CollectionAssert.AreNotEqual (expectedEffects, SideEffects.get ())
         Assert.AreEqual (None, a)

--- a/tests/FSharpPlus.Tests/General.fs
+++ b/tests/FSharpPlus.Tests/General.fs
@@ -1343,35 +1343,38 @@ module Traversable =
         Assert.AreEqual (Either<string list,NonEmptySeq<int>>.Left ["This is a failure"], e)
         
 
+    let toEithersStrict x =
+        if x = 4 then Left ["This is a failure"] else Right x
+
     [<Test>]
     let traverseFiniteApplicatives () = // TODO -> implement short-circuit without breaking anything else
 
         SideEffects.reset ()
 
-        let a = sequence (Seq.initInfinite toOptions |> Seq.take 20 |> Seq.toList)
-        let b = sequence (Seq.initInfinite toOptions |> Seq.take 20 |> Seq.toList)
-        let c = sequence (Seq.initInfinite toChoices |> Seq.take 20 |> Seq.toList)
-        let d = sequence (Seq.initInfinite toLists   |> Seq.take 20 |> Seq.toList)
-        let e = sequence (Seq.initInfinite toEithers |> Seq.take 5 |> Seq.toList)
+        let a = sequence (Seq.initInfinite toOptions       |> Seq.take 20 |> Seq.toList)
+        let b = sequence (Seq.initInfinite toOptions       |> Seq.take 20 |> Seq.toList)
+        let c = sequence (Seq.initInfinite toChoices       |> Seq.take 20 |> Seq.toList)
+        let d = sequence (Seq.initInfinite toLists         |> Seq.take 20 |> Seq.toList)
+        let e = sequence (Seq.initInfinite toEithersStrict |> Seq.take 20 |> Seq.toList)
 
         CollectionAssert.AreEqual (expectedEffects, SideEffects.get ())
         SideEffects.reset ()
 
-        let f = sequence (Seq.initInfinite toEithers |> Seq.take 5 |> Seq.toArray)
+        let f = sequence (Seq.initInfinite toEithersStrict |> Seq.take 5 |> Seq.toArray)
 
         CollectionAssert.AreEqual (expectedEffects, SideEffects.get ())
         SideEffects.reset ()
 
-        let _a = traverse toOptions [1..20]
-        let _b = traverse toOptions [1..20]
-        let _c = traverse toChoices [1..20]
-        let _d = traverse toLists   [1..20]
-        let _e = traverse toEithers [1..4]
+        let _a = traverse toOptions       [1..20]
+        let _b = traverse toOptions       [1..20]
+        let _c = traverse toChoices       [1..20]
+        let _d = traverse toLists         [1..20]
+        let _e = traverse toEithersStrict [1..20]
 
         CollectionAssert.AreNotEqual (expectedEffects, SideEffects.get ())
         SideEffects.reset ()
 
-        let _f = traverse toEithers [|1..4|]
+        let _f = traverse toEithersStrict [|1..20|]
 
         CollectionAssert.AreNotEqual (expectedEffects, SideEffects.get ())
         Assert.AreEqual (None, a)

--- a/tests/FSharpPlus.Tests/General.fs
+++ b/tests/FSharpPlus.Tests/General.fs
@@ -1279,7 +1279,7 @@ module Traversable =
     let toChoices x = if x <> 4 then Choice1Of2 x else Choice2Of2 "This is a failure"
     let toLists   x = if x <> 4 then [x; x]       else []
     let toEithers x =
-        if x > 4 then failwith "Shouldn't be mapping for %i" x
+        if x > 4 then failwithf "Shouldn't be mapping for %i" x
         if x = 4 then Left ["This is a failure"] else Right x
 
     let expectedEffects =

--- a/tests/FSharpPlus.Tests/General.fs
+++ b/tests/FSharpPlus.Tests/General.fs
@@ -1278,7 +1278,9 @@ module Traversable =
     let toOptions x = if x <> 4 then Some x       else None
     let toChoices x = if x <> 4 then Choice1Of2 x else Choice2Of2 "This is a failure"
     let toLists   x = if x <> 4 then [x; x]       else []
-    let toEithers x = if x <> 4 then Right x else Left ["This is a failure"]
+    let toEithers x =
+        if x > 4 then failwith "Shouldn't be mapping for %i" x
+        if x = 4 then Left ["This is a failure"] else Right x
 
     let expectedEffects =
         [

--- a/tests/FSharpPlus.Tests/General.fs
+++ b/tests/FSharpPlus.Tests/General.fs
@@ -1347,7 +1347,7 @@ module Traversable =
         if x = 4 then Left ["This is a failure"] else Right x
 
     [<Test>]
-    let traverseFiniteApplicatives () = // TODO -> implement short-circuit without breaking anything else
+    let traverseFiniteApplicatives () =
 
         SideEffects.reset ()
 
@@ -1360,7 +1360,7 @@ module Traversable =
         CollectionAssert.AreEqual (expectedEffects, SideEffects.get ())
         SideEffects.reset ()
 
-        let f = sequence (Seq.initInfinite toEithersStrict |> Seq.take 5 |> Seq.toArray)
+        let f = sequence (Seq.initInfinite toEithersStrict |> Seq.take 20 |> Seq.toArray)
 
         CollectionAssert.AreEqual (expectedEffects, SideEffects.get ())
         SideEffects.reset ()


### PR DESCRIPTION
This PR add short circuit for traversing non-lazy collections and also fixes mapping next element after short-circuiting lazy collections (solves #415), since right now it stops at the first error but maps over the next element after the error, which shouldn't be necessary.