### PR TITLE
Fable compatibility for un/curry functions

### DIFF
--- a/src/FSharpPlus/Control/Tuple.fs
+++ b/src/FSharpPlus/Control/Tuple.fs
@@ -160,7 +160,7 @@ type MapItem5 =
         call (Unchecked.defaultof<MapItem5>, value)
 
 
-#if !FABLE_COMPILER
+#if !FABLE_COMPILER || FABLE_COMPILER_3
 
 open FSharpPlus.Internals.Prelude
 

--- a/src/FSharpPlus/Internals.fs
+++ b/src/FSharpPlus/Internals.fs
@@ -19,8 +19,14 @@ module internal Prelude =
     let inline flip f x y = f y x
     let inline const' k _ = k
     let inline tupleToOption x = match x with true, value -> Some value | _ -> None
-    let inline retype (x: 'T) : 'U = (# "" x: 'U #)
     let inline opaqueId x = Unchecked.defaultof<_>; x
+    
+    let inline retype (x: 'T) : 'U =
+    #if !FABLE_COMPILER
+        (# "" x: 'U #)
+    #else
+        unbox<'U> x
+    #endif
 
 
 [<RequireQualifiedAccess>]
@@ -95,6 +101,12 @@ type Either<'t,'u> =
     | Right of 'u
 
 type DmStruct = struct end
+
+#if FABLE_COMPILER
+type Tuple<'t> (v: 't) =
+    let value = v
+    member _.Item1 = value
+#endif
 
 
 [<Sealed>]

--- a/src/FSharpPlus/Operators.fs
+++ b/src/FSharpPlus/Operators.fs
@@ -22,21 +22,19 @@ module Operators =
     /// <category index="0">Common Combinators</category>
     let inline curry f (x: 'T1) (y: 'T2) : 'Result = f (x, y)
     
-    #if !FABLE_COMPILER
-    /// <summary>
-    /// Takes a function expecting a tuple of any N number of elements and returns a function expecting N curried arguments.
-    /// </summary>
-    /// <category index="0">Common Combinators</category>
-    let inline curryN (f: (^``T1 * ^T2 * ... * ^Tn``) -> 'Result) : 'T1 -> '``T2 -> ... -> 'Tn -> 'Result`` = fun t -> Curry.Invoke f t
-    #endif
-
     /// <summary>
     /// Takes a function expecting two curried arguments and returns a function expecting a tuple of two elements. Same as (&lt;||).
     /// </summary>
     /// <category index="0">Common Combinators</category>
     let inline uncurry f (x: 'T1, y: 'T2) : 'Result = f x y
     
-    #if !FABLE_COMPILER
+    #if !FABLE_COMPILER || FABLE_COMPILER_3
+    /// <summary>
+    /// Takes a function expecting a tuple of any N number of elements and returns a function expecting N curried arguments.
+    /// </summary>
+    /// <category index="0">Common Combinators</category>
+    let inline curryN (f: (^``T1 * ^T2 * ... * ^Tn``) -> 'Result) : 'T1 -> '``T2 -> ... -> 'Tn -> 'Result`` = fun t -> Curry.Invoke f t
+    
     /// <summary>
     /// Takes a function expecting any N number of curried arguments and returns a function expecting a tuple of N elements.
     /// </summary>

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General.fs
@@ -282,7 +282,7 @@ let bitConverter = testList "BitConverter" [
 
 let curry = testList "Curry" [
 
-#if !FABLE_COMPILER
+#if !FABLE_COMPILER || FABLE_COMPILER_3
     testCase "curryTest" (fun () ->
         let f1  (x: Tuple<_>) = [x.Item1]
         let f2  (x, y)    = [x + y]
@@ -307,7 +307,7 @@ let curry = testList "Curry" [
         ())
 #endif
 
-#if !FABLE_COMPILER
+#if !FABLE_COMPILER || FABLE_COMPILER_3
     testCase "uncurryTest" (fun () ->
         let g2  x y   = [x + y]
         let g3  x y z = [x + y + z]

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General.fs
@@ -284,25 +284,36 @@ let curry = testList "Curry" [
 
 #if !FABLE_COMPILER || FABLE_COMPILER_3
     testCase "curryTest" (fun () ->
-        // let f1  (x: Tuple<_>) = [x.Item1]
+    
+        #if !FABLE_COMPILER
+        let f1  (x: Tuple<_>) = [x.Item1]
+        #endif
+        
         let f2  (x, y)    = [x + y]
         let f3  (x, y, z) = [x + y + z]
         let f7  (t1, t2, t3, t4, t5, t6, t7) = [t1+t2+t3+t4+t5+t6+t7]
-        // let f8  (t1, t2, t3, t4, t5, t6, t7: float, t8: char) = [t1+t2+t3+t4+t5+t6+ int t7 + int t8]
-        // let f9  (t1, t2, t3, t4, t5, t6, t7: float, t8: char, t9: decimal) = [t1+t2+t3+t4+t5+t6+ int t7 + int t8+ int t9]
-        // let f15 (t1, t2, t3, t4, t5, t6, t7: float, t8: char, t9: decimal, t10, t11, t12, t13, t14, t15) = [t1+t2+t3+t4+t5+t6+ int t7 + int t8+ int t9+t10+t11+t12+t13+t14+t15]
-        // let f16 (t1, t2, t3, t4, t5, t6, t7: float, t8: char, t9: decimal, t10, t11, t12, t13, t14, t15, t16) = [t1+t2+t3+t4+t5+t6+ int t7 + int t8+ int t9+t10+t11+t12+t13+t14+t15+t16]
-        // let f17 (t1, t2, t3, t4, t5, t6, t7: float, t8: char, t9: decimal, t10, t11, t12, t13, t14, t15, t16, t17) = [t1+t2+t3+t4+t5+t6+ int t7 + int t8+ int t9+t10+t11+t12+t13+t14+t15+t16+t17]
+        
+        #if !FABLE_COMPILER
+        let f8  (t1, t2, t3, t4, t5, t6, t7: float, t8: char) = [t1+t2+t3+t4+t5+t6+ int t7 + int t8]
+        let f9  (t1, t2, t3, t4, t5, t6, t7: float, t8: char, t9: decimal) = [t1+t2+t3+t4+t5+t6+ int t7 + int t8+ int t9]
+        let f15 (t1, t2, t3, t4, t5, t6, t7: float, t8: char, t9: decimal, t10, t11, t12, t13, t14, t15) = [t1+t2+t3+t4+t5+t6+ int t7 + int t8+ int t9+t10+t11+t12+t13+t14+t15]
+        let f16 (t1, t2, t3, t4, t5, t6, t7: float, t8: char, t9: decimal, t10, t11, t12, t13, t14, t15, t16) = [t1+t2+t3+t4+t5+t6+ int t7 + int t8+ int t9+t10+t11+t12+t13+t14+t15+t16]
+        let f17 (t1, t2, t3, t4, t5, t6, t7: float, t8: char, t9: decimal, t10, t11, t12, t13, t14, t15, t16, t17) = [t1+t2+t3+t4+t5+t6+ int t7 + int t8+ int t9+t10+t11+t12+t13+t14+t15+t16+t17]
 
-        // let _x1  = curryN f1 100
+        let _x1  = curryN f1 100
+        #endif
+        
         let _x2  = curryN f2 1 2
         let _x3  = curryN f3 1 2 3
         let _x7  = curryN f7 1 2 3 4 5 6 7
-        // let _x8  = curryN f8 1 2 3 4 5 6 7. '8'
-        // let _x9  = curryN f9 1 2 3 4 5 6 7. '8' 9M
-        // let _x15 = curryN f15 1 2 3 4 5 6 7. '8' 9M 10 11 12 13 14 15
-        // let _x16 = curryN f16 1 2 3 4 5 6 7. '8' 9M 10 11 12 13 14 15 16
-        // let _x17 = curryN f17 1 2 3 4 5 6 7. '8' 9M 10 11 12 13 14 15 16 17
+        
+        #if !FABLE_COMPILER
+        let _x8  = curryN f8 1 2 3 4 5 6 7. '8'
+        let _x9  = curryN f9 1 2 3 4 5 6 7. '8' 9M
+        let _x15 = curryN f15 1 2 3 4 5 6 7. '8' 9M 10 11 12 13 14 15
+        let _x16 = curryN f16 1 2 3 4 5 6 7. '8' 9M 10 11 12 13 14 15 16
+        let _x17 = curryN f17 1 2 3 4 5 6 7. '8' 9M 10 11 12 13 14 15 16 17
+        #endif
 
         ())
 #endif
@@ -312,21 +323,28 @@ let curry = testList "Curry" [
         let g2  x y   = [x + y]
         let g3  x y z = [x + y + z]
         let g7  a b c d e f g = [a + b + c + d + e + f + g]
-        // let g8  t1 t2 t3 t4 t5 t6 (t7: float) (t8: char) = [t1+t2+t3+t4+t5+t6+ int t7 + int t8]
-        // let g9  t1 t2 t3 t4 t5 t6 (t7: float) (t8: char) (t9: decimal)  = [t1+t2+t3+t4+t5+t6+ int t7 + int t8+ int t9]
-        // let g12 t1 t2 t3 t4 t5 t6 (t7: float) (t8: char) (t9: decimal) t10 t11 t12 = [t1+t2+t3+t4+t5+t6+ int t7 + int t8+ int t9+t10+t11+t12]
-        // let g15 t1 t2 t3 t4 t5 t6 (t7: float) (t8: char) (t9: decimal) t10 t11 t12 t13 t14 t15 = [t1+t2+t3+t4+t5+t6+ int t7 + int t8+ int t9+t10+t11+t12+t13+t14+t15]
-        // let g16 t1 t2 t3 t4 t5 t6 (t7: float) (t8: char) (t9: decimal) t10 t11 t12 t13 t14 t15 t16 = [t1+t2+t3+t4+t5+t6+ int t7 + int t8+ int t9+t10+t11+t12+t13+t14+t15+t16]
+        
+        #if !FABLE_COMPILER
+        let g8  t1 t2 t3 t4 t5 t6 (t7: float) (t8: char) = [t1+t2+t3+t4+t5+t6+ int t7 + int t8]
+        let g9  t1 t2 t3 t4 t5 t6 (t7: float) (t8: char) (t9: decimal)  = [t1+t2+t3+t4+t5+t6+ int t7 + int t8+ int t9]
+        let g12 t1 t2 t3 t4 t5 t6 (t7: float) (t8: char) (t9: decimal) t10 t11 t12 = [t1+t2+t3+t4+t5+t6+ int t7 + int t8+ int t9+t10+t11+t12]
+        let g15 t1 t2 t3 t4 t5 t6 (t7: float) (t8: char) (t9: decimal) t10 t11 t12 t13 t14 t15 = [t1+t2+t3+t4+t5+t6+ int t7 + int t8+ int t9+t10+t11+t12+t13+t14+t15]
+        let g16 t1 t2 t3 t4 t5 t6 (t7: float) (t8: char) (t9: decimal) t10 t11 t12 t13 t14 t15 t16 = [t1+t2+t3+t4+t5+t6+ int t7 + int t8+ int t9+t10+t11+t12+t13+t14+t15+t16]
 
-        // let _y1  = uncurryN string (Tuple<_> 1)
+        let _y1  = uncurryN string (Tuple<_> 1)
+        #endif
+        
         let _y2  = uncurryN g2 (1, 2)
         let _y3  = uncurryN g3 (1, 2, 3)
-        let _y7  = uncurryN g7 (1, 2, 3, 4, 5, 6, 7)        
-        // let _y8  = uncurryN g8 (1, 2, 3, 4, 5, 6, 7. , '8')
-        // let _y9  = uncurryN g9 (1, 2, 3, 4, 5, 6, 7. , '8', 9M)
-        // let _y12 = uncurryN g12 (1, 2, 3, 4, 5, 6, 7. , '8', 9M, 10 , 11, 12)
-        // let _y15 = uncurryN g15 (1, 2, 3, 4, 5, 6, 7. , '8', 9M, 10 , 11, 12, 13, 14, 15)
-        // let _y16 = uncurryN g16 (1, 2, 3, 4, 5, 6, 7. , '8', 9M, 10 , 11, 12, 13, 14, 15, 16)
+        let _y7  = uncurryN g7 (1, 2, 3, 4, 5, 6, 7)
+        
+        #if !FABLE_COMPILER
+        let _y8  = uncurryN g8 (1, 2, 3, 4, 5, 6, 7. , '8')
+        let _y9  = uncurryN g9 (1, 2, 3, 4, 5, 6, 7. , '8', 9M)
+        let _y12 = uncurryN g12 (1, 2, 3, 4, 5, 6, 7. , '8', 9M, 10 , 11, 12)
+        let _y15 = uncurryN g15 (1, 2, 3, 4, 5, 6, 7. , '8', 9M, 10 , 11, 12, 13, 14, 15)
+        let _y16 = uncurryN g16 (1, 2, 3, 4, 5, 6, 7. , '8', 9M, 10 , 11, 12, 13, 14, 15, 16)
+        #endif
 
         ())
 #endif

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General.fs
@@ -284,25 +284,25 @@ let curry = testList "Curry" [
 
 #if !FABLE_COMPILER || FABLE_COMPILER_3
     testCase "curryTest" (fun () ->
-        let f1  (x: Tuple<_>) = [x.Item1]
+        // let f1  (x: Tuple<_>) = [x.Item1]
         let f2  (x, y)    = [x + y]
         let f3  (x, y, z) = [x + y + z]
         let f7  (t1, t2, t3, t4, t5, t6, t7) = [t1+t2+t3+t4+t5+t6+t7]
-        let f8  (t1, t2, t3, t4, t5, t6, t7: float, t8: char) = [t1+t2+t3+t4+t5+t6+ int t7 + int t8]
-        let f9  (t1, t2, t3, t4, t5, t6, t7: float, t8: char, t9: decimal) = [t1+t2+t3+t4+t5+t6+ int t7 + int t8+ int t9]
-        let f15 (t1, t2, t3, t4, t5, t6, t7: float, t8: char, t9: decimal, t10, t11, t12, t13, t14, t15) = [t1+t2+t3+t4+t5+t6+ int t7 + int t8+ int t9+t10+t11+t12+t13+t14+t15]
-        let f16 (t1, t2, t3, t4, t5, t6, t7: float, t8: char, t9: decimal, t10, t11, t12, t13, t14, t15, t16) = [t1+t2+t3+t4+t5+t6+ int t7 + int t8+ int t9+t10+t11+t12+t13+t14+t15+t16]
-        let f17 (t1, t2, t3, t4, t5, t6, t7: float, t8: char, t9: decimal, t10, t11, t12, t13, t14, t15, t16, t17) = [t1+t2+t3+t4+t5+t6+ int t7 + int t8+ int t9+t10+t11+t12+t13+t14+t15+t16+t17]
+        // let f8  (t1, t2, t3, t4, t5, t6, t7: float, t8: char) = [t1+t2+t3+t4+t5+t6+ int t7 + int t8]
+        // let f9  (t1, t2, t3, t4, t5, t6, t7: float, t8: char, t9: decimal) = [t1+t2+t3+t4+t5+t6+ int t7 + int t8+ int t9]
+        // let f15 (t1, t2, t3, t4, t5, t6, t7: float, t8: char, t9: decimal, t10, t11, t12, t13, t14, t15) = [t1+t2+t3+t4+t5+t6+ int t7 + int t8+ int t9+t10+t11+t12+t13+t14+t15]
+        // let f16 (t1, t2, t3, t4, t5, t6, t7: float, t8: char, t9: decimal, t10, t11, t12, t13, t14, t15, t16) = [t1+t2+t3+t4+t5+t6+ int t7 + int t8+ int t9+t10+t11+t12+t13+t14+t15+t16]
+        // let f17 (t1, t2, t3, t4, t5, t6, t7: float, t8: char, t9: decimal, t10, t11, t12, t13, t14, t15, t16, t17) = [t1+t2+t3+t4+t5+t6+ int t7 + int t8+ int t9+t10+t11+t12+t13+t14+t15+t16+t17]
 
-        let _x1  = curryN f1 100
+        // let _x1  = curryN f1 100
         let _x2  = curryN f2 1 2
         let _x3  = curryN f3 1 2 3
         let _x7  = curryN f7 1 2 3 4 5 6 7
-        let _x8  = curryN f8 1 2 3 4 5 6 7. '8'
-        let _x9  = curryN f9 1 2 3 4 5 6 7. '8' 9M
-        let _x15 = curryN f15 1 2 3 4 5 6 7. '8' 9M 10 11 12 13 14 15
-        let _x16 = curryN f16 1 2 3 4 5 6 7. '8' 9M 10 11 12 13 14 15 16
-        let _x17 = curryN f17 1 2 3 4 5 6 7. '8' 9M 10 11 12 13 14 15 16 17
+        // let _x8  = curryN f8 1 2 3 4 5 6 7. '8'
+        // let _x9  = curryN f9 1 2 3 4 5 6 7. '8' 9M
+        // let _x15 = curryN f15 1 2 3 4 5 6 7. '8' 9M 10 11 12 13 14 15
+        // let _x16 = curryN f16 1 2 3 4 5 6 7. '8' 9M 10 11 12 13 14 15 16
+        // let _x17 = curryN f17 1 2 3 4 5 6 7. '8' 9M 10 11 12 13 14 15 16 17
 
         ())
 #endif
@@ -312,21 +312,21 @@ let curry = testList "Curry" [
         let g2  x y   = [x + y]
         let g3  x y z = [x + y + z]
         let g7  a b c d e f g = [a + b + c + d + e + f + g]
-        let g8  t1 t2 t3 t4 t5 t6 (t7: float) (t8: char) = [t1+t2+t3+t4+t5+t6+ int t7 + int t8]
-        let g9  t1 t2 t3 t4 t5 t6 (t7: float) (t8: char) (t9: decimal)  = [t1+t2+t3+t4+t5+t6+ int t7 + int t8+ int t9]
-        let g12 t1 t2 t3 t4 t5 t6 (t7: float) (t8: char) (t9: decimal) t10 t11 t12 = [t1+t2+t3+t4+t5+t6+ int t7 + int t8+ int t9+t10+t11+t12]
-        let g15 t1 t2 t3 t4 t5 t6 (t7: float) (t8: char) (t9: decimal) t10 t11 t12 t13 t14 t15 = [t1+t2+t3+t4+t5+t6+ int t7 + int t8+ int t9+t10+t11+t12+t13+t14+t15]
-        let g16 t1 t2 t3 t4 t5 t6 (t7: float) (t8: char) (t9: decimal) t10 t11 t12 t13 t14 t15 t16 = [t1+t2+t3+t4+t5+t6+ int t7 + int t8+ int t9+t10+t11+t12+t13+t14+t15+t16]
+        // let g8  t1 t2 t3 t4 t5 t6 (t7: float) (t8: char) = [t1+t2+t3+t4+t5+t6+ int t7 + int t8]
+        // let g9  t1 t2 t3 t4 t5 t6 (t7: float) (t8: char) (t9: decimal)  = [t1+t2+t3+t4+t5+t6+ int t7 + int t8+ int t9]
+        // let g12 t1 t2 t3 t4 t5 t6 (t7: float) (t8: char) (t9: decimal) t10 t11 t12 = [t1+t2+t3+t4+t5+t6+ int t7 + int t8+ int t9+t10+t11+t12]
+        // let g15 t1 t2 t3 t4 t5 t6 (t7: float) (t8: char) (t9: decimal) t10 t11 t12 t13 t14 t15 = [t1+t2+t3+t4+t5+t6+ int t7 + int t8+ int t9+t10+t11+t12+t13+t14+t15]
+        // let g16 t1 t2 t3 t4 t5 t6 (t7: float) (t8: char) (t9: decimal) t10 t11 t12 t13 t14 t15 t16 = [t1+t2+t3+t4+t5+t6+ int t7 + int t8+ int t9+t10+t11+t12+t13+t14+t15+t16]
 
-        let _y1  = uncurryN string (Tuple<_> 1)
+        // let _y1  = uncurryN string (Tuple<_> 1)
         let _y2  = uncurryN g2 (1, 2)
         let _y3  = uncurryN g3 (1, 2, 3)
-        let _y7  = uncurryN g7 (1, 2, 3, 4, 5, 6, 7)
-        let _y8  = uncurryN g8 (1, 2, 3, 4, 5, 6, 7. , '8')
-        let _y9  = uncurryN g9 (1, 2, 3, 4, 5, 6, 7. , '8', 9M)
-        let _y12 = uncurryN g12 (1, 2, 3, 4, 5, 6, 7. , '8', 9M, 10 , 11, 12)
-        let _y15 = uncurryN g15 (1, 2, 3, 4, 5, 6, 7. , '8', 9M, 10 , 11, 12, 13, 14, 15)
-        let _y16 = uncurryN g16 (1, 2, 3, 4, 5, 6, 7. , '8', 9M, 10 , 11, 12, 13, 14, 15, 16)
+        let _y7  = uncurryN g7 (1, 2, 3, 4, 5, 6, 7)        
+        // let _y8  = uncurryN g8 (1, 2, 3, 4, 5, 6, 7. , '8')
+        // let _y9  = uncurryN g9 (1, 2, 3, 4, 5, 6, 7. , '8', 9M)
+        // let _y12 = uncurryN g12 (1, 2, 3, 4, 5, 6, 7. , '8', 9M, 10 , 11, 12)
+        // let _y15 = uncurryN g15 (1, 2, 3, 4, 5, 6, 7. , '8', 9M, 10 , 11, 12, 13, 14, 15)
+        // let _y16 = uncurryN g16 (1, 2, 3, 4, 5, 6, 7. , '8', 9M, 10 , 11, 12, 13, 14, 15, 16)
 
         ())
 #endif


### PR DESCRIPTION
This will enable:

- curryN
- uncurryN

for tuples of 2 to 7 elements.
More elements should in theory work but current Fable version is not able to compile the required trait calls.