### PR TITLE
Downgrade to net45

### DIFF
--- a/docsrc/content/abstraction-alternative.fsx
+++ b/docsrc/content/abstraction-alternative.fsx
@@ -77,7 +77,7 @@ Examples
 
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus
 

--- a/docsrc/content/abstraction-applicative.fsx
+++ b/docsrc/content/abstraction-applicative.fsx
@@ -110,7 +110,7 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus
 open FSharpPlus.Data

--- a/docsrc/content/abstraction-bifoldable.fsx
+++ b/docsrc/content/abstraction-bifoldable.fsx
@@ -94,7 +94,7 @@ Examples
 --------
 *)
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus
 open FSharpPlus.Control

--- a/docsrc/content/abstraction-bifunctor.fsx
+++ b/docsrc/content/abstraction-bifunctor.fsx
@@ -85,7 +85,7 @@ Examples
 
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus
 

--- a/docsrc/content/abstraction-bitraversable.fsx
+++ b/docsrc/content/abstraction-bitraversable.fsx
@@ -71,7 +71,7 @@ Examples
 
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus
 

--- a/docsrc/content/abstraction-comonad.fsx
+++ b/docsrc/content/abstraction-comonad.fsx
@@ -84,7 +84,7 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus
 open FSharpPlus.Data

--- a/docsrc/content/abstraction-contravariant.fsx
+++ b/docsrc/content/abstraction-contravariant.fsx
@@ -68,7 +68,7 @@ Examples
 
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open System
 open FSharpPlus

--- a/docsrc/content/abstraction-foldable.fsx
+++ b/docsrc/content/abstraction-foldable.fsx
@@ -81,7 +81,7 @@ Examples
 
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus
 open FSharpPlus.Data

--- a/docsrc/content/abstraction-functor.fsx
+++ b/docsrc/content/abstraction-functor.fsx
@@ -107,7 +107,7 @@ Examples
 
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus
 open FSharpPlus.Math.Generic

--- a/docsrc/content/abstraction-misc.fsx
+++ b/docsrc/content/abstraction-misc.fsx
@@ -17,7 +17,7 @@ Here are some other abstractions, not present in the diagram.
 
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open System
 open FSharpPlus

--- a/docsrc/content/abstraction-monad.fsx
+++ b/docsrc/content/abstraction-monad.fsx
@@ -107,7 +107,7 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus
 open FSharpPlus.Data

--- a/docsrc/content/abstraction-monoid.fsx
+++ b/docsrc/content/abstraction-monoid.fsx
@@ -94,7 +94,7 @@ Examples
 
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus
 open FSharpPlus.Math.Generic

--- a/docsrc/content/abstraction-profunctor.fsx
+++ b/docsrc/content/abstraction-profunctor.fsx
@@ -81,7 +81,7 @@ Examples
 
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open System
 open FSharpPlus

--- a/docsrc/content/abstraction-traversable.fsx
+++ b/docsrc/content/abstraction-traversable.fsx
@@ -77,7 +77,7 @@ Examples
 
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus
 

