### PR TITLE
Add bindError -- flipped `catch` which is useful for piping

### DIFF
--- a/src/FSharpPlus/Operators.fs
+++ b/src/FSharpPlus/Operators.fs
@@ -982,9 +982,27 @@ module Operators =
     /// <category index="18">Monad Transformers</category>
     let inline throw (error: 'E) : '``'MonadError<'E,'T>`` = Throw.Invoke error
 
-    /// <summary> Executes a handler when the value contained in the Error monad represents an error. </summary>
+    /// <summary>
+    /// Executes a handler when the value contained in the Error monad represents an error.
+    /// This is bindError flipped, which makes it useful when used as an operator.
+    /// </summary>
+    /// <example>
+    /// <code>
+    ///    let doSomeOperation x = ResultT <| async {
+    ///        if x < 10 then return Ok 10
+    ///        else return Error "failure" }
+    ///
+    ///    doSomeOperation &lt;/catch/&gt; (fun s -> throw ("The error was: " + s))
+    /// </code>
+    /// </example>
     /// <category index="18">Monad Transformers</category>
     let inline catch (value: '``'MonadError<'E1,'T>``) (handler: 'E1->'``'MonadError<'E2,'T>``) : '``'MonadError<'E2,'T>`` = Catch.Invoke value handler
+
+    /// <summary>
+    /// Executes a handler when the value contained in the Error monad represents an error.
+    /// </summary>
+    /// <category index="18">Monad Transformers</category>
+    let inline bindError  (handler: 'E1->'``'MonadError<'E2,'T>``) (value: '``'MonadError<'E1,'T>``): '``'MonadError<'E2,'T>`` = Catch.Invoke value handler
 
     #endif
     #if !FABLE_COMPILER || FABLE_COMPILER_3


### PR DESCRIPTION
Adding bindError, which I find myself reaching for when piping values, just for a more consistent style.

```
    let subscribe profile watermark =
        subscribeProfileAsResultT watermark profile
        </ catch /> (UserProfiles.Subscribe.deactivateOrResubscribe mitimesUri profile)
        |> ResultT.map ignore
```

Also, I've starting using fantomas to autoformat, which (currently) can't format `</ catch />` nicely. It becomes:
```
    let subscribe profile watermark =
        subscribeProfileAsResultT watermark profile
        </ catch
           /> (UserProfiles.Subscribe.deactivateOrResubscribe mitimesUri profile)
        |> map ignore
```

I also had to recently train a new dev on code and catch and the </ and /> operators were kind of hard to explain.

Having `bindError` as an alternative style, looks like:
```
    let subscribe profile watermark =
        subscribeProfileAsResultT watermark profile
        |> bindError (UserProfiles.Subscribe.deactivateOrResubscribe mitimesUri profile)
        |> map ignore
```
