### PR TITLE
Enable CEs in Fable

### DIFF
--- a/src/FSharpPlus/Control/Monad.fs
+++ b/src/FSharpPlus/Control/Monad.fs
@@ -151,23 +151,28 @@ type Return =
 type Delay =
     inherit Default1
     
+    #if !FABLE_COMPILER
     static member inline Delay (_mthd: Default3, x: unit-> ^``Monad<'T>``                                 , _: Default1) = Bind.Invoke (Return.Invoke ()) x : ^``Monad<'T>``
     
-    #if !FABLE_COMPILER
     static member inline Delay (_mthd: Default1, x: unit-> ^I                                             , _: Delay   ) = (^I : (static member Delay : _->_) x) : ^I
     static member inline Delay (_mthd: Default1, _: unit-> ^t when  ^t : null and ^t  : struct            , _          ) = ()
 
     static member        Delay (_mthd: Default2, x: unit-> _                                              , _          ) = Seq.delay x      : seq<'T>
     static member        Delay (_mthd: Default2, x: unit-> _                                              , _          ) = NonEmptySeq.delay x : NonEmptySeq<'T>
     static member        Delay (_mthd: Default2, x: unit-> 'R -> _                                        , _          ) = (fun s -> x () s): 'R -> _
-    static member        Delay (_mthd: Delay   , x: unit-> _                                              , _          ) = async.Delay x    : Async<'T>    
-    static member        Delay (_mthd: Delay   , x: unit-> Task<_>                                        , _          ) = x () : Task<'T>    
+    static member        Delay (_mthd: Delay   , x: unit-> _                                              , _          ) = async.Delay x    : Async<'T>
+    static member        Delay (_mthd: Delay   , x: unit-> Task<_>                                        , _          ) = x () : Task<'T>
     static member        Delay (_mthd: Delay   , x: unit-> Lazy<_>                                        , _          ) = lazy (x().Value) : Lazy<'T>
-    #endif
-    
+        
     static member inline Invoke source : 'R =
         let inline call (mthd: ^M, input: unit -> ^I) = ((^M or ^I) : (static member Delay : _*_*_ -> _) mthd, input, Unchecked.defaultof<Delay>)
         call (Unchecked.defaultof<Delay>, source)
+    
+    #else
+    
+    static member inline Invoke source : '``Monad<'T>`` = Bind.Invoke (Return.Invoke ()) source
+    
+    #endif
 
 
 [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]

--- a/src/FSharpPlus/Control/Monad.fs
+++ b/src/FSharpPlus/Control/Monad.fs
@@ -152,18 +152,19 @@ type Delay =
     inherit Default1
     
     static member inline Delay (_mthd: Default3, x: unit-> ^``Monad<'T>``                                 , _: Default1) = Bind.Invoke (Return.Invoke ()) x : ^``Monad<'T>``
+    
+    #if !FABLE_COMPILER
     static member inline Delay (_mthd: Default1, x: unit-> ^I                                             , _: Delay   ) = (^I : (static member Delay : _->_) x) : ^I
     static member inline Delay (_mthd: Default1, _: unit-> ^t when  ^t : null and ^t  : struct            , _          ) = ()
 
     static member        Delay (_mthd: Default2, x: unit-> _                                              , _          ) = Seq.delay x      : seq<'T>
     static member        Delay (_mthd: Default2, x: unit-> _                                              , _          ) = NonEmptySeq.delay x : NonEmptySeq<'T>
     static member        Delay (_mthd: Default2, x: unit-> 'R -> _                                        , _          ) = (fun s -> x () s): 'R -> _
-    static member        Delay (_mthd: Delay   , x: unit-> _                                              , _          ) = async.Delay x    : Async<'T>
-    #if !FABLE_COMPILER
-    static member        Delay (_mthd: Delay   , x: unit-> Task<_>                                        , _          ) = x () : Task<'T>
+    static member        Delay (_mthd: Delay   , x: unit-> _                                              , _          ) = async.Delay x    : Async<'T>    
+    static member        Delay (_mthd: Delay   , x: unit-> Task<_>                                        , _          ) = x () : Task<'T>    
+    static member        Delay (_mthd: Delay   , x: unit-> Lazy<_>                                        , _          ) = lazy (x().Value) : Lazy<'T>
     #endif
-    static member        Delay (_mthd: Delay   , x: unit-> Lazy<_>                                        , _          ) = lazy (x().Value) : Lazy<'T>    
-
+    
     static member inline Invoke source : 'R =
         let inline call (mthd: ^M, input: unit -> ^I) = ((^M or ^I) : (static member Delay : _*_*_ -> _) mthd, input, Unchecked.defaultof<Delay>)
         call (Unchecked.defaultof<Delay>, source)

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/Monad.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/Monad.fs
@@ -18,7 +18,7 @@ let monad = testList "Monad" [
         equal ["Join"] (SideEffects.get ()))
     #endif
 
-    #if !FABLE_COMPILER
+    #if !FABLE_COMPILER || FABLE_COMPILER_3
     testCase "workFlow" (fun () ->       
         let testVal = 
             monad {

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/Monad.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/Monad.fs
@@ -59,7 +59,7 @@ let monad = testList "Monad" [
             return x + y
         }
         
-        equal (Some 25) v
+        equal (25) (Option.get v)
     )    
     
     #endif

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/Monad.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/Monad.fs
@@ -32,6 +32,7 @@ let monad = testList "Monad" [
         #if !FABLE_COMPILER
         Assert.IsInstanceOf<WrappedListD<int>> (testVal)
         #endif
+        equal (WrappedListD [11; 21; 12; 22]) testVal
         () )
     #endif
     

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/Monad.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/Monad.fs
@@ -47,9 +47,22 @@ let monad = testList "Monad" [
     testCase "return Const" (fun () ->
         let c : Const<int,int> = Control.Return.InvokeOnInstance 1 in equal 0 (Const.run c)
     )
+    
+    testCase "specialized maybe monad" (fun () ->
+        let option<'t> = monad<Option<'t>>
+        let v = option {
+            let! x = Some 10
+            let! y = Some 15
+            return x + y
+        }
+        
+        equal (Some 25) v
+    )    
+    
     #endif
 
-    #if !FABLE_COMPILER || FABLE_COMPILER_3
+    //  Exception: RangeError: Maximum call stack size exceeded
+    #if !FABLE_COMPILER
     testCase "DelayForCont" (fun () -> 
         // If Delay is not properly implemented this will stack-overflow
         // See http://stackoverflow.com/questions/11188779/stackoverflow-in-continuation-monad

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/Monad.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/Monad.fs
@@ -29,7 +29,10 @@ let monad = testList "Monad" [
         Assert.IsInstanceOf<WrappedListD<int>> (testVal)
         #endif
         () )
-
+    #endif
+    
+    // Exception: TypeError: Cannot read property '0' of undefined 
+    #if !FABLE_COMPILER
     testCase "return Const First using invoke on instance" (fun () ->
         let cf : Const<First<int>,int> = Control.Return.InvokeOnInstance 1
         equal None (cf |> Const.run |> First.run)
@@ -46,7 +49,7 @@ let monad = testList "Monad" [
     )
     #endif
 
-    #if !FABLE_COMPILER
+    #if !FABLE_COMPILER || FABLE_COMPILER_3
     testCase "DelayForCont" (fun () -> 
         // If Delay is not properly implemented this will stack-overflow
         // See http://stackoverflow.com/questions/11188779/stackoverflow-in-continuation-monad

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/Monad.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/Monad.fs
@@ -7,6 +7,7 @@ open FSharpPlus.Data
 
 #if !FABLE_COMPILER || FABLE_COMPILER_3
 let option<'t> = monad<Option<'t>>
+let list<'t>   = monad'<list<'t>>
 #endif
 
 let monad = testList "Monad" [
@@ -58,10 +59,18 @@ let monad = testList "Monad" [
             let! x = Some 10
             let! y = Some 15
             return x + y
-        }
-        
-        equal (25) (Option.get v)
-    )    
+        }        
+        equal (Some 25) v
+    )
+    
+    testCase "specialized (strict) list monad" (fun () ->
+        let v = list {
+            let! x = [10]
+            let! y = [15]
+            return x + y
+        }        
+        equal [25] v
+    )  
     
     #endif
 

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/Monad.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/Monad.fs
@@ -29,9 +29,7 @@ let monad = testList "Monad" [
         Assert.IsInstanceOf<WrappedListD<int>> (testVal)
         #endif
         () )
-    #endif
 
-    #if !FABLE_COMPILER
     testCase "return Const First using invoke on instance" (fun () ->
         let cf : Const<First<int>,int> = Control.Return.InvokeOnInstance 1
         equal None (cf |> Const.run |> First.run)

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/Monad.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/Monad.fs
@@ -26,9 +26,9 @@ let monad = testList "Monad" [
                 let! x2 = WrappedListD [10;20]
                 return ((+) x1 x2) }
         #if !FABLE_COMPILER
-        Assert.IsInstanceOf<WrappedListD<int>> (testVal))
+        Assert.IsInstanceOf<WrappedListD<int>> (testVal)
         #endif
-        ()
+        () )
     #endif
 
     #if !FABLE_COMPILER
@@ -37,8 +37,8 @@ let monad = testList "Monad" [
         equal None (cf |> Const.run |> First.run)
     )
     #endif
+    
     #if !FABLE_COMPILER || FABLE_COMPILER_3
-
     testCase "return Const First using explicit method" (fun () ->
         let cf : Const<First<int>,int> = Const.Return<_,_> 1
         equal None (cf |> Const.run |> First.run)

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/Monad.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/Monad.fs
@@ -25,7 +25,11 @@ let monad = testList "Monad" [
                 let! x1 = WrappedListD [1;2]
                 let! x2 = WrappedListD [10;20]
                 return ((+) x1 x2) }
+        #if !FABLE_COMPILER
         Assert.IsInstanceOf<WrappedListD<int>> (testVal))
+        #else
+        ()
+        #endif
 
     testCase "return Const First using invoke on instance" (fun () ->
         let cf : Const<First<int>,int> = Control.Return.InvokeOnInstance 1

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/Monad.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/Monad.fs
@@ -30,9 +30,8 @@ let monad = testList "Monad" [
                 let! x1 = WrappedListD [1;2]
                 let! x2 = WrappedListD [10;20]
                 return ((+) x1 x2) }
-        #if !FABLE_COMPILER
+        
         Assert.IsInstanceOf<WrappedListD<int>> (testVal)
-        #endif
         equal (WrappedListD [11; 21; 12; 22]) testVal
         () )
     #endif

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/Monad.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/Monad.fs
@@ -5,6 +5,10 @@ open FSharpPlus
 open FSharpPlus.Data
 #nowarn "686"
 
+#if !FABLE_COMPILER || FABLE_COMPILER_3
+let option<'t> = monad<Option<'t>>
+#endif
+
 let monad = testList "Monad" [
     #if !FABLE_COMPILER || FABLE_COMPILER_3
     testCase "joinDefaultCustom" (fun () -> 
@@ -49,7 +53,6 @@ let monad = testList "Monad" [
     )
     
     testCase "specialized maybe monad" (fun () ->
-        let option<'t> = monad<Option<'t>>
         let v = option {
             let! x = Some 10
             let! y = Some 15

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/Monad.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/Monad.fs
@@ -27,10 +27,11 @@ let monad = testList "Monad" [
                 return ((+) x1 x2) }
         #if !FABLE_COMPILER
         Assert.IsInstanceOf<WrappedListD<int>> (testVal))
-        #else
-        ()
         #endif
+        ()
+    #endif
 
+    #if !FABLE_COMPILER
     testCase "return Const First using invoke on instance" (fun () ->
         let cf : Const<First<int>,int> = Control.Return.InvokeOnInstance 1
         equal None (cf |> Const.run |> First.run)


### PR DESCRIPTION
After testing CEs in Fable I just realized that the problem is the complex resolution of the `Delay` method.

This solution consists in leaving only the default Delay implementation available to Fable, which in theory is less efficient in some cases, but still better than nothing.