### PR TITLE
Build docs on GitHub action instead of in AppVeyor

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -32,11 +32,15 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 6.0.201
+    - name: Setup .NET Core 5
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.405
     - name: Setup .NET Core 3.1
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.420
+        dotnet-version: 3.1.416
     - name: Restore
       run: git submodule update --init --recursive
-    - name: Restore tools
+    - name: Build All Docs
       run: dotnet msbuild -target:AllDocs build.proj

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -23,3 +23,20 @@ jobs:
       run: dotnet build build.proj --configuration Release
     - name: Test with dotnet
       run: dotnet test build.proj -v n
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core 6
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.201
+    - name: Setup .NET Core 3.1
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.420
+    - name: Restore
+      run: git submodule update --init --recursive
+    - name: Restore tools
+      run: dotnet msbuild -target:AllDocs build.proj

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -25,7 +25,7 @@ jobs:
       run: dotnet test build.proj -v n
 
   docs:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET Core 6

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,8 +18,6 @@ build_script:
   - cmd: dotnet build -c Release ./FSharpPlus.sln
   - cmd: dotnet test -c Release tests/FSharpPlus.Tests
   - ps: if ($env:VersionSuffix) { dotnet pack build.proj --version-suffix $env:VersionSuffix } else { dotnet pack build.proj }
-  - ps: ./docsrc/tools/download_nugets.ps1
-  - cmd: dotnet run -c Release --project ./docsrc/tools
 test: off
 artifacts:
   - path: bin

--- a/build.proj
+++ b/build.proj
@@ -18,6 +18,14 @@
     <Exec Command='dotnet test tests/FSharpPlus.Tests -c Release --logger:trx' WorkingDirectory="$(RepoRootDir)" IgnoreStandardErrorWarningFormat="true" />
   </Target>
 
+  <!-- dotnet msbuild -target:AllDocs build.proj -->
+  <Target Name="AllDocs">
+    <Exec Command='dotnet build FSharpPlus.sln -c Release' WorkingDirectory="$(RepoRootDir)" IgnoreStandardErrorWarningFormat="true" />
+    <Exec Command='./docsrc/tools/download_nugets.cmd' WorkingDirectory="$(RepoRootDir)" IgnoreStandardErrorWarningFormat="true" Condition=" '$(OS)' == 'Windows_NT' " />
+    <Exec Command='./docsrc/tools/download_nugets.sh' WorkingDirectory="$(RepoRootDir)" IgnoreStandardErrorWarningFormat="true" Condition=" '$(OS)' != 'Windows_NT' " />
+    <Exec Command='dotnet run -c Release --project ./docsrc/tools' WorkingDirectory="$(RepoRootDir)" IgnoreStandardErrorWarningFormat="true" />
+  </Target>
+
   <Target Name="VSTest" DependsOnTargets="Test" />
 
 </Project>

