### PR TITLE
+ Missing Lift2 and Lift3

### DIFF
--- a/src/FSharpPlus/Data/Cont.fs
+++ b/src/FSharpPlus/Data/Cont.fs
@@ -35,6 +35,9 @@ module Cont =
     let bind (f: 'T->_) (Cont x) = Cont (fun k -> x (fun a -> run (f a) k))           : Cont<'R,'U>
     let apply  (Cont f) (Cont x) = Cont (fun k -> f (fun (f': 'T->_) -> x (k << f'))) : Cont<'R,'U>
 
+    let map2 (f: 'T -> 'U -> 'V) (Cont x) (Cont y)                = Cont (fun k -> x (f >> fun k' -> y (k' >> k)))                       : Cont<'R, 'V>
+    let map3 (f: 'T -> 'U -> 'V -> 'W) (Cont x) (Cont y) (Cont z) = Cont (fun k -> x (f >> fun k' -> y (k' >> fun k'' -> z (k'' >> k)))) : Cont<'R, 'W>
+
 
 /// Monad Transformer for Cont<'R,'T>
 type ContT<'r,'t> = Cont<'r,'t>
@@ -44,6 +47,12 @@ type Cont<'r,'t> with
 
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Map   (x: Cont<'R,'T>, f) = Cont.map f x    : Cont<'R,'U>
+
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
+    static member inline Lift2 (f: 'T->'U->'V, x: Cont<'R,'T>, y: Cont<'R,'U>) : Cont<'R,'V> = Cont.map2 f x y
+
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
+    static member inline Lift3 (f: 'T->'U->'V->'W, x: Cont<'R,'T>, y: Cont<'R,'U>, z: Cont<'R,'V>) : Cont<'R,'W> = Cont.map3 f x y z
 
     static member (<*>) (f, x: Cont<'R,'T>) = Cont.apply f x  : Cont<'R,'U>
     static member (>>=) (x, f: 'T->_)       = Cont.bind f x   : Cont<'R,'U>

--- a/src/FSharpPlus/Data/Error.fs
+++ b/src/FSharpPlus/Data/Error.fs
@@ -54,6 +54,7 @@ module ResultT =
     let inline apply (ResultT f:ResultT<'``Monad<'Result<('T -> 'U),'E>>``>) (ResultT x: ResultT<'``Monad<'Result<'T,'E>>``>) = ResultT (map Result.apply f <*> x) : ResultT<'``Monad<'Result<'U,'E>>``>
     let inline map (f: 'T->'U) (ResultT m: ResultT<'``Monad<'Result<'T,'E>>``>) = ResultT (map (Result.map f) m) : ResultT<'``Monad<'Result<('T -> 'U),'E>>``>
     let inline map2 (f: 'T->'U->'V) (ResultT x: ResultT<'``Monad<Result<'T,'E>>``>) (ResultT y: ResultT<'``Monad<Result<'U,'E>>``>) : ResultT<'``Monad<Result<'V,'E>>``> = ResultT (lift2 (Result.map2 f) x y)
+    let inline map3 (f: 'T->'U->'V->'W) (ResultT x: ResultT<'``Monad<Result<'T,'E>>``>) (ResultT y: ResultT<'``Monad<Result<'U,'E>>``>) (ResultT z: ResultT<'``Monad<Result<'V,'E>>``>) : ResultT<'``Monad<Result<'W,'E>>``> = ResultT (lift3 (Result.map3 f) x y z)
 
 type ResultT<'``monad<'result<'t,'e>>``> with
     
@@ -64,6 +65,9 @@ type ResultT<'``monad<'result<'t,'e>>``> with
 
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Lift2 (f: 'T->'U->'V, x: ResultT<'``Monad<Result<'T,'E>``>, y: ResultT<'``Monad<Result<'U,'E>``>) : ResultT<'``Monad<Result<'V,'E>``> = ResultT.map2 f x y
+
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
+    static member inline Lift3 (f: 'T->'U->'V->'W, x: ResultT<'``Monad<Result<'T,'E>``>, y: ResultT<'``Monad<Result<'U,'E>``>, z: ResultT<'``Monad<Result<'V,'E>``>) : ResultT<'``Monad<Result<'W,'E>``> = ResultT.map3 f x y z
 
     static member inline (<*>) (f: ResultT<'``Monad<'Result<('T -> 'U),'E>>``>, x: ResultT<'``Monad<'Result<'T,'E>>``>) = ResultT.apply f x : ResultT<'``Monad<'Result<'U,'E>>``>    
     static member inline (>>=) (x: ResultT<'``Monad<'Result<'T,'E>>``>, f: 'T->ResultT<'``Monad<'Result<'U,'E>>``>)     = ResultT.bind  f x

--- a/src/FSharpPlus/Data/Free.fs
+++ b/src/FSharpPlus/Data/Free.fs
@@ -61,6 +61,13 @@ module Free =
             | Roll (x: ^``Functor<Free<'Functor<'T>,'T>>``) -> Roll (Map.Invoke (loop y: Free<'``Functor<'T>``,'T> -> _) x: '``Functor<Free<'Functor<'V>,'V>>``)
         loop y x
 
+    let inline map3 (f: 'T->'U->'V->'W) (x: Free<'``Functor<'T>``,'T>) (y: Free<'``Functor<'U>``,'U>) (z: Free<'``Functor<'V>``,'V>) : Free<'``Functor<'W>``,'W> =
+        let rec loop (y: Free<_,_>) (x: Free<_,_>) (z: Free<_,_>) =
+            match run x with
+            | Pure x -> map2<'U,'V,'W,'``Functor<'U>``,'``Functor<Free<'Functor<'U>,'U>>``,'``Functor<Free<'Functor<'V>,'V>>``,'``Functor<Free<'Functor<'W>,'W>>``,'``Functor<'V>``,'``Functor<'W>``> (f x) y z : Free<'``Functor<'W>``,'W>
+            | Roll (x: ^``Functor<Free<'Functor<'T>,'T>>``) -> Roll (Map.Invoke (loop y: Free<'``Functor<'T>``,'T> -> _) x: '``Functor<Free<'Functor<'W>,'W>>``)
+        loop y x z
+
     /// Folds the Free structure into a Monad
     let inline fold (f: '``Functor<'T>`` -> '``Monad<'T>``) (x: Free<'``Functor<'U>``,'U>) : '``Monad<'U>`` =
         let rec loop f x =
@@ -89,7 +96,13 @@ type Free<'``functor<'t>``,'t> with
     static member Return x = Pure x
     static member inline (>>=) (x: Free<'``Functor<'T>``,'T>, f: 'T -> Free<'``Functor<'U>``,'U>)   = Free.bind  f x : Free<'``Functor<'U>``,'U>
     static member inline (<*>) (f: Free<'``Functor<'T->'U>``,'T->'U>, x: Free<'``Functor<'T>``,'T>) = Free.apply f x : Free<'``Functor<'U>``,'U>
+    
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Lift2 (f, x: Free<'``Functor<'T>``,'T>, y: Free<'``Functor<'U>``,'U>) = Free.map2 f x y: Free<'``Functor<'V>``,'V>
+
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
+    static member inline Lift3 (f, x: Free<'``Functor<'T>``,'T>, y: Free<'``Functor<'U>``,'U>, z: Free<'``Functor<'V>``,'V>) = Free.map3 f x y z: Free<'``Functor<'W>``,'W>
+
     static member        Delay (x: unit -> Free<'``Functor<'T>``,'T>) = x ()
 
 #endif

--- a/src/FSharpPlus/Data/Identity.fs
+++ b/src/FSharpPlus/Data/Identity.fs
@@ -15,6 +15,7 @@ type Identity<'t> = Identity of 't with
     static member (>>=) (Identity x, f :'T -> Identity<'U>) = f x                   : Identity<'U>
     static member (<*>) (Identity (f : 'T->'U), Identity (x : 'T)) = Identity (f x) : Identity<'U>
     static member Lift2 (f, Identity (x: 'T), Identity (y: 'U)) = Identity (f x y)  : Identity<'V>
+    static member Lift3 (f, Identity (x: 'T), Identity (y: 'U), Identity (z: 'V)) = Identity (f x y z) : Identity<'W>
     static member Map   (Identity x, f : 'T->'U) = Identity (f x)                   : Identity<'U>
     static member Zip   (Identity x, Identity y) = Identity (x, y)                  : Identity<'T * 'U>
 

--- a/src/FSharpPlus/Data/List.fs
+++ b/src/FSharpPlus/Data/List.fs
@@ -56,7 +56,8 @@ module ListT =
 
     let inline bind (f: 'T-> ListT<'``Monad<list<'U>``>) (ListT m: ListT<'``Monad<list<'T>``>) = (ListT (m >>= mapM (run << f) >>= ((List.concat: list<_>->_) >> result)))
     let inline apply (ListT f: ListT<'``Monad<list<('T -> 'U)>``>) (ListT x: ListT<'``Monad<list<'T>``>) = ListT (map List.apply f <*> x) : ListT<'``Monad<list<'U>``>
-    let inline lift2 (f: 'T->'U->'V) (ListT x: ListT<'``Monad<list<'T>``>) (ListT y: ListT<'``Monad<list<'U>``>) = ListT (lift2 (List.lift2 f) x y)  : ListT<'``Monad<list<'V>``>
+    let inline lift2 (f: 'T->'U->'V) (ListT x: ListT<'``Monad<list<'T>``>) (ListT y: ListT<'``Monad<list<'U>``>) = ListT (lift2 (List.lift2 f) x y) : ListT<'``Monad<list<'V>``>
+    let inline lift3 (f: 'T->'U->'V->'W) (ListT x: ListT<'``Monad<list<'T>``>) (ListT y: ListT<'``Monad<list<'U>``>) (ListT z: ListT<'``Monad<list<'V>``>) = ListT (lift3 (List.lift3 f) x y z) : ListT<'``Monad<list<'W>``>
     let inline map  (f: 'T->'U) (ListT m: ListT<'``Monad<list<'T>``>) =  ListT (map (List.map f) m) : ListT<'``Monad<list<'U>``>
 
 type ListT<'``monad<list<'t>>``> with
@@ -68,6 +69,9 @@ type ListT<'``monad<list<'t>>``> with
 
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Lift2 (f: 'T->'U->'V, x: ListT<'``Monad<list<'T>``>, y: ListT<'``Monad<list<'U>``>) = ListT.lift2 f x y : ListT<'``Monad<list<'V>``>
+
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
+    static member inline Lift3 (f: 'T->'U->'V->'W, x: ListT<'``Monad<list<'T>``>, y: ListT<'``Monad<list<'U>``>, z: ListT<'``Monad<list<'V>``>) = ListT.lift3 f x y z : ListT<'``Monad<list<'W>``>
 
     static member inline (<*>) (f: ListT<'``Monad<list<('T -> 'U)>``>, x: ListT<'``Monad<list<'T>``>) = ListT.apply f x : ListT<'``Monad<list<'U>``>
     static member inline (>>=) (x: ListT<'``Monad<list<'T>``>, f: 'T -> ListT<'``Monad<list<'U>``>)   = ListT.bind f x

--- a/src/FSharpPlus/Data/Monoids.fs
+++ b/src/FSharpPlus/Data/Monoids.fs
@@ -60,6 +60,7 @@ type Const<'t,'u> = Const of 't with
     static member inline Return (_: 'U) = Const (getZero ()) : Const<'T,'U>
     static member inline (<*>) (Const f: Const<'C,'T->'U>, Const x: Const<'C,'T>) = Const (plus f x) : Const<'C,'U>
     static member inline Lift2 (_: 'T->'U->'V, Const x: Const<'C,'T>, Const y: Const<'C,'U>) = Const (plus x y) : Const<'C,'V>
+    static member inline Lift3 (_: 'T->'U->'V->'W, Const x: Const<'C,'T>, Const y: Const<'C,'U>, Const z: Const<'C,'V>) = Const (x ++ y ++ z) : Const<'C,'W>
 
     // Contravariant
     static member Contramap (Const x: Const<'C,'T>, _: 'U->'T) = Const x     : Const<'C,'U>
@@ -130,6 +131,9 @@ type Compose<'``functorF<'functorG<'t>>``> = Compose of '``functorF<'functorG<'t
 
     static member inline Lift2 (f: 'T -> 'U -> 'V, Compose (x: '``ApplicativeF<'ApplicativeG<'T>``), Compose (y: '``ApplicativeF<'ApplicativeG<'U>``)) =
         Compose (Lift2.Invoke (Lift2.Invoke f: '``ApplicativeG<'T>`` -> '``ApplicativeG<'U>`` -> '``ApplicativeG<'V>``) x y: '``ApplicativeF<'ApplicativeG<'V>``)
+
+    static member inline Lift3 (f: 'T -> 'U -> 'V -> 'W, Compose (x: '``ApplicativeF<'ApplicativeG<'T>``), Compose (y: '``ApplicativeF<'ApplicativeG<'U>``), Compose (z: '``ApplicativeF<'ApplicativeG<'V>``)) =
+        Compose (Lift3.Invoke (Lift3.Invoke f: '``ApplicativeG<'T>`` -> '``ApplicativeG<'U>`` -> '``ApplicativeG<'V>`` -> '``ApplicativeG<'W>``) x y z: '``ApplicativeF<'ApplicativeG<'W>``)
 
     // Alternative
     static member inline get_Empty ()                 = Compose (getEmpty ()) : Compose<'``AlternativeF<'ApplicativeG<'T>``>

--- a/src/FSharpPlus/Data/NonEmptyList.fs
+++ b/src/FSharpPlus/Data/NonEmptyList.fs
@@ -230,6 +230,7 @@ type NonEmptyList<'t> with
         {Head = r.Head; Tail = r.Tail}
 
     static member Lift2 (f: 'T -> 'U -> 'V, x, y) = NonEmptyList.ofList (List.lift2 f (NonEmptyList.toList x) (NonEmptyList.toList y))
+    static member Lift3 (f: 'T -> 'U -> 'V -> 'W, x, y, z) = NonEmptyList.ofList (List.lift3 f (NonEmptyList.toList x) (NonEmptyList.toList y) (NonEmptyList.toList z))
 
     static member Extract   {Head = h; Tail = _} = h : 't
 

--- a/src/FSharpPlus/Data/Option.fs
+++ b/src/FSharpPlus/Data/Option.fs
@@ -34,6 +34,7 @@ module OptionT =
     let inline apply (OptionT f: OptionT<'``Monad<option<('T -> 'U)>``>) (OptionT x: OptionT<'``Monad<option<'T>``>) = OptionT (map Option.apply f <*> x) : OptionT<'``Monad<option<'U>``>    
     let inline map  (f: 'T->'U) (OptionT m: OptionT<'``Monad<option<'T>``>)                                          = OptionT (map (Option.map f) m) : OptionT<'``Monad<option<'U>``>
     let inline map2 (f: 'T->'U->'V) (OptionT x: OptionT<'``Monad<option<'T>>``>) (OptionT y: OptionT<'``Monad<option<'U>>``>) = OptionT (lift2 (Option.map2 f) x y) : OptionT<'``Monad<option<'V>>``>
+    let inline map3 (f: 'T->'U->'V->'W) (OptionT x: OptionT<'``Monad<option<'T>>``>) (OptionT y: OptionT<'``Monad<option<'U>>``>) (OptionT z: OptionT<'``Monad<option<'V>>``>) = OptionT (lift3 (Option.map3 f) x y z) : OptionT<'``Monad<option<'W>>``>
 
 type OptionT<'``monad<option<'t>>``> with
     
@@ -44,6 +45,9 @@ type OptionT<'``monad<option<'t>>``> with
 
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Lift2 (f: 'T->'U->'V, x: OptionT<'``Monad<option<'T>``>, y: OptionT<'``Monad<option<'U>``>) = OptionT.map2 f x y  : OptionT<'``Monad<option<'V>``>
+
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
+    static member inline Lift3 (f: 'T->'U->'V->'W, x: OptionT<'``Monad<option<'T>``>, y: OptionT<'``Monad<option<'U>``>, z: OptionT<'``Monad<option<'W>``>) = OptionT.map3 f x y z : OptionT<'``Monad<option<'W>``>
 
     static member inline (<*>)  (f: OptionT<'``Monad<option<('T -> 'U)>``>, x: OptionT<'``Monad<option<'T>``>) = OptionT.apply f x : OptionT<'``Monad<option<'U>``>
     static member inline (>>=)  (x: OptionT<'``Monad<option<'T>``>, f: 'T -> OptionT<'``Monad<option<'U>``>)   = OptionT.bind  f x

--- a/src/FSharpPlus/Data/Seq.fs
+++ b/src/FSharpPlus/Data/Seq.fs
@@ -42,6 +42,7 @@ module SeqT =
     let inline bind (f: 'T-> SeqT<'``Monad<seq<'U>``>) (SeqT m: SeqT<'``Monad<seq<'T>``>)          = SeqT (m >>= (mapM : _->seq<_>->_) (run << f) >>= ((Seq.concat: seq<seq<_>>->_) >> result))
     let inline apply (SeqT f: SeqT<'``Monad<seq<('T -> 'U)>``>) (SeqT x: SeqT<'``Monad<seq<'T>``>) = SeqT (map (Seq.apply : seq<_->_>->seq<_>->seq<_>) f <*> x) : SeqT<'``Monad<seq<'U>``>
     let inline lift2 (f: 'T->'U->'V) (SeqT x: SeqT<'``Monad<seq<'T>``>) (SeqT y: SeqT<'``Monad<seq<'U>``>) = SeqT (lift2 (Seq.lift2 f) x y)                     : SeqT<'``Monad<seq<'V>``>
+    let inline lift3 (f: 'T->'U->'V->'W) (SeqT x: SeqT<'``Monad<seq<'T>``>) (SeqT y: SeqT<'``Monad<seq<'U>``>) (SeqT z: SeqT<'``Monad<seq<'V>``>) = SeqT (lift3 (Seq.lift3 f) x y z) : SeqT<'``Monad<seq<'W>``>
     let inline map (f: 'T->'U) (SeqT m: SeqT<'``Monad<seq<'T>``>)                                  = SeqT <| map (Seq.map f : (seq<_>->_)) m                    : SeqT<'``Monad<seq<'U>``>
 
 type SeqT<'``monad<seq<'t>>``> with
@@ -53,6 +54,9 @@ type SeqT<'``monad<seq<'t>>``> with
 
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Lift2 (f: 'T->'U->'V, x: SeqT<'``Monad<seq<'T>``>, y: SeqT<'``Monad<seq<'U>``>) = SeqT.lift2 f x y : SeqT<'``Monad<seq<'V>``>
+
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
+    static member inline Lift3 (f: 'T->'U->'V->'W, x: SeqT<'``Monad<seq<'T>``>, y: SeqT<'``Monad<seq<'U>``>, z: SeqT<'``Monad<seq<'V>``>) = SeqT.lift3 f x y z : SeqT<'``Monad<seq<'W>``>
 
     static member inline (<*>) (f: SeqT<'``Monad<seq<('T -> 'U)>``>, x: SeqT<'``Monad<seq<'T>``>) = SeqT.apply f x : SeqT<'``Monad<seq<'U>``>
     static member inline (>>=) (x: SeqT<'``Monad<seq<'T>``>, f: 'T -> SeqT<'``Monad<seq<'U>``>)   = SeqT.bind  f x

--- a/src/FSharpPlus/Data/State.fs
+++ b/src/FSharpPlus/Data/State.fs
@@ -24,6 +24,9 @@ module State =
     /// Combines two States into one by applying a mapping function.
     let map2 (f: 'T->'U->_) (State x) (State y) = State (fun s -> let (g, s1) = Tuple2.mapItem1 f (x s) in Tuple2.mapItem1 g (y s1)) : State<'S,'V>
 
+    /// Combines three States into one by applying a mapping function.
+    let map3 (f: 'T->'U->'V->_) (State x) (State y) (State z) = State (fun s -> let (g, s1) = Tuple2.mapItem1 f (x s) in let (h, s2) = Tuple2.mapItem1 g (y s1) in Tuple2.mapItem1 h (z s2)) : State<'S,'W>
+
     let bind  f (State m) = State (fun s -> let (a: 'T, s') = m s in run (f a) s')                                : State<'S,'U>
     let apply (State f) (State x) = State (fun s -> let (f', s1) = f s in let (x': 'T, s2) = x s1 in (f' x', s2)) : State<'S,'U>
     /// Evaluates a <paramref name="sa">state computation</paramref> with the <paramref name="s">initial value</paramref> and return only the result value of the computation. Ignore the final state.
@@ -50,6 +53,12 @@ type State<'s,'t> with
 
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Map   (x, f: 'T->_) = State.map f x          : State<'S,'U>
+
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
+    static member Lift2 (f: 'T->'U->_, x, y) = State.map2 f x y : State<'S, 'V>
+
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
+    static member Lift3 (f: 'T->'U->'V->_, x, y, z) = State.map3 f x y z : State<'S, 'W>
 
     static member Return a = State (fun s -> (a, s))           : State<'S,'T>
     static member (>>=) (x, f: 'T->_) = State.bind f x         : State<'S,'U>
@@ -98,6 +107,10 @@ module StateT =
     /// Combines two StateTs into one by applying a mapping function.
     let inline map2 (f: 'T->'U->'V) (StateT x: StateT<'S,'``Monad<'T * 'S>``>) (StateT y: StateT<'S,'``Monad<'U * 'S>``>) : StateT<'S,'``Monad<'V * 'S>``> = StateT (fun s -> x s >>= fun (g, s1) -> y s1 >>= fun (h, s2) -> result (f g h, s2)) : StateT<'S,'``Monad<'V * 'S>``>
 
+    /// Combines three StateTs into one by applying a mapping function.
+    let inline map3 (f: 'T->'U->'V->'W) (StateT x: StateT<'S,'``Monad<'T * 'S>``>) (StateT y: StateT<'S,'``Monad<'U * 'S>``>) (StateT z: StateT<'S,'``Monad<'V * 'S>``>) : StateT<'S,'``Monad<'W * 'S>``> =
+        StateT (fun s -> x s >>= fun (g, s1) -> y s1 >>= fun (h, s2) -> z s2 >>= fun (i, s3) -> result (f g h i, s3))
+
     let inline apply (StateT f: StateT<'S,'``Monad<('T -> 'U) * 'S>``>) (StateT a: StateT<'S,'``Monad<'T * 'S>``>) = StateT (fun s -> f s >>= fun (g, t) -> Map.Invoke (fun (z: 'T, u: 'S) -> ((g z: 'U), u)) (a t)) : StateT<'S,'``Monad<'U * 'S>``>
 
     /// Zips two StateTs into one.
@@ -114,6 +127,9 @@ type StateT<'s,'``monad<'t * 's>``> with
 
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Lift2 (f: 'T->'U->'V, x: StateT<'S,'``Monad<'T * 'S>``>, y: StateT<'S,'``Monad<'U * 'S>``>) : StateT<'S,'``Monad<'V * 'S>``> = StateT.map2 f x y
+
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
+    static member inline Lift3 (f: 'T->'U->'V->'W, x: StateT<'S,'``Monad<'T * 'S>``>, y: StateT<'S,'``Monad<'U * 'S>``>, z : StateT<'S,'``Monad<'V * 'S>``>) : StateT<'S,'``Monad<'W * 'S>``> = StateT.map3 f x y z
 
     static member inline (<*>)  (f: StateT<'S,'``Monad<('T -> 'U) * 'S>``>, x: StateT<'S,'``Monad<'T * 'S>``>) = StateT.apply f x : StateT<'S,'``Monad<'U * 'S>``>
     static member inline (>>=)  (x: StateT<'S,'``Monad<'T * 'S>``>, f: 'T->StateT<'S,'``Monad<'U * 'S>``>)     = StateT.bind  f x

--- a/src/FSharpPlus/Data/ZipList.fs
+++ b/src/FSharpPlus/Data/ZipList.fs
@@ -15,6 +15,7 @@ module ZipList =
     let run   (ZipList x) = x
     let map f (ZipList x) = ZipList (Seq.map f x)
     let map2 (f:'T1->'T2->'U) (ZipList x) (ZipList y) = ZipList (Seq.map2 f x y)
+    let map3 (f:'T1->'T2->'T3->'U) (ZipList x) (ZipList y) (ZipList z) = ZipList (Seq.map3 f x y z)
     let singleton x = ZipList (Seq.singleton x)
 
     /// <summary>Combines the two lists into a list of pairs. The two lists need not have equal lengths:
@@ -31,7 +32,14 @@ type ZipList<'s> with
 
     static member Return (x: 'a)     = ZipList (Seq.initInfinite (konst x))
     static member (<*>) (ZipList (f: seq<'a->'b>), ZipList x) = ZipList (Seq.zip f x |> Seq.map (fun (f, x) -> f x)) : ZipList<'b>    
+    
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Lift2 (f, x : ZipList<'T1>, y : ZipList<'T2>) = ZipList.map2 f x y
+
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
+    static member Lift3 (f, x : ZipList<'T1>, y : ZipList<'T2>, z : ZipList<'T3>) = ZipList.map3 f x y z
+
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member IsLeftZero (ZipList x) = Seq.isEmpty x
     
     static member get_Empty () = ZipList Seq.empty

--- a/src/FSharpPlus/Extensions/Result.fs
+++ b/src/FSharpPlus/Extensions/Result.fs
@@ -32,7 +32,7 @@ module Result =
     /// <param name="z">The third Result value.</param>
     ///
     /// <returns>The combined value, or the first Error.</returns>
-    let map3 f (x: Result<'T, 'Error>) (y: Result<'U, 'Error>) (z: Result<'V, 'Error>): Result<'V, 'Error> =
+    let map3 f (x: Result<'T, 'Error>) (y: Result<'U, 'Error>) (z: Result<'V, 'Error>) : Result<'W, 'Error> =
         match x, y, z with
         | Ok a, Ok b, Ok c -> Ok(f a b c)
         | Error e, _, _


### PR DESCRIPTION
This aims to add missing Lift 2/3 static members in order to be able to use up to `lift3` generic function without any type inference problems.