### PR TITLE
Add missing applicative operators to types

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageProjectUrl>https://github.com/fsprojects/FSharpPlus</PackageProjectUrl>
     <PackageIconUrl>https://raw.github.com/fsprojects/FSharpPlus/master/docsrc/files/img/logo.png</PackageIconUrl>
     <PackageTags>f# FSharp Applicative Monad MonadTransformer Arrow Overloading</PackageTags>
-    <VersionPrefix>1.2.0</VersionPrefix>
+    <VersionPrefix>1.2.3.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</Version>
     <Version Condition=" '$(VersionSuffix)' == '' ">$(VersionPrefix)</Version>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageProjectUrl>https://github.com/fsprojects/FSharpPlus</PackageProjectUrl>
     <PackageIconUrl>https://raw.github.com/fsprojects/FSharpPlus/master/docsrc/files/img/logo.png</PackageIconUrl>
     <PackageTags>f# FSharp Applicative Monad MonadTransformer Arrow Overloading</PackageTags>
-    <VersionPrefix>1.2.3.1</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</Version>
     <Version Condition=" '$(VersionSuffix)' == '' ">$(VersionPrefix)</Version>

--- a/src/FSharpPlus/Data/Cont.fs
+++ b/src/FSharpPlus/Data/Cont.fs
@@ -48,6 +48,12 @@ type Cont<'r,'t> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Map   (x: Cont<'R,'T>, f) = Cont.map f x    : Cont<'R,'U>
 