--- a/docsrc/content/abstraction-alternative.fsx
+++ b/docsrc/content/abstraction-alternative.fsx
@@ -1,7 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
 
 (**
 Alternative

--- a/docsrc/content/abstraction-applicative.fsx
+++ b/docsrc/content/abstraction-applicative.fsx
@@ -1,7 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
 
 (**
 Applicative

--- a/docsrc/content/abstraction-arrow.fsx
+++ b/docsrc/content/abstraction-arrow.fsx
@@ -1,7 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
 
 (**
 Arrow

--- a/docsrc/content/abstraction-bifoldable.fsx
+++ b/docsrc/content/abstraction-bifoldable.fsx
@@ -1,7 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
 
 (**
 Bifoldable

--- a/docsrc/content/abstraction-bifunctor.fsx
+++ b/docsrc/content/abstraction-bifunctor.fsx
@@ -1,7 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
 
 (**
 Bifunctor

--- a/docsrc/content/abstraction-bitraversable.fsx
+++ b/docsrc/content/abstraction-bitraversable.fsx
@@ -1,7 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
 
 (**
 Bitraversable

--- a/docsrc/content/abstraction-category.fsx
+++ b/docsrc/content/abstraction-category.fsx
@@ -1,7 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
 
 (**
 Category

--- a/docsrc/content/abstraction-comonad.fsx
+++ b/docsrc/content/abstraction-comonad.fsx
@@ -1,7 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
 
 (**
 Comonad

--- a/docsrc/content/abstraction-contravariant.fsx
+++ b/docsrc/content/abstraction-contravariant.fsx
@@ -1,7 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
 
 (**
 Contravariant

--- a/docsrc/content/abstraction-foldable.fsx
+++ b/docsrc/content/abstraction-foldable.fsx
@@ -1,7 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
 
 (**
 Foldable

--- a/docsrc/content/abstraction-functor.fsx
+++ b/docsrc/content/abstraction-functor.fsx
@@ -1,7 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
 
 (**
 Functor

--- a/docsrc/content/abstraction-misc.fsx
+++ b/docsrc/content/abstraction-misc.fsx
@@ -1,7 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
 
 (**
 Other abstractions

--- a/docsrc/content/abstraction-monad.fsx
+++ b/docsrc/content/abstraction-monad.fsx
@@ -1,7 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
 
 (**
 Monad

--- a/docsrc/content/abstraction-monoid.fsx
+++ b/docsrc/content/abstraction-monoid.fsx
@@ -1,7 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
 
 (**
 Monoid

--- a/docsrc/content/abstraction-profunctor.fsx
+++ b/docsrc/content/abstraction-profunctor.fsx
@@ -1,7 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
 
 (**
 Profunctor

--- a/docsrc/content/abstraction-semigroup.fsx
+++ b/docsrc/content/abstraction-semigroup.fsx
@@ -1,7 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
 
 (**
 Semigroup

--- a/docsrc/content/abstraction-traversable.fsx
+++ b/docsrc/content/abstraction-traversable.fsx
@@ -1,7 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
 
 (**
 Traversable

--- a/docsrc/content/abstractions.fsx
+++ b/docsrc/content/abstractions.fsx
@@ -1,7 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
 
 (**
 

--- a/docsrc/content/applicative-functors.fsx
+++ b/docsrc/content/applicative-functors.fsx
@@ -1,7 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
 
 (**
 Functors and Applicatives

--- a/docsrc/content/computation-expressions.fsx
+++ b/docsrc/content/computation-expressions.fsx
@@ -1,7 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
 
 #r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 open FSharpPlus

--- a/docsrc/content/extension-methods.fsx
+++ b/docsrc/content/extension-methods.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 #r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 open FSharpPlus
 

--- a/docsrc/content/extensions.fsx
+++ b/docsrc/content/extensions.fsx
@@ -1,7 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
 #r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 (**

--- a/docsrc/content/generic-doc.fsx
+++ b/docsrc/content/generic-doc.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 #r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 open FSharpPlus
 

--- a/docsrc/content/index.fsx
+++ b/docsrc/content/index.fsx
@@ -1,7 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
 #r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 (**

--- a/docsrc/content/lens.fsx
+++ b/docsrc/content/lens.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 #r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 (**

--- a/docsrc/content/numerics.fsx
+++ b/docsrc/content/numerics.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 #r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 open FSharpPlus
 

--- a/docsrc/content/operators-common.fsx
+++ b/docsrc/content/operators-common.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 #r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 open FSharpPlus
 

--- a/docsrc/content/parsing.fsx
+++ b/docsrc/content/parsing.fsx
@@ -1,7 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
 open System
 #r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 open FSharpPlus

--- a/docsrc/content/tutorial.fsx
+++ b/docsrc/content/tutorial.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 Introducing FSharpPlus
 ======================

--- a/docsrc/content/type-all.fsx
+++ b/docsrc/content/type-all.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 All
 ===

--- a/docsrc/content/type-any.fsx
+++ b/docsrc/content/type-any.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 Any
 ===

--- a/docsrc/content/type-choicet.fsx
+++ b/docsrc/content/type-choicet.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 TO-DO Add some docs here !
 =========================

--- a/docsrc/content/type-compose.fsx
+++ b/docsrc/content/type-compose.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 Compose
 =======

--- a/docsrc/content/type-const.fsx
+++ b/docsrc/content/type-const.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 Const<'T,'U>
 ============

--- a/docsrc/content/type-cont.fsx
+++ b/docsrc/content/type-cont.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 Cont<'R,'U>
 ===========

--- a/docsrc/content/type-contt.fsx
+++ b/docsrc/content/type-contt.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 TO-DO Add some docs here !
 =========================

--- a/docsrc/content/type-coproduct.fsx
+++ b/docsrc/content/type-coproduct.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 TO-DO Add some docs here !
 =========================

--- a/docsrc/content/type-dlist.fsx
+++ b/docsrc/content/type-dlist.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 DList
 =========================

--- a/docsrc/content/type-dual.fsx
+++ b/docsrc/content/type-dual.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 TO-DO Add some docs here !
 =========================

--- a/docsrc/content/type-endo.fsx
+++ b/docsrc/content/type-endo.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 TO-DO Add some docs here !
 =========================

--- a/docsrc/content/type-first.fsx
+++ b/docsrc/content/type-first.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 TO-DO Add some docs here !
 =========================

--- a/docsrc/content/type-free.fsx
+++ b/docsrc/content/type-free.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 TO-DO Add some docs here !
 =========================

--- a/docsrc/content/type-identity.fsx
+++ b/docsrc/content/type-identity.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 TO-DO Add some docs here !
 =========================

--- a/docsrc/content/type-kleisli.fsx
+++ b/docsrc/content/type-kleisli.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 TO-DO Add some docs here !
 =========================

--- a/docsrc/content/type-last.fsx
+++ b/docsrc/content/type-last.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 TO-DO Add some docs here !
 =========================

--- a/docsrc/content/type-listt.fsx
+++ b/docsrc/content/type-listt.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 TO-DO Add some docs here !
 =========================

--- a/docsrc/content/type-matrix.fsx
+++ b/docsrc/content/type-matrix.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 Matrix<'NumType,'Rows,'Cols>
 ========================================

--- a/docsrc/content/type-mult.fsx
+++ b/docsrc/content/type-mult.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 TO-DO Add some docs here !
 =========================

--- a/docsrc/content/type-nonempty-map.fsx
+++ b/docsrc/content/type-nonempty-map.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 NonEmptyMap<'Key, 'Value>
 ================

--- a/docsrc/content/type-nonempty-set.fsx
+++ b/docsrc/content/type-nonempty-set.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 NonEmptySet<'T>
 ================

--- a/docsrc/content/type-nonempty.fsx
+++ b/docsrc/content/type-nonempty.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 NonEmptyList<'T>
 ================

--- a/docsrc/content/type-optiont.fsx
+++ b/docsrc/content/type-optiont.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 TO-DO Add some docs here !
 =========================

--- a/docsrc/content/type-parallelarray.fsx
+++ b/docsrc/content/type-parallelarray.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 ParallelArray<'T>
 =================

--- a/docsrc/content/type-reader.fsx
+++ b/docsrc/content/type-reader.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 Reader<'R,'T>
 =============

--- a/docsrc/content/type-readert.fsx
+++ b/docsrc/content/type-readert.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 TO-DO Add some docs here !
 =========================

--- a/docsrc/content/type-resultt.fsx
+++ b/docsrc/content/type-resultt.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 TO-DO Add some docs here !
 =========================

--- a/docsrc/content/type-seqt.fsx
+++ b/docsrc/content/type-seqt.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 TO-DO Add some docs here !
 =========================

--- a/docsrc/content/type-state.fsx
+++ b/docsrc/content/type-state.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 State<'S,'T>
 ============

--- a/docsrc/content/type-statet.fsx
+++ b/docsrc/content/type-statet.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 TO-DO Add some docs here !
 =========================

--- a/docsrc/content/type-validation.fsx
+++ b/docsrc/content/type-validation.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 Validation<'Error,'T>
 =====================

--- a/docsrc/content/type-vector.fsx
+++ b/docsrc/content/type-vector.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 Vector<'NumType,'Dimension>
 ===========================

--- a/docsrc/content/type-writer.fsx
+++ b/docsrc/content/type-writer.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 Writer<'Monoid,'T>
 ==================

--- a/docsrc/content/type-writert.fsx
+++ b/docsrc/content/type-writert.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 TO-DO Add some docs here !
 =========================

--- a/docsrc/content/type-ziplist.fsx
+++ b/docsrc/content/type-ziplist.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 ZipList<'T>
 ===========

--- a/docsrc/content/types.fsx
+++ b/docsrc/content/types.fsx
@@ -1,8 +1,6 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#I "../../bin"
-
 (**
 
 Types


### PR DESCRIPTION
- build proj target to build all docs
- configuration to build docs on GitHub action
- Remove ../../bin references that are no longer relevant for docs