--- a/docsrc/content/applicative-functors.fsx
+++ b/docsrc/content/applicative-functors.fsx
@@ -9,7 +9,7 @@ Functors and Applicatives
 
 *)
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 open FSharpPlus
 
 (**

--- a/docsrc/content/computation-expressions.fsx
+++ b/docsrc/content/computation-expressions.fsx
@@ -63,7 +63,7 @@ You may run this script step-by-step.
 
 *)
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 open FSharpPlus
 
 let lazyValue = monad {

--- a/docsrc/content/extension-methods.fsx
+++ b/docsrc/content/extension-methods.fsx
@@ -3,7 +3,7 @@
 // it to define helpers that you do not want to show in the documentation.
 #I "../../bin"
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 open FSharpPlus
 
 (**

--- a/docsrc/content/extensions.fsx
+++ b/docsrc/content/extensions.fsx
@@ -2,7 +2,7 @@
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
 #I "../../bin"
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 (**
 Extensions

--- a/docsrc/content/generic-doc.fsx
+++ b/docsrc/content/generic-doc.fsx
@@ -3,7 +3,7 @@
 // it to define helpers that you do not want to show in the documentation.
 #I "../../bin"
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 open FSharpPlus
 
 (**

--- a/docsrc/content/index.fsx
+++ b/docsrc/content/index.fsx
@@ -54,7 +54,7 @@ Example 1
 This example demonstrates using an extension function defined in this library.
 
 *)
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 open FSharpPlus
 
 let x = String.replace "old" "new" "Good old days"

--- a/docsrc/content/lens.fsx
+++ b/docsrc/content/lens.fsx
@@ -3,7 +3,7 @@
 // it to define helpers that you do not want to show in the documentation.
 #I "../../bin"
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 (**
 Lens

--- a/docsrc/content/numerics.fsx
+++ b/docsrc/content/numerics.fsx
@@ -3,7 +3,7 @@
 // it to define helpers that you do not want to show in the documentation.
 #I "../../bin"
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 open FSharpPlus
 
 (**

--- a/docsrc/content/operators-common.fsx
+++ b/docsrc/content/operators-common.fsx
@@ -3,7 +3,7 @@
 // it to define helpers that you do not want to show in the documentation.
 #I "../../bin"
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 open FSharpPlus
 
 (**

--- a/docsrc/content/parsing.fsx
+++ b/docsrc/content/parsing.fsx
@@ -3,7 +3,7 @@
 // it to define helpers that you do not want to show in the documentation.
 #I "../../bin"
 open System
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 open FSharpPlus
 (**
 # Parsing

--- a/docsrc/content/tutorial.fsx
+++ b/docsrc/content/tutorial.fsx
@@ -13,7 +13,7 @@ Introducing FSharpPlus
 
 *)
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 open FSharpPlus
 
 (**

--- a/docsrc/content/type-all.fsx
+++ b/docsrc/content/type-all.fsx
@@ -27,7 +27,7 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus
 open FSharpPlus.Data

--- a/docsrc/content/type-any.fsx
+++ b/docsrc/content/type-any.fsx
@@ -27,7 +27,7 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus
 open FSharpPlus.Data

--- a/docsrc/content/type-choicet.fsx
+++ b/docsrc/content/type-choicet.fsx
@@ -12,6 +12,6 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus

--- a/docsrc/content/type-compose.fsx
+++ b/docsrc/content/type-compose.fsx
@@ -20,7 +20,7 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus
 open FSharpPlus.Data

--- a/docsrc/content/type-const.fsx
+++ b/docsrc/content/type-const.fsx
@@ -14,7 +14,7 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus
 open FSharpPlus.Lens

--- a/docsrc/content/type-cont.fsx
+++ b/docsrc/content/type-cont.fsx
@@ -21,7 +21,7 @@ In order to get an idea about this style, let us contrast some of the examples a
 
 *)
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus
 open FSharpPlus.Data

--- a/docsrc/content/type-contt.fsx
+++ b/docsrc/content/type-contt.fsx
@@ -12,6 +12,6 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus

--- a/docsrc/content/type-coproduct.fsx
+++ b/docsrc/content/type-coproduct.fsx
@@ -12,6 +12,6 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus

--- a/docsrc/content/type-dlist.fsx
+++ b/docsrc/content/type-dlist.fsx
@@ -17,7 +17,7 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus
 open FSharpPlus.Data

--- a/docsrc/content/type-dual.fsx
+++ b/docsrc/content/type-dual.fsx
@@ -12,6 +12,6 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus

--- a/docsrc/content/type-endo.fsx
+++ b/docsrc/content/type-endo.fsx
@@ -12,6 +12,6 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus

--- a/docsrc/content/type-first.fsx
+++ b/docsrc/content/type-first.fsx
@@ -12,6 +12,6 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus

--- a/docsrc/content/type-free.fsx
+++ b/docsrc/content/type-free.fsx
@@ -12,6 +12,6 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus

--- a/docsrc/content/type-identity.fsx
+++ b/docsrc/content/type-identity.fsx
@@ -12,6 +12,6 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus

--- a/docsrc/content/type-kleisli.fsx
+++ b/docsrc/content/type-kleisli.fsx
@@ -12,6 +12,6 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus

--- a/docsrc/content/type-last.fsx
+++ b/docsrc/content/type-last.fsx
@@ -12,6 +12,6 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus

--- a/docsrc/content/type-listt.fsx
+++ b/docsrc/content/type-listt.fsx
@@ -12,6 +12,6 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus

--- a/docsrc/content/type-matrix.fsx
+++ b/docsrc/content/type-matrix.fsx
@@ -32,7 +32,7 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus
 open FSharpPlus.Data

--- a/docsrc/content/type-mult.fsx
+++ b/docsrc/content/type-mult.fsx
@@ -12,6 +12,6 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus

--- a/docsrc/content/type-nonempty-map.fsx
+++ b/docsrc/content/type-nonempty-map.fsx
@@ -14,7 +14,7 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus
 open FSharpPlus.Data

--- a/docsrc/content/type-nonempty-set.fsx
+++ b/docsrc/content/type-nonempty-set.fsx
@@ -14,7 +14,7 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus
 open FSharpPlus.Data

--- a/docsrc/content/type-nonempty.fsx
+++ b/docsrc/content/type-nonempty.fsx
@@ -14,7 +14,7 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus
 open FSharpPlus.Data

--- a/docsrc/content/type-optiont.fsx
+++ b/docsrc/content/type-optiont.fsx
@@ -12,6 +12,6 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus

--- a/docsrc/content/type-parallelarray.fsx
+++ b/docsrc/content/type-parallelarray.fsx
@@ -17,7 +17,7 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus
 open FSharpPlus.Data

--- a/docsrc/content/type-reader.fsx
+++ b/docsrc/content/type-reader.fsx
@@ -19,7 +19,7 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 (**
 One usage of the Reader monad is an alternative to dependency injection or currying

--- a/docsrc/content/type-readert.fsx
+++ b/docsrc/content/type-readert.fsx
@@ -12,6 +12,6 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus

--- a/docsrc/content/type-resultt.fsx
+++ b/docsrc/content/type-resultt.fsx
@@ -12,6 +12,6 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus

--- a/docsrc/content/type-seqt.fsx
+++ b/docsrc/content/type-seqt.fsx
@@ -12,6 +12,6 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus

--- a/docsrc/content/type-state.fsx
+++ b/docsrc/content/type-state.fsx
@@ -19,7 +19,7 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus
 open FSharpPlus.Data

--- a/docsrc/content/type-statet.fsx
+++ b/docsrc/content/type-statet.fsx
@@ -12,6 +12,6 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus

--- a/docsrc/content/type-validation.fsx
+++ b/docsrc/content/type-validation.fsx
@@ -14,7 +14,7 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open System
 open FSharpPlus

--- a/docsrc/content/type-vector.fsx
+++ b/docsrc/content/type-vector.fsx
@@ -35,7 +35,7 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus
 open FSharpPlus.Data

--- a/docsrc/content/type-writer.fsx
+++ b/docsrc/content/type-writer.fsx
@@ -15,7 +15,7 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus
 open FSharpPlus.Data

--- a/docsrc/content/type-writert.fsx
+++ b/docsrc/content/type-writert.fsx
@@ -12,6 +12,6 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus

--- a/docsrc/content/type-ziplist.fsx
+++ b/docsrc/content/type-ziplist.fsx
@@ -14,7 +14,7 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open FSharpPlus
 open FSharpPlus.Data

--- a/docsrc/tools/Program.fs
+++ b/docsrc/tools/Program.fs
@@ -61,7 +61,7 @@ Target.create "Build" (fun _ ->
             OutputDirectory = output
             ProjectParameters =  ("root", root)::info
             Projects = rootDir @@ "src/FSharpPlus/FSharpPlus.fsproj"
-            TargetPath = rootDir @@ "src/FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+            TargetPath = rootDir @@ "src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
             SourceRepository = githubLink @@ "tree/master" }
            )
 )

--- a/docsrc/tools/manually_build_docs.sh
+++ b/docsrc/tools/manually_build_docs.sh
@@ -15,4 +15,4 @@ dotnet run --project ./docsrc/tools
 # dotnet run --project ./docsrc/tools ReleaseDocs
 
 # To run the documentation without going through docsrc/tools:
-# (export TargetPath=src/FSharpPlus/bin/Release/net46/FSharpPlus.dll ;dotnet fsdocs build --projects src/FSharpPlus/FSharpPlus.fsproj --input docsrc/content/ --output docs/)
+# (export TargetPath=src/FSharpPlus/bin/Release/net45/FSharpPlus.dll ;dotnet fsdocs build --projects src/FSharpPlus/FSharpPlus.fsproj --input docsrc/content/ --output docs/)

--- a/docsrc/tools/tools.fs
+++ b/docsrc/tools/tools.fs
@@ -5,7 +5,7 @@ let (</>) x y = IO.Path.Combine(x,y)
 
 module Path =
     // Paths with template/source/output locations
-    let bin        = __SOURCE_DIRECTORY__ </> "../../src/FSharpPlus/bin/Release/net46/"
+    let bin        = __SOURCE_DIRECTORY__ </> "../../src/FSharpPlus/bin/Release/net45/"
     let content    = __SOURCE_DIRECTORY__ </> "../content"
     let output     = __SOURCE_DIRECTORY__ </> "../../docs"
     let templates      = __SOURCE_DIRECTORY__ </> "./templates"

--- a/src/FSharpPlus.Docs/Samples/Collections.fsx
+++ b/src/FSharpPlus.Docs/Samples/Collections.fsx
@@ -1,5 +1,5 @@
 #if INTERACTIVE
-#r @"../../FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 #else
 module Samples.Collections
 #endif

--- a/src/FSharpPlus.Docs/Samples/Conversions.fsx
+++ b/src/FSharpPlus.Docs/Samples/Conversions.fsx
@@ -1,5 +1,5 @@
 #if INTERACTIVE
-#r @"../../FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 #else
 module Samples.Conversions
 #endif

--- a/src/FSharpPlus.Docs/Samples/Learn You a Haskell.fsx
+++ b/src/FSharpPlus.Docs/Samples/Learn You a Haskell.fsx
@@ -1,5 +1,5 @@
 #if INTERACTIVE
-#r @"../../FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 #else
 module Samples.Learn_You_a_Haskell
 #endif

--- a/src/FSharpPlus.Docs/Samples/Split-Join.fsx
+++ b/src/FSharpPlus.Docs/Samples/Split-Join.fsx
@@ -1,5 +1,5 @@
 #if INTERACTIVE
-#r @"../../FSharpPlus/bin/Release/net46/FSharpPlus.dll"
+#r @"../../FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 #else
 module Samples.SplitJoin
 #endif

--- a/src/FSharpPlus/FSharpPlus.fsproj
+++ b/src/FSharpPlus/FSharpPlus.fsproj
@@ -5,7 +5,7 @@
     <FscToolExe>$(FSC_ExePathCompilerBuild)</FscToolExe>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     <Title>FSharpPlus</Title>
     <AssemblyName>FSharpPlus</AssemblyName>
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
@@ -13,7 +13,7 @@
     <ProjectGuid>1368368e-d2f4-4fef-bb2f-492e05156e0f</ProjectGuid>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <OtherFlags Condition=" '$(TargetFramework)' == 'netstandard2.0'">--warnon:1182 $(OtherFlags)</OtherFlags>
-    <OtherFlags Condition=" '$(TargetFramework)' == 'net46'">--warnon:1182 $(OtherFlags)</OtherFlags>
+    <OtherFlags Condition=" '$(TargetFramework)' == 'net45'">--warnon:1182 $(OtherFlags)</OtherFlags>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
@@ -106,7 +106,7 @@
     <Compile Include="Data/Matrix.fs" />
     <Compile Include="Memoization.fs" />
     <Compile Include="Parsing.fs" />
-    <Content Condition=" '$(TargetFramework)' == 'net46'" Include="App.config" />
+    <Content Condition=" '$(TargetFramework)' == 'net45'" Include="App.config" />
   </ItemGroup>
 
   <!-- Add source files to "fable" folder in Nuget package - required for the library to be consumable by Fable -->
@@ -132,7 +132,7 @@
   </Target>
 
   <ItemGroup>
-    <Reference Condition=" '$(TargetFramework)' == 'net46'" Include="System.Runtime" />
+    <Reference Condition=" '$(TargetFramework)' == 'net45'" Include="System.Runtime" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="4.6.2" />

--- a/src/FSharpPlus/Providers/FSharpPlus.Providers.fsproj
+++ b/src/FSharpPlus/Providers/FSharpPlus.Providers.fsproj
@@ -5,7 +5,7 @@
     <FscToolExe>$(FSC_ExePathCompilerBuild)</FscToolExe>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     <Title>FSharpPlus.Providers</Title>
     <AssemblyName>FSharpPlus.Providers</AssemblyName>
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
@@ -38,7 +38,7 @@
     <Content Condition=" '$(TargetFramework)' == 'net46'" Include="../App.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Condition=" '$(TargetFramework)' == 'net46'" Include="System.Runtime" />
+    <Reference Condition=" '$(TargetFramework)' == 'net45'" Include="System.Runtime" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="4.6.2" />


### PR DESCRIPTION
In #420 we upgraded the project to net46 but only the tests required specific net46 constructs, so let's revert the project part before releasing anything with net46 requirements.