### PR TITLE
+ Internal error to Result.get

### DIFF
--- a/src/FSharpPlus/Extensions/Result.fs
+++ b/src/FSharpPlus/Extensions/Result.fs
@@ -73,7 +73,7 @@ module Result =
         | Ok x -> x
         | Error e ->
             match box e with
-            | :? string as s -> invalidArg "source" $"Result value was Error: {s}"
+            | :? string as s -> invalidArg "source" ("Result value was Error: " + s)
             | :? exn    as e -> raise <| System.ArgumentException ("Result value was Error", "source", e)
             | _              -> invalidArg "source" $"Result value was Error: {string e}"
 

--- a/src/FSharpPlus/Extensions/Result.fs
+++ b/src/FSharpPlus/Extensions/Result.fs
@@ -74,7 +74,7 @@ module Result =
         | Error e ->
             match box e with
             | :? exn as e -> raise <| System.ArgumentException ("Result value was Error", "source", e)
-            | _           -> invalidArg "source" ("Result value was Error: " + string e)
+            | e           -> invalidArg "source" ("Result value was Error: " + string e)
 
     /// Extracts the Ok value or use the supplied default value when it's an Error.
     let defaultValue (value:'T) (source: Result<'T,'Error>) : 'T = match source with Ok v -> v | _ -> value

--- a/src/FSharpPlus/Extensions/Result.fs
+++ b/src/FSharpPlus/Extensions/Result.fs
@@ -68,7 +68,14 @@ module Result =
         with e -> Error e
 
     /// Gets the 'Ok' value. If it's an 'Error' this function will throw an exception.
-    let get (source: Result<'T,'Error>) = match source with Ok x -> x | _ -> invalidArg "source" "Result value was Error"
+    let get (source: Result<'T,'Error>) =
+        match source with
+        | Ok x -> x
+        | Error e ->
+            match box e with
+            | :? string as s -> invalidArg "source" $"Result value was Error: {s}"
+            | :? exn    as e -> raise <| System.ArgumentException ("Result value was Error", "source", e)
+            | _              -> invalidArg "source" $"Result value was Error: {string e}"
 
     /// Extracts the Ok value or use the supplied default value when it's an Error.
     let defaultValue (value:'T) (source: Result<'T,'Error>) : 'T = match source with Ok v -> v | _ -> value

--- a/src/FSharpPlus/Extensions/Result.fs
+++ b/src/FSharpPlus/Extensions/Result.fs
@@ -74,7 +74,7 @@ module Result =
         | Error e ->
             match box e with
             | :? exn as e -> raise <| System.ArgumentException ("Result value was Error", "source", e)
-            | _           -> invalidArg "source" ("Result value was Error: " + string s)
+            | _           -> invalidArg "source" ("Result value was Error: " + string e)
 
     /// Extracts the Ok value or use the supplied default value when it's an Error.
     let defaultValue (value:'T) (source: Result<'T,'Error>) : 'T = match source with Ok v -> v | _ -> value

--- a/src/FSharpPlus/Extensions/Result.fs
+++ b/src/FSharpPlus/Extensions/Result.fs
@@ -73,9 +73,8 @@ module Result =
         | Ok x -> x
         | Error e ->
             match box e with
-            | :? string as s -> invalidArg "source" ("Result value was Error: " + s)
-            | :? exn    as e -> raise <| System.ArgumentException ("Result value was Error", "source", e)
-            | _              -> invalidArg "source" $"Result value was Error: {string e}"
+            | :? exn as e -> raise <| System.ArgumentException ("Result value was Error", "source", e)
+            | _           -> invalidArg "source" ("Result value was Error: " + string s)
 
     /// Extracts the Ok value or use the supplied default value when it's an Error.
     let defaultValue (value:'T) (source: Result<'T,'Error>) : 'T = match source with Ok v -> v | _ -> value


### PR DESCRIPTION
I am not sure if this is a good design, so did this PR to get started the discussion.

The problem is that, as opposed to `Option.get` where the error doesn't carry any information, in `Result` we normally carry a description of what happened. By using `get` when the value is an `Error` an exception is thrown, hiding the error description.

Of course, we don't know the error type, but in case of an error we can do our best to match on the type and try to throw a better exception.

Comments?