+    /// <summary>Lifts a function into a Cont. Same as map.
+    /// To be used in Applicative Style expressions, combined with &lt;*&gt;
+    /// </summary>
+    /// <category index="1">Functor</category>
+    static member (<!>) (f: 'T->'U, x: Cont<'R, 'T>) : Cont<'R, 'U> = Cont.map f x
+
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Lift2 (f: 'T->'U->'V, x: Cont<'R,'T>, y: Cont<'R,'U>) : Cont<'R,'V> = Cont.map2 f x y
 
@@ -55,6 +61,19 @@ type Cont<'r,'t> with
     static member inline Lift3 (f: 'T->'U->'V->'W, x: Cont<'R,'T>, y: Cont<'R,'U>, z: Cont<'R,'V>) : Cont<'R,'W> = Cont.map3 f x y z
 
     static member (<*>) (f, x: Cont<'R,'T>) = Cont.apply f x  : Cont<'R,'U>
+
+    /// <summary>
+    /// Sequences two Conts left-to-right, discarding the value of the first argument.
+    /// </summary>
+    /// <category index="2">Applicative</category>
+    static member ( *>) (x: Cont<'R, 'T>, y: Cont<'R, 'U>) : Cont<'R, 'U> = ((fun (_: 'T) (k: 'U) -> k) </Cont.map/>  x : Cont<'R, 'U->'U>) </Cont.apply/> y
+    
+    /// <summary>
+    /// Sequences two Conts left-to-right, discarding the value of the second argument.
+    /// </summary>
+    /// <category index="2">Applicative</category>
+    static member (<*  ) (x: Cont<'R, 'U>, y: Cont<'R, 'T>) : Cont<'R, 'U> = ((fun (k: 'U) (_: 'T) -> k ) </Cont.map/> x : Cont<'R, 'T->'U>) </Cont.apply/> y
+
     static member (>>=) (x, f: 'T->_)       = Cont.bind f x   : Cont<'R,'U>
 
     static member Delay f = Cont (fun k -> Cont.run (f ()) k) : Cont<'R,'T>

--- a/src/FSharpPlus/Data/Monoids.fs
+++ b/src/FSharpPlus/Data/Monoids.fs
@@ -79,13 +79,13 @@ type Const<'t,'u> with
     /// Sequences two Consts left-to-right, discarding the value of the first argument.
     /// </summary>
     /// <category index="2">Applicative</category>
-    static member inline ( *>) (x: Const<'C, 'T>, y: Const<'C, 'U>) : Const<'C, 'U> = ((fun (_: 'T) (k: 'U) -> k) </Const.map/> x : Const<'C, 'U->'U>) </Const.apply/> y
+    static member inline ( *>) (Const x: Const<'C, 'T>, Const y: Const<'C, 'U>) : Const<'C, 'U> = Const (plus x y)
     
     /// <summary>
     /// Sequences two Consts left-to-right, discarding the value of the second argument.
     /// </summary>
     /// <category index="2">Applicative</category>
-    static member inline (<* ) (x: Const<'C, 'U>, y: Const<'C, 'T>): Const<'C, 'U> = ((fun (k: 'U) (_: 'T) -> k ) </Const.map/> x : Const<'C, 'T->'U>) </Const.apply/> y
+    static member inline (<* ) (Const x: Const<'C, 'U>, Const y: Const<'C, 'T>) : Const<'C, 'U> = Const (plus x y)
 
     static member inline Lift2 (_: 'T->'U->'V, Const x: Const<'C,'T>, Const y: Const<'C,'U>) = Const (plus x y) : Const<'C,'V>
     static member inline Lift3 (_: 'T->'U->'V->'W, Const x: Const<'C,'T>, Const y: Const<'C,'U>, Const z: Const<'C,'V>) = Const (x ++ y ++ z) : Const<'C,'W>

--- a/src/FSharpPlus/Data/Monoids.fs
+++ b/src/FSharpPlus/Data/Monoids.fs
@@ -147,12 +147,30 @@ type Compose<'``functorF<'functorG<'t>>``> = Compose of '``functorF<'functorG<'t
     // Functor
     static member inline Map (Compose (x: '``FunctorF<'FunctorG<'T>>``), f: 'T->'U) = Compose (map (map f: '``FunctorG<'T>`` -> '``FunctorG<'U>``) x : '``FunctorF<'FunctorG<'U>>``)
 
+    /// <summary>Lifts a function into a Composed Applicative Functor. Same as map.
+    /// To be used in Applicative Style expressions, combined with &lt;*&gt;
+    /// </summary>
+    /// <category index="1">Functor</category>
+    static member inline (<!>) (f: 'T->'U, x: '``FunctorF<'FunctorG<'T>>``) = Compose (map (map f: '``FunctorG<'T>`` -> '``FunctorG<'U>``) x : '``FunctorF<'FunctorG<'U>>``)
+
     // Applicative
     static member inline Return (x: 'T) = Compose (result (result x: '``ApplicativeG<'T>``)) : Compose<'``ApplicativeF<'ApplicativeG<'T>``>
 
     static member inline (<*>) (Compose (f: '``ApplicativeF<'ApplicativeG<'T->'U>``), Compose (x: '``ApplicativeF<'ApplicativeG<'T>``)) =
         Compose ((((<*>) : '``ApplicativeG<'T->'U>`` -> '``ApplicativeG<'T>`` -> '``ApplicativeG<'U>``) <!> f: '``ApplicativeF<'ApplicativeG<'T>->'ApplicativeG<'U>`` ) <*> x: '``ApplicativeF<'ApplicativeG<'U>``)
 
+    /// <summary>
+    /// Sequences two composed applicatives left-to-right, discarding the value of the first argument.
+    /// </summary>
+    /// <category index="2">Applicative</category>
+    static member inline ( *>) (x: '``FunctorF<'FunctorG<'T>>``, y: '``FunctorF<'FunctorG<'U>>``) : '``FunctorF<'FunctorG<'U>>`` = ((fun (_: 'T) (k: 'U) -> k) <!>  x : '``FunctorF<'FunctorG<'U->'U>>``) <*> y
+    
+    /// <summary>
+    /// Sequences two composed applicatives left-to-right, discarding the value of the second argument.
+    /// </summary>
+    /// <category index="2">Applicative</category>
+    static member inline (<*  ) (x: '``FunctorF<'FunctorG<'U>>``, y: '``FunctorF<'FunctorG<'T>>``): '``FunctorF<'FunctorG<'U>>`` = ((fun (k: 'U) (_: 'T) -> k ) <!> x : '``FunctorF<'FunctorG<'T->'U>>``) <*> y
+    
     static member inline Lift2 (f: 'T -> 'U -> 'V, Compose (x: '``ApplicativeF<'ApplicativeG<'T>``), Compose (y: '``ApplicativeF<'ApplicativeG<'U>``)) =
         Compose (Lift2.Invoke (Lift2.Invoke f: '``ApplicativeG<'T>`` -> '``ApplicativeG<'U>`` -> '``ApplicativeG<'V>``) x y: '``ApplicativeF<'ApplicativeG<'V>``)
 

--- a/src/FSharpPlus/Data/State.fs
+++ b/src/FSharpPlus/Data/State.fs
@@ -54,6 +54,12 @@ type State<'s,'t> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Map   (x, f: 'T->_) = State.map f x          : State<'S,'U>
 
+    /// <summary>Lifts a function into a State. Same as map.
+    /// To be used in Applicative Style expressions, combined with &lt;*&gt;
+    /// </summary>
+    /// <category index="1">Functor</category>
+    static member (<!>) (f: 'T->'U, x: State<'S, 'T>) : State<'S, 'U> = State.map f x
+
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Lift2 (f: 'T->'U->_, x, y) = State.map2 f x y : State<'S, 'V>
 
@@ -63,6 +69,19 @@ type State<'s,'t> with
     static member Return a = State (fun s -> (a, s))           : State<'S,'T>
     static member (>>=) (x, f: 'T->_) = State.bind f x         : State<'S,'U>
     static member (<*>) (f, x: State<'S,'T>) = State.apply f x : State<'S,'U>
+
+    /// <summary>
+    /// Sequences two States left-to-right, discarding the value of the first argument.
+    /// </summary>
+    /// <category index="2">Applicative</category>
+    static member ( *>) (x: State<'S, 'T>, y: State<'S, 'U>) : State<'S, 'U> = ((fun (_: 'T) (k: 'U) -> k) </State.map/> x : State<'S, 'U->'U>) </State.apply/> y
+
+    /// <summary>
+    /// Sequences two States left-to-right, discarding the value of the second argument.
+    /// </summary>
+    /// <category index="2">Applicative</category>
+    static member (<* ) (x: State<'S, 'U>, y: State<'S, 'T>) : State<'S, 'U> = ((fun (k: 'U) (_: 'T) -> k ) </State.map/> x : State<'S, 'T->'U>) </State.apply/> y
+
     static member get_Get () = State.get                       : State<'S,'S>
 
     [<EditorBrowsable(EditorBrowsableState.Never)>]
@@ -125,6 +144,12 @@ type StateT<'s,'``monad<'t * 's>``> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Map    (x: StateT<'S,'``Monad<'T * 'S>``>, f : 'T->'U)                                = StateT.map   f x : StateT<'S,'``Monad<'U * 'S>``>
 
+    /// <summary>Lifts a function into a StateT. Same as map.
+    /// To be used in Applicative Style expressions, combined with &lt;*&gt;
+    /// </summary>
+    /// <category index="1">Functor</category>
+    static member inline (<!>) (f: 'T -> 'U, x: StateT<'S, '``Monad<'T * 'S>``>) : StateT<'S, '``Monad<'U * 'S>``> = StateT.map f x
+
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Lift2 (f: 'T->'U->'V, x: StateT<'S,'``Monad<'T * 'S>``>, y: StateT<'S,'``Monad<'U * 'S>``>) : StateT<'S,'``Monad<'V * 'S>``> = StateT.map2 f x y
 
@@ -132,7 +157,20 @@ type StateT<'s,'``monad<'t * 's>``> with
     static member inline Lift3 (f: 'T->'U->'V->'W, x: StateT<'S,'``Monad<'T * 'S>``>, y: StateT<'S,'``Monad<'U * 'S>``>, z : StateT<'S,'``Monad<'V * 'S>``>) : StateT<'S,'``Monad<'W * 'S>``> = StateT.map3 f x y z
 
     static member inline (<*>)  (f: StateT<'S,'``Monad<('T -> 'U) * 'S>``>, x: StateT<'S,'``Monad<'T * 'S>``>) = StateT.apply f x : StateT<'S,'``Monad<'U * 'S>``>
-    static member inline (>>=)  (x: StateT<'S,'``Monad<'T * 'S>``>, f: 'T->StateT<'S,'``Monad<'U * 'S>``>)     = StateT.bind  f x
+    
+    /// <summary>
+    /// Sequences two States left-to-right, discarding the value of the first argument.
+    /// </summary>
+    /// <category index="2">Applicative</category>
+    static member inline ( *>) (x: StateT<'S, '``Monad<'T * 'S>``>, y: StateT<'S, '``Monad<'U * 'S>``>) : StateT<'S, '``Monad<'U * 'S>``> = ((fun (_: 'T) (k: 'U) -> k) </StateT.map/> x : StateT<'S, '``Monad<('U->'U) * 'S>``>) </StateT.apply/> y
+
+    /// <summary>
+    /// Sequences two States left-to-right, discarding the value of the second argument.
+    /// </summary>
+    /// <category index="2">Applicative</category>
+    static member inline (<* ) (x: StateT<'S, '``Monad<'U * 'S>``>, y: StateT<'S, '``Monad<'T * 'S>``>) : StateT<'S, '``Monad<'U * 'S>``> = ((fun (k: 'U) (_: 'T) -> k ) </StateT.map/> x : StateT<'S, '``Monad<('T->'U) * 'S>``>) </StateT.apply/> y
+    
+    static member inline (>>=)  (x: StateT<'S,'``Monad<'T * 'S>``>, f: 'T->StateT<'S,'``Monad<'U * 'S>``>) = StateT.bind  f x
 
     static member inline get_Empty () = StateT (fun _ -> getEmpty ()) : StateT<'S,'``MonadPlus<'T * 'S>``>
     static member inline (<|>) (StateT m, StateT n) = StateT (fun s -> m s <|> n s) : StateT<'S,'``MonadPlus<'T * 'S>``>

--- a/src/FSharpPlus/Data/Validation.fs
+++ b/src/FSharpPlus/Data/Validation.fs
@@ -237,6 +237,18 @@ type Validation<'err,'a> with
     static member Return x = Success x
     static member inline (<*>)  (f: Validation<_,'T->'U>, x: Validation<_,'T>) : Validation<_,_> = Validation.apply f x
 
+    /// <summary>
+    /// Sequences two Validations left-to-right, discarding the value of the first argument.
+    /// </summary>
+    /// <category index="2">Applicative</category>
+    static member inline ( *>) (x: Validation<'Error, 'T>, y: Validation<'Error, 'U>) : Validation<'Error, 'U> = ((fun (_: 'T) (k: 'U) -> k) </Validation.map/>  x : Validation<'Error, 'U->'U>) </Validation.apply/> y
+    
+    /// <summary>
+    /// Sequences two Validations left-to-right, discarding the value of the second argument.
+    /// </summary>
+    /// <category index="2">Applicative</category>
+    static member inline (<*  ) (x: Validation<'Error, 'U>, y: Validation<'Error, 'T>): Validation<'Error, 'U> = ((fun (k: 'U) (_: 'T) -> k ) </Validation.map/> x : Validation<'Error, 'T->'U>) </Validation.apply/> y
+
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Lift2 (f, x: Validation<_,'T>, y: Validation<_,'U>) : Validation<_,'V> = Validation.map2 f x y
 
@@ -253,6 +265,10 @@ type Validation<'err,'a> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Map (x: Validation<_,_>, f) = Validation.map f x
     
+    /// <summary>Lifts a function into a Validator. Same as map.
+    /// To be used in Applicative Style expressions, combined with &lt;*&gt;
+    /// </summary>
+    /// <category index="1">Functor</category>
     static member (<!>) (f, x: Validation<_,_>) = Validation.map f x
 
     // as Bifunctor

--- a/src/FSharpPlus/Data/Writer.fs
+++ b/src/FSharpPlus/Data/Writer.fs
@@ -65,6 +65,12 @@ type Writer<'monoid,'t> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member        Map   (x, f: 'T->_) = Writer.map f x           : Writer<'Monoid,'U>
 
+    /// <summary>Lifts a function into a Writer. Same as map.
+    /// To be used in Applicative Style expressions, combined with &lt;*&gt;
+    /// </summary>
+    /// <category index="1">Functor</category>
+    static member (<!>) (f: 'T -> _, x) : Writer<'Monoid, 'U> = Writer.map f x
+
     #if !FABLE_COMPILER
     static member inline Return x = Writer (x, getZero ())              : Writer<'Monoid,'T>
     #else
@@ -73,6 +79,18 @@ type Writer<'monoid,'t> with
 
     static member inline (>>=) (x, f: 'T->_) = Writer.bind f x          : Writer<'Monoid,'U>
     static member inline (<*>) (f, x: Writer<_,'T>) = Writer.apply f x  : Writer<'Monoid,'U>
+
+    /// <summary>
+    /// Sequences two Writers left-to-right, discarding the value of the first argument.
+    /// </summary>
+    /// <category index="2">Applicative</category>
+    static member inline ( *>) (x: Writer<'Monoid, 'T>, y: Writer<'Monoid, 'U>) : Writer<'Monoid, 'U> = ((fun (_: 'T) (k: 'U) -> k) </Writer.map/> x : Writer<'Monoid, 'U -> 'U>) </Writer.apply/> y
+
+    /// <summary>
+    /// Sequences two Writers left-to-right, discarding the value of the second argument.
+    /// </summary>
+    /// <category index="2">Applicative</category>
+    static member inline (<* ) (x: Writer<'Monoid, 'U>, y: Writer<'Monoid, 'T>) : Writer<'Monoid, 'U> = ((fun (k: 'U) (_: 'T) -> k ) </Writer.map/> x : Writer<'Monoid, 'T -> 'U>) </Writer.apply/> y
 
     static member        Tell   w = Writer.tell w                       : Writer<'Monoid,unit>
     static member        Listen m = Writer.listen m                     : Writer<'Monoid,('T * 'Monoid)>
@@ -123,6 +141,12 @@ type WriterT<'``monad<'t * 'monoid>``> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Map   (x: WriterT<'``Monad<'T * 'Monoid>``>, f: 'T -> 'U)                                   = WriterT.map   f x : WriterT<'``Monad<'U * 'Monoid>``>
 
+    /// <summary>Lifts a function into a WriterT. Same as map.
+    /// To be used in Applicative Style expressions, combined with &lt;*&gt;
+    /// </summary>
+    /// <category index="1">Functor</category>
+    static member inline (<!>) (f: 'T -> 'U, x: WriterT<'``Monad<'T * 'Monoid>``>) : WriterT<'``Monad<'U * 'Monoid>``> = WriterT.map f x
+
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Lift2 (f: 'T->'U->'V, x: WriterT<'``Monad<'T * 'Monoid>``>, y: WriterT<'``Monad<'U * 'Monoid>``>) : WriterT<'``Monad<'V * 'Monoid>``> = WriterT.map2 f x y
 
@@ -130,6 +154,19 @@ type WriterT<'``monad<'t * 'monoid>``> with
     static member inline Lift3 (f: 'T->'U->'V->'W, x: WriterT<'``Monad<'T * 'Monoid>``>, y: WriterT<'``Monad<'U * 'Monoid>``>, z: WriterT<'``Monad<'V * 'Monoid>``>) : WriterT<'``Monad<'W * 'Monoid>``> = WriterT.map3 f x y z
 
     static member inline (<*>) (f: WriterT<'``Monad<('T -> 'U) * 'Monoid>``>, x: WriterT<'``Monad<'T * 'Monoid>``>)  = WriterT.apply f x : WriterT<'``Monad<'U * 'Monoid>``>
+    
+    /// <summary>
+    /// Sequences two Writers left-to-right, discarding the value of the first argument.
+    /// </summary>
+    /// <category index="2">Applicative</category>
+    static member inline ( *>) (x: WriterT<'``Monad<'T * 'Monoid>``>, y: WriterT<'``Monad<'U * 'Monoid>``>) : WriterT<'``Monad<'U * 'Monoid>``> = ((fun (_: 'T) (k: 'U) -> k) </WriterT.map/> x : WriterT<'``Monad<('U -> 'U) * 'Monoid>``>) </WriterT.apply/> y
+
+    /// <summary>
+    /// Sequences two Writers left-to-right, discarding the value of the second argument.
+    /// </summary>
+    /// <category index="2">Applicative</category>
+    static member inline (<* ) (x: WriterT<'``Monad<'U * 'Monoid>``>, y: WriterT<'``Monad<'T * 'Monoid>``>) : WriterT<'``Monad<'U * 'Monoid>``> = ((fun (k: 'U) (_: 'T) -> k ) </WriterT.map/> x : WriterT<'``Monad<('T -> 'U) * 'Monoid>``>) </WriterT.apply/> y
+    
     static member inline (>>=) (x: WriterT<'``Monad<'T * 'Monoid>``>, f: 'T -> _)                                    = WriterT.bind  f x : WriterT<'``Monad<'U * 'Monoid>``>
 
     static member inline get_Empty () = WriterT (getEmpty ()) : WriterT<'``MonadPlus<'T * 'Monoid>``>

--- a/src/FSharpPlus/Operators.fs
+++ b/src/FSharpPlus/Operators.fs
@@ -204,7 +204,7 @@ module Operators =
     /// Sequences two applicatives left-to-right, discarding the value of the second argument.
     /// </summary>
     /// <category index="2">Applicative</category>
-    let inline (<*  ) (x: '``Applicative<'U>``) (y: '``Applicative<'T>``): '``Applicative<'U>`` = ((fun (k: 'U) (_: 'T) -> k ) <!> x : '``Applicative<'T->'U>``) <*> y
+    let inline (<*  ) (x: '``Applicative<'U>``) (y: '``Applicative<'T>``) : '``Applicative<'U>`` = ((fun (k: 'U) (_: 'T) -> k ) <!> x : '``Applicative<'T->'U>``) <*> y
 
     /// <summary>
     /// Apply a lifted argument to a lifted function (flipped): arg &lt;**&gt; f


### PR DESCRIPTION
Adding `<!>`, `*>` and `<*` as static members to:
- Const, Compose, Validation
- Reader, ReaderT
- State, StateT
- Writer, WriterT
- Cont, ContT

This will have the subtle advantage of having them available even if `FSharpPlus.Operators` is not in scope, which would in such case reduce compiler pressure.