### PR TITLE
Proper SeqT implementation

### DIFF
--- a/docsrc/content/type-seqt.fsx
+++ b/docsrc/content/type-seqt.fsx
@@ -1,15 +1,79 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-(**
-TO-DO Add some docs here !
-=========================
+(*
+SeqT<Monad<bool>, 'T>
+=====================
+
+This is the the Monad Transformer for `seq<'T>` so it adds sequencing to existing monads by composing then with `seq<'T>`.
+
+Any monad can be composed, but a very typical usage is when combined with `Async` or `Task`, which gives rise to what's called async sequences.
+
+Therefore the [AsyncSeq](https://github.com/fsprojects/FSharp.Control.AsyncSeq) library can be considered a specialization of this monad in Async.
+
+The original post from AsyncSeq can be found [here](http://tomasp.net/blog/async-sequences.aspx) and we can run those examples with `SeqT` by adapting the code.
+
+In order to do so we need to be aware of the design differences of both implementations.
+
+| AsyncSeq  			        | SeqT 	                                | Notes	|
+|--|--|:--:|
+|`AsyncSeq<'T>`                 |`SeqT<Async<bool>, 'T>`                |           |
+|`asyncSeq { .. }`              |`monad.plus { .. }`                    | At some point it needs to be inferred as `SeqT<Async<bool>, 'T>`, or it can be specified with type parameters: `monad<SeqT<Async<bool>, 'T>>.plus` |
+|`let! x = y`                   |`let! x = SeqT.lift y`                 | No auto lifting. Lifting should be explicit. |
+|`do! x`                        |`do! x`                                | ''        |
+|`for x in s`                   |`let! x = s`                           | When `s: AsyncSeq<'T>` otherwise `for` is still ok with regular sequences. |
+|`AsyncSeq.[function]`          |`SeqT.[function]`                      | See differences in functions below. |
+|`AsyncSeq.[function]Async`     |`SeqT.[function]M`                     | ''        |
+|`AsyncSeq.skip`                |`SeqT.drop`                            | `.skip` is available but consistently with F# collections, it throws when the sequence doesn't have enough elements. |
+|`AsyncSeq.take`                |`SeqT.truncate`                        | `.take` is available but consistently with F# collections, it throws when the sequence doesn't have enough elements. |
+|`AsyncSeq.toBlockingSequence`  |`SeqT.run >> Async.RunSynchronously`   | Not really the same but semantically equivalent. |
+|`AsyncSeq.toListAsync`         |`SeqT.runAsList`                       |           |
+|`AsyncSeq.toArrayAsync`        |`SeqT.runAsArray`                      |           |
+|`AsyncSeq.zipWith`             |`SeqT.map2`                            | Aligned with F# collections. |
+|`AsyncSeq.zipWithAsync`        |`SeqT.map2M`                           |  ''       |
+|`AsyncSeq.ofObservable`        |`Observable.toAsyncSeq`                |`.toAsyncTask` is also available. |
+|`AsyncSeq.toObservable`        |`Observable.ofAsyncSeq`                |`.ofAsyncTask` is also available. |
+
+
 
 Examples
 --------
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
+#r @"C:\Repos\FSharpPlus\src\FSharpPlus\bin\Release\net6\FSharpPlus.dll"
 
+open System
+open System.Net
 open FSharpPlus
+open FSharpPlus.Data
+
+let urls =
+  [ "http://bing.com"; "http://yahoo.com";
+    "http://google.com"; "http://msn.com"; ]
+
+// Asynchronous sequence that returns URLs and lengths
+// of the downloaded HTML. Web pages from a given list
+// are downloaded asynchronously in sequence.
+let pages: SeqT<_, _> = monad.plus {
+    use wc = new WebClient ()
+    for url in urls do
+        try
+            let! html = wc.AsyncDownloadString (Uri url) |> SeqT.lift
+            yield url, html.Length
+        with _ ->
+            yield url, -1 }
+
+
+// Print URL of pages that are smaller than 100k
+let printPages =
+    pages
+    |> SeqT.filter (fun (_, len) -> len < 100000)
+    |> SeqT.map fst
+    |> SeqT.iter (printfn "%s")
+ 
+printPages |> Async.Start
+
+(*
+To make it work with tasks simply add `|> Async.StartAsTask` between `wc.AsyncDownloadString (Uri url)` and `|> SeqT.lift` then run eveything but the `printPages |> Async.Start`.
+**)

--- a/docsrc/content/type-seqt.fsx
+++ b/docsrc/content/type-seqt.fsx
@@ -1,6 +1,11 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
+
+// For some reason AsyncDownloadString is not found during doc build. The following is a dumb implementation just to make the compiler happy.
+// TODO find out why.
+type System.Net.WebClient with member wc.AsyncDownloadString (uri: System.Uri) = async { return wc.DownloadString uri }
+
 (*
 SeqT<Monad<bool>, 'T>
 =====================
@@ -39,7 +44,6 @@ In order to do so we need to be aware of the design differences of both implemen
 Examples
 --------
 *)
-
 
 #r @"C:\Repos\FSharpPlus\src\FSharpPlus\bin\Release\net6\FSharpPlus.dll"
 

--- a/docsrc/content/type-seqt.fsx
+++ b/docsrc/content/type-seqt.fsx
@@ -45,7 +45,7 @@ Examples
 --------
 *)
 
-#r @"C:\Repos\FSharpPlus\src\FSharpPlus\bin\Release\net6\FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net45/FSharpPlus.dll"
 
 open System
 open System.Net

--- a/src/FSharpPlus/Data/Seq.fs
+++ b/src/FSharpPlus/Data/Seq.fs
@@ -92,6 +92,9 @@ type SeqT<'``monad``, 't> =
 
 module SeqT =
 
+    [<Literal>]
+    let private enumNotStarted = "Enumeration has not started. Call MoveNext."
+
     let ofIEnumerableM x : SeqT<'``Monad<bool>``, 'T> = SeqT x
 
     [<RequireQualifiedAccess; EditorBrowsable(EditorBrowsableState.Never)>]
@@ -110,7 +113,7 @@ module SeqT =
                         member _.Current =
                             match current with
                             | Some c -> c
-                            | None -> invalidOp "Enumeration has not started. Call MoveNext."                            
+                            | None -> invalidOp enumNotStarted
                         member x.MoveNext () = monad' {
                             match state with
                             | SeqState.NotStarted inp ->
@@ -144,7 +147,7 @@ module SeqT =
                         member _.Current =
                             match current with
                             | Some c -> c
-                            | None -> invalidOp "Enumeration has not started. Call MoveNext."
+                            | None -> invalidOp enumNotStarted
                         member x.MoveNext () = monad' {
                             match state with
                             | SeqState.NotStarted inp ->
@@ -205,7 +208,7 @@ module SeqT =
                 member _.GetEnumerator () =
                     { new IEnumeratorM<'``Monad<bool>``, 'T> with
                         member _.MoveNext () = result false
-                        member _.Current = invalidOp "Enumeration has not started. Call MoveNext."
+                        member _.Current = invalidOp enumNotStarted
                         member _.Dispose () = () } }
 
     let inline singleton (v: 'T) : SeqT<'``Monad<bool>``, 'T> =
@@ -220,7 +223,7 @@ module SeqT =
                             return res }
                         member _.Current =
                             if started then v
-                            else invalidOp "Enumeration has not started. Call MoveNext."
+                            else invalidOp enumNotStarted
                         member _.Dispose () = () } }
 
     [<EditorBrowsable(EditorBrowsableState.Never)>]
@@ -234,7 +237,7 @@ module SeqT =
                     { new IEnumeratorM<'``Monad<bool>``, 'T> with 
                         member _.Current =
                             match state with
-                            | -1 -> invalidOp "Enumeration has not started. Call MoveNext."
+                            | -1 -> invalidOp enumNotStarted
                             | _  -> current
                         member x.MoveNext () = innerMonad {
                             match state with
@@ -283,7 +286,7 @@ module SeqT =
                         member _.Current =
                             match started with
                             | Some v -> v
-                            | None -> invalidOp "Enumeration has not started. Call MoveNext."
+                            | None -> invalidOp enumNotStarted
                         member _.Dispose () = () } }
 
     [<RequireQualifiedAccess; EditorBrowsable(EditorBrowsableState.Never)>]
@@ -303,7 +306,7 @@ module SeqT =
                         member _.Current =
                             match current with
                             | Some c -> c
-                            | None -> invalidOp "Enumeration has not started. Call MoveNext."                            
+                            | None -> invalidOp enumNotStarted
                         member x.MoveNext () = monad' {
                             match state with
                             | CollectState.NotStarted inp ->
@@ -318,7 +321,7 @@ module SeqT =
                                         let e2 = (f e1.Current :> IEnumerableM<'``Monad<bool>``, 'U>).GetEnumerator ()
                                         state <- CollectState.HaveInnerEnumerator (e1, e2)
                                     else x.Dispose ()
-                                    x.MoveNext () )
+                                    x.MoveNext ())
                             | CollectState.HaveInnerEnumerator (e1, e2) ->
                                 let! (res2: bool) = e2.MoveNext ()
                                 if res2 then
@@ -350,7 +353,7 @@ module SeqT =
                         member _.Current =
                             match current with
                             | Some c -> c
-                            | None -> invalidOp "Enumeration has not started. Call MoveNext."                            
+                            | None -> invalidOp enumNotStarted
                         member x.MoveNext () = monad' {
                             match state with
                             | CollectState.NotStarted f ->
@@ -365,7 +368,7 @@ module SeqT =
                                         let e2 = (x1 :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
                                         state <- CollectState.HaveInnerEnumerator (e1, e2)
                                     else x.Dispose ()
-                                    x.MoveNext () )
+                                    x.MoveNext ())
                             | CollectState.HaveInnerEnumerator (e1, e2) ->
                                 let! (res2: bool) = e2.MoveNext ()
                                 if res2 then
@@ -397,7 +400,7 @@ module SeqT =
                         member _.Current =
                             match current with
                             | Some c -> c
-                            | None -> invalidOp "Enumeration has not started. Call MoveNext."                            
+                            | None -> invalidOp enumNotStarted
                         member x.MoveNext () = monad' {
                             match state with
                             | CollectState.NotStarted x1 ->
@@ -412,7 +415,7 @@ module SeqT =
                                         let e2 = (x2 :> IEnumerableM<'``Monad<bool>``, 'T2>).GetEnumerator ()
                                         state <- CollectState.HaveInnerEnumerator (e1, e2)
                                     else x.Dispose ()
-                                    x.MoveNext () )
+                                    x.MoveNext ())
                             | CollectState.HaveInnerEnumerator (e1, e2) ->
                                 let! (res2: bool) = e2.MoveNext ()
                                 if res2 then
@@ -452,7 +455,7 @@ module SeqT =
                         member _.Current =
                             match current with
                             | Some c -> c
-                            | None -> invalidOp "Enumeration has not started. Call MoveNext."
+                            | None -> invalidOp enumNotStarted
                         member x.MoveNext () = innerMonad {
                             match state with 
                             | AppendState.NotStarted1 (inp1, inp2) -> 
@@ -474,7 +477,7 @@ module SeqT =
                                 return! (
                                     let enum2 = (inp2 :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
                                     state <- AppendState.HaveEnumerator2 enum2
-                                    x.MoveNext () )
+                                    x.MoveNext ())
                             | AppendState.HaveEnumerator2 enum2 ->   
                                 let! (res: bool) = enum2.MoveNext ()
                                 return (
@@ -513,7 +516,7 @@ module SeqT =
                         member _.Current =
                             match current with
                             | Some c -> c
-                            | None -> invalidOp "Enumeration has not started. Call MoveNext."                            
+                            | None -> invalidOp enumNotStarted
                         member x.MoveNext () = innerMonad {
                               match state with
                               | MapState.NotStarted inp ->
@@ -553,7 +556,7 @@ module SeqT =
                         member _.Current =
                             match current with
                             | Some c -> c
-                            | None -> invalidOp "Enumeration has not started. Call MoveNext."                            
+                            | None -> invalidOp enumNotStarted
                         member x.MoveNext () = innerMonad {
                             match state with
                             | Map2State.NotStarted (s1, s2) -> return! (
@@ -589,7 +592,7 @@ module SeqT =
                         member _.Current =
                             match current with
                             | Some c -> c
-                            | None -> invalidOp "Enumeration has not started. Call MoveNext."                            
+                            | None -> invalidOp enumNotStarted
                         member x.MoveNext () = innerMonad {
                             match state with
                             | Map2State.NotStarted (s1, s2) ->
@@ -642,7 +645,7 @@ module SeqT =
                         member _.Current =
                             match current with
                             | Some c -> c
-                            | None -> invalidOp "Enumeration has not started. Call MoveNext."
+                            | None -> invalidOp enumNotStarted
                         member x.MoveNext () = innerMonad {
                               match state with
                               | CollectState.NotStarted inp ->
@@ -704,7 +707,7 @@ module SeqT =
                         member _.Current =
                             match current with
                             | Some c -> c
-                            | None -> invalidOp "Enumeration has not started. Call MoveNext."
+                            | None -> invalidOp enumNotStarted
                         member x.MoveNext () = innerMonad2<_, '``Monad<unit>``> () {
                             match state with
                             | TryWithState.NotStarted inp ->
@@ -776,7 +779,7 @@ module SeqT =
                         member _.Current =
                             match current with
                             | Some c -> c
-                            | None -> invalidOp "Enumeration has not started. Call MoveNext."
+                            | None -> invalidOp enumNotStarted
                         member x.MoveNext () = innerMonad {
                             match state with
                             | TryFinallyState.NotStarted inp ->
@@ -810,7 +813,7 @@ module SeqT =
                         member _.Current =
                             match current, started with
                             | Some c, true -> c
-                            | _     , false -> invalidOp "Enumeration has not started. Call MoveNext."
+                            | _     , false -> invalidOp enumNotStarted
                             | None  , true  -> invalidOp "Enumeration finished."
                         member x.MoveNext () = monad' {
                             if not started then
@@ -881,25 +884,20 @@ module SeqT =
                             if i > 0 then
                                 i <- i - 1
                                 e.MoveNext () |> monomorphicBind (fun res ->
-                                    if not res then
-                                        let msg = sprintf "The input sequence has an insufficient number of elements: tried to take %i %s past the end of the sequence. Use SeqT.truncate to get %i or less elements" (i+1) (if i = 0 then "element" else "elements") count
-                                        raise (new InvalidOperationException(msg))
-                                    result res )
+                                    if not res then invalidOp (
+                                        sprintf
+                                            "The input sequence has an insufficient number of elements: tried to take %i %s past the end of the sequence. Use SeqT.truncate to get %i or less elements."
+                                            (i + 1)
+                                            (if i = 0 then "element" else "elements")
+                                            count)
+                                    result res)
                             else
                                 x.Dispose ()
                                 result false
                         member _.Dispose () = dispose e } }
-
-    /// <summary>Returns a sequence that skips at most N elements of the underlying sequence and then yields the
-    /// remaining elements of the sequence.</summary>
-    ///
-    /// <param name="count">The number of items to skip.</param>
-    /// <param name="source">The input sequence.</param>
-    ///
-    /// <returns>The result sequence.</returns>
-    ///
-    /// <exception cref="T:System.ArgumentNullException">Thrown when count is negative.</exception>
-    let inline drop count (source: SeqT<'``Monad<bool>``, 'T>) : SeqT<'``Monad<bool>``, 'T> =
+    
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
+    let inline skipImpl throw count (source: SeqT<'``Monad<bool>``, 'T>) : SeqT<'``Monad<bool>``, 'T> =
         if (count < 0) then invalidArg "count" "must be non-negative"
         SeqT
             { new IEnumerableM<'``Monad<bool>``, 'T> with
@@ -915,14 +913,33 @@ module SeqT =
                                     if res then
                                         x.MoveNext ()
                                     else
-                                        x.Dispose ()
-                                        result res)
+                                        if throw then
+                                            invalidOp (
+                                                sprintf
+                                                    "tried to skip %i %s past the end of the seq. Use SeqT.drop to skip %i or less elements."
+                                                    (i + 1)
+                                                    (if i = 0 then "element" else "elements")
+                                                    count)
+                                        else
+                                            x.Dispose ()
+                                            result false)
                             else
                                 e.MoveNext () |> monomorphicBind (fun res ->
                                     if not res then
                                         x.Dispose ()
                                     result res)
                         member _.Dispose () = dispose e } }
+
+    /// <summary>Returns a sequence that skips at most N elements of the underlying sequence and then yields the
+    /// remaining elements of the sequence.</summary>
+    ///
+    /// <param name="count">The number of items to skip.</param>
+    /// <param name="source">The input sequence.</param>
+    ///
+    /// <returns>The result sequence.</returns>
+    ///
+    /// <exception cref="T:System.ArgumentNullException">Thrown when count is negative.</exception>
+    let inline drop count (source: SeqT<'``Monad<bool>``, 'T>) : SeqT<'``Monad<bool>``, 'T> = skipImpl false count source
 
     /// <summary>Returns a sequence that skips N elements of the underlying sequence and then yields the
     /// remaining elements of the sequence.</summary>
@@ -939,34 +956,7 @@ module SeqT =
     /// <exception cref="T:System.ArgumentNullException">Thrown when count is negative.</exception>
     /// <exception cref="T:System.InvalidOperationException">Thrown when count exceeds the number of elements
     /// in the sequence.</exception>
-    let inline skip count (source: SeqT<'``Monad<bool>``, 'T>) : SeqT<'``Monad<bool>``, 'T> =
-        if (count < 0) then invalidArg "count" "must be non-negative"
-        SeqT
-            { new IEnumerableM<'``Monad<bool>``, 'T> with
-                member _.GetEnumerator () =
-                    let mutable i = count
-                    let e = (source :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
-                    { new IEnumeratorM<'``Monad<bool>``, 'T> with
-                        member _.Current = e.Current                       
-                        member x.MoveNext () =
-                            if i > 0 then
-                                i <- i - 1
-                                e.MoveNext () |> monomorphicBind (fun res ->
-                                    if res then
-                                        x.MoveNext ()
-                                    else
-                                        invalidOp (
-                                            sprintf
-                                                "tried to skip %i %s past the end of the seq. Use SeqT.drop to skip %i or less elements."
-                                                (i + 1)
-                                                (if i = 0 then "element" else "elements")
-                                                count))
-                            else
-                                e.MoveNext () |> monomorphicBind (fun res ->
-                                    if not res then
-                                        x.Dispose ()
-                                    result res)
-                        member _.Dispose () = dispose e } }
+    let inline skip count (source: SeqT<'``Monad<bool>``, 'T>) : SeqT<'``Monad<bool>``, 'T> = skipImpl true count source
 
 
 type [<AutoOpen>]SeqTOperations =

--- a/src/FSharpPlus/Data/Seq.fs
+++ b/src/FSharpPlus/Data/Seq.fs
@@ -16,73 +16,534 @@ module Seq =
 
     let inline replicateM count (initial: '``Applicative<'T>``) = sequence (Seq.replicate count initial)
 
-
+open System
+open System.Collections.Generic
 open FSharpPlus.Control
 
-/// Monad Transformer for seq<'T>
+#endif
+#nowarn "0193"
+#if !FABLE_COMPILER
+
+type MonadFxStrictBuilderMod<'``monad<'t>``> () =
+    inherit FSharpPlus.GenericBuilders.MonadFxStrictBuilder<'``monad<'t>``> ()
+    
+    member inline _.Delay expr = (fun () -> Delay.Invoke expr) : unit -> '``Monad<'T>``
+
+type MonadFxStrictBuilderMod2<'``monad<'t>``, ^``monad<unit>``>
+                                    when (Return or  ^``monad<unit>``) : (static member Return: ^``monad<unit>`` * Return -> (unit -> ^``monad<unit>``)) 
+                                    and  (Bind or  ^``monad<unit>``) : (static member (>>=): ^``monad<unit>`` * (unit -> ^``monad<unit>``) -> ^``monad<unit>``)
+                                    and  (Using or ^``monad<unit>``) : (static member Using: IDisposable * (IDisposable -> ^``monad<unit>``) * Using -> ^``monad<unit>``)
+                                         () =
+    inherit StrictBuilder<'``monad<'t>``> ()
+    member inline _.Zero () = result ()                                       : '``monad<unit>``
+    member inline _.Combine (a: '``Monad<unit>``, b) = a >>= (fun () -> b ()) : '``Monad<'T>``
+    
+    member inline _.While (guard, body: unit -> '``monad<unit>``)             : '``monad<unit>`` =
+        let rec loop guard body =
+            if guard () then body () >>= fun () -> loop guard body
+            else result ()
+        loop guard body
+    
+     member inline this.For (p: #seq<'T>, rest: 'T->'``monad<unit>``) =
+         Using.Invoke (p.GetEnumerator () :> IDisposable) (fun enum ->
+             let enum = enum :?> IEnumerator<_>
+             this.While (enum.MoveNext, fun () -> rest enum.Current) : '``monad<unit>``)
+
+    member inline _.Delay expr = (fun () -> Delay.Invoke expr) : unit -> '``Monad<'T>``
+
+
+module SpecialBuilders =
+    let innerMonad<'mt> = new (*FSharpPlus.GenericBuilders.*) MonadFxStrictBuilderMod<'mt> () // works perfectly with this for tasks
+    let inline innerMonad2<'mt, .. > () = new MonadFxStrictBuilderMod2<'mt, _> ()
+
+open SpecialBuilders
+
+
+
+type IEnumeratorM<'``Monad<bool>``, 'T> =
+    abstract MoveNext : unit -> '``Monad<bool>``
+    abstract Current : 'T with get
+    inherit IDisposable
+
+type IEnumerableM<'``Monad<bool>``, 'T> =
+    abstract GetEnumerator : unit -> IEnumeratorM<'``Monad<bool>``, 'T>
+
+// Monad Transformer for seq<'T>
 [<Struct>]
-type SeqT<'``monad<seq<'t>>``> = SeqT of '``monad<seq<'t>>``
+type SeqT<'``monad``, 't> =
+    | SeqT of IEnumerableM<'``monad``, 't>
+    interface IEnumerableM<'``monad``, 't> with
+        member x.GetEnumerator () = let (SeqT x) = x in x.GetEnumerator()
 
-/// Basic operations on SeqT
-[<RequireQualifiedAccess>]
+
 module SeqT =
-    let run (SeqT m) = m
 
-    /// Embed a Monad<'T> into a SeqT<'Monad<seq<'T>>>
-    let inline lift (x: '``Monad<'T>``) : SeqT<'``Monad<seq<'T>>``> =
-           if opaqueId false then x |> liftM Seq.singleton |> SeqT
-           else x |> map Seq.singleton |> SeqT
-
-    let inline internal sequence ms =
-        let k m m' = m >>= fun (x: 'a) -> m' >>= fun (xs: seq<'a>) -> (result: seq<'a> -> 'M) (seq {yield x; yield! xs})
-        Seq.foldBack k ms ((result: seq<'a> -> 'M) Seq.empty)
-
-    let inline internal mapM f as' = sequence (Seq.map f as')
-
-    let inline bind (f: 'T-> SeqT<'``Monad<seq<'U>``>) (SeqT m: SeqT<'``Monad<seq<'T>``>)          = SeqT (m >>= (mapM : _->seq<_>->_) (run << f) >>= ((Seq.concat: seq<seq<_>>->_) >> result))
-    let inline apply (SeqT f: SeqT<'``Monad<seq<('T -> 'U)>``>) (SeqT x: SeqT<'``Monad<seq<'T>``>) = SeqT (map (Seq.apply : seq<_->_>->seq<_>->seq<_>) f <*> x) : SeqT<'``Monad<seq<'U>``>
-    let inline lift2 (f: 'T->'U->'V) (SeqT x: SeqT<'``Monad<seq<'T>``>) (SeqT y: SeqT<'``Monad<seq<'U>``>) = SeqT (lift2 (Seq.lift2 f) x y)                     : SeqT<'``Monad<seq<'V>``>
-    let inline lift3 (f: 'T->'U->'V->'W) (SeqT x: SeqT<'``Monad<seq<'T>``>) (SeqT y: SeqT<'``Monad<seq<'U>``>) (SeqT z: SeqT<'``Monad<seq<'V>``>) = SeqT (lift3 (Seq.lift3 f) x y z) : SeqT<'``Monad<seq<'W>``>
-    let inline map (f: 'T->'U) (SeqT m: SeqT<'``Monad<seq<'T>``>)                                  = SeqT <| map (Seq.map f : (seq<_>->_)) m                    : SeqT<'``Monad<seq<'U>``>
-
-type SeqT<'``monad<seq<'t>>``> with
-
-    static member inline Return (x: 'T) = x |> Seq.singleton |> result |> SeqT                                     : SeqT<'``Monad<seq<'T>``>
+    let inline toArrayM<'T, .. > (source: SeqT<'``Monad<bool>``, 'T>) : '``Monad<'T []>`` =
+        let ra = new ResizeArray<_> ()
+        Using.Invoke
+            ((source :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ())
+            (fun ie ->
+                ie.MoveNext () >>= fun (move: bool) ->
+                    let b = ref move
+                    let rec loop guard (body: unit -> '``Monad<unit>``) : '``Monad<unit>`` =
+                        if guard () then body () >>= (fun () -> loop guard body)
+                        else result ()
+                    loop
+                        (fun () -> b.Value)
+                        (fun () ->
+                            ra.Add ie.Current
+                            ie.MoveNext() >>= fun moven ->
+                                b := moven
+                                result () )
+                    >>= fun () -> result (ra.ToArray ()) )
     
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
-    static member inline Map   (x: SeqT<'``Monad<seq<'T>``>, f: 'T->'U) = SeqT.map f x                             : SeqT<'``Monad<seq<'U>``>
+    let inline toListM<'T, .. > (source: SeqT<'``Monad<bool>``, 'T>) : '``Monad<'T list>`` = toArrayM<_, _, '``Monad<'T []>``, '``Monad<unit>``> source |> map Array.toList<'T>
+    let inline toSeqM<'T, .. >  (source: SeqT<'``Monad<bool>``, 'T>) : '``Monad<'T seq>``  = toArrayM<_, _, '``Monad<'T []>``, '``Monad<unit>``> source |> map Array.toSeq<'T>
+    let inline run<'T, .. >     (source: SeqT<'``Monad<bool>``, 'T>) : '``Monad<'T seq>``  =   toSeqM<_, _, '``Monad<unit>``, '``Monad<'T []>``, '``Monad<'T seq>``> source
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
-    static member inline Lift2 (f: 'T->'U->'V, x: SeqT<'``Monad<seq<'T>``>, y: SeqT<'``Monad<seq<'U>``>) = SeqT.lift2 f x y : SeqT<'``Monad<seq<'V>``>
+    [<GeneralizableValue>]
+    let inline empty<'T, .. > : SeqT<'``Monad<bool>``, 'T> =
+        SeqT
+          { new IEnumerableM<'``Monad<bool>``, 'T> with
+                member _.GetEnumerator() =
+                    { new IEnumeratorM<'``Monad<bool>``, 'T> with
+                          member _.MoveNext() = result false
+                          member _.Current = invalidOp "Enumeration has not started. Call MoveNext."
+                          member _.Dispose() = () } }
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
-    static member inline Lift3 (f: 'T->'U->'V->'W, x: SeqT<'``Monad<seq<'T>``>, y: SeqT<'``Monad<seq<'U>``>, z: SeqT<'``Monad<seq<'V>``>) = SeqT.lift3 f x y z : SeqT<'``Monad<seq<'W>``>
 
-    static member inline (<*>) (f: SeqT<'``Monad<seq<('T -> 'U)>``>, x: SeqT<'``Monad<seq<'T>``>) = SeqT.apply f x : SeqT<'``Monad<seq<'U>``>
-    static member inline (>>=) (x: SeqT<'``Monad<seq<'T>``>, f: 'T -> SeqT<'``Monad<seq<'U>``>)   = SeqT.bind  f x
+    let inline singleton (v: 'T) : SeqT<'``Monad<bool>``, 'T> =
+        SeqT
+          { new IEnumerableM<'``Monad<bool>``, 'T> with 
+                member _.GetEnumerator () = 
+                    let stateStarted = ref false
+                    { new IEnumeratorM<'``Monad<bool>``, 'T> with 
+                          member _.MoveNext () =
+                              innerMonad {
+                                  let res = not stateStarted.Value
+                                  stateStarted := true
+                                  return res }
+                          member _.Current =
+                              if stateStarted.Value then v
+                              else invalidOp "Enumeration has not started. Call MoveNext."
+                          member _.Dispose() = () } }
 
-    static member inline get_Empty () = SeqT <| result Seq.empty : SeqT<'``MonadPlus<seq<'T>``>
-    static member inline (<|>) (SeqT x, SeqT y) = SeqT <| (x >>= (fun a -> y >>= (fun b ->  result ((Seq.append:seq<_>->seq<_>->_) a b)))) : SeqT<'``MonadPlus<seq<'T>``>
 
-    static member inline TryWith (source: SeqT<'``Monad<seq<'T>>``>, f: exn -> SeqT<'``Monad<seq<'T>>``>) = SeqT (TryWith.Invoke (SeqT.run source) (SeqT.run << f))
-    static member inline TryFinally (computation: SeqT<'``Monad<seq<'T>>``>, f) = SeqT (TryFinally.Invoke     (SeqT.run computation) f)
-    static member inline Using (resource, f: _ -> SeqT<'``Monad<seq<'T>>``>)    = SeqT (Using.Invoke resource (SeqT.run << f))
-    static member inline Delay (body : unit   ->  SeqT<'``Monad<seq<'T>>``>)    = SeqT (Delay.Invoke (fun _ -> SeqT.run (body ()))) : SeqT<'``Monad<seq<'T>>``>
+
+
+    let inline make (f: unit -> '``Monad<SeqT<'Monad<bool>, 'T>>``) : SeqT<'``Monad<bool>``, 'T> =
+        SeqT
+          { new IEnumerableM<'``Monad<bool>``, 'T> with
+                member _.GetEnumerator() = 
+                    let state   = ref -1
+                    let enum    = ref Unchecked.defaultof<IEnumeratorM<'``Monad<bool>``, 'T>>
+                    let current = ref Unchecked.defaultof<'T>
+                    { new IEnumeratorM<'``Monad<bool>``, 'T> with 
+                        member _.Current =
+                            match !state with
+                            | -1 -> invalidOp "Enumeration has not started. Call MoveNext."
+                            | _  -> current.Value
+
+                        member x.MoveNext() = 
+                            innerMonad {
+                                match !state with
+                                    | -1 -> 
+                                        let! (s: SeqT<'``Monad<bool>``, 'T>) = f ()
+                                        return! (
+                                            let e = (s :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
+                                            enum := e
+                                            state := 0
+                                            x.MoveNext ())
+                                    | 0 ->   
+                                        let e = enum.Value
+                                        let! (res: bool) = e.MoveNext ()
+                                        do
+                                            current := e.Current
+                                            if not res then x.Dispose ()
+                                        return res
+                                    | _ -> return false }
+                        member _.Dispose() = 
+                            match !state with 
+                            | 0 -> 
+                                let e = enum.Value
+                                state := 1
+                                enum := Unchecked.defaultof<_>
+                                dispose e 
+                            | _ -> () } }
+
+
+    // let inline delayO (f: unit -> SeqT<'``Monad<bool>``, 'T>) : SeqT<'``Monad<bool>``, 'T> =  make (fun () -> monad { return f() })
+
+    let delay (f: unit -> SeqT<'``Monad<bool>``, 'T>) : SeqT<'``Monad<bool>``, 'T> =
+        SeqT
+            { new IEnumerableM<'``Monad<bool>``, 'T> with
+                member _.GetEnumerator() = (f () :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator () }
+
+    let inline bindM<'T, 'U, .. > (f: 'T -> SeqT<'``Monad<bool>``, 'U>) (inp: '``Monad<'T>``) : SeqT<'``Monad<bool>``, 'U> =
+         make (fun () -> innerMonad<'``Monad<SeqT<'Monad<bool>, 'U>>``> { let! v = inp in return f v })
+
+    let inline lift<'T, .. > (x: '``Monad<'T>``) : SeqT<'``Monad<bool>``, 'T> =
+        bindM<_, _, _, '``Monad<SeqT<'Monad<bool>, 'T>>``, _> (singleton: 'T -> SeqT<'``Monad<bool>``, 'T>) x
+
+
+    [<RequireQualifiedAccess>]
+    type CollectState<'T, 'U, '``Monad<bool>``> =
+       | NotStarted    of SeqT<'``Monad<bool>``, 'T>
+       | HaveInputEnumerator of IEnumeratorM<'``Monad<bool>``, 'T>
+       | HaveInnerEnumerator of IEnumeratorM<'``Monad<bool>``, 'T> * IEnumeratorM<'``Monad<bool>``, 'U>
+       | Finished
+
+
+    let inline collect<'T, 'U, .. > (f: 'T -> SeqT<'``Monad<bool>``, 'U>) (inp: SeqT<'``Monad<bool>``, 'T>) : SeqT<'``Monad<bool>``, 'U> =
+        SeqT
+          { new IEnumerableM<'``Monad<bool>``, 'U> with
+                member x.GetEnumerator() =
+                    let state = ref (CollectState.NotStarted inp)
+                    let current = ref Option<'U>.None
+                    { new IEnumeratorM<'``Monad<bool>``, 'U>  with
+                        member _.Current =
+                            match !current with
+                            | Some c -> c
+                            | None -> invalidOp "Enumeration has not started. Call MoveNext."                            
+                        member x.MoveNext() =
+                            innerMonad {
+                                match !state with
+                                    | CollectState.NotStarted inp ->
+                                        return! (
+                                            let e1 = (inp :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
+                                            state := CollectState.HaveInputEnumerator e1
+                                            x.MoveNext ())
+                                    | CollectState.HaveInputEnumerator e1 ->
+                                        let! res1 = e1.MoveNext()
+                                        return! (
+                                            if res1 then
+                                                let e2 = (f e1.Current :> IEnumerableM<'``Monad<bool>``, 'U>).GetEnumerator ()
+                                                state := CollectState.HaveInnerEnumerator (e1, e2)
+                                            else
+                                                x.Dispose ()
+                                            x.MoveNext() )
+                                    | CollectState.HaveInnerEnumerator (e1, e2) ->
+                                        let! (res2: bool) = e2.MoveNext()
+                                        if res2 then
+                                            current := Some e2.Current
+                                            return res2
+                                        else
+                                            state := CollectState.HaveInputEnumerator e1
+                                            dispose e2
+                                            return! x.MoveNext()
+                                    | _ ->
+                                        return false }
+                        member _.Dispose() =
+                            match !state with
+                            | CollectState.HaveInputEnumerator e1 ->
+                                state := CollectState.Finished
+                                dispose e1
+                            | CollectState.HaveInnerEnumerator (e1, e2) ->
+                                state := CollectState.Finished
+                                dispose e2
+                                dispose e1
+                            | _ -> () } }
+
+
+    [<RequireQualifiedAccess>]
+    type AppendState<'``Monad<bool>``, 'T> =
+       | NotStarted1     of SeqT<'``Monad<bool>``, 'T> * SeqT<'``Monad<bool>``, 'T>
+       | HaveEnumerator1 of IEnumeratorM<'``Monad<bool>``, 'T> * SeqT<'``Monad<bool>``, 'T>
+       | NotStarted2     of SeqT<'``Monad<bool>``, 'T>
+       | HaveEnumerator2 of IEnumeratorM<'``Monad<bool>``, 'T> 
+       | Finished        
+
+    let inline append (inp1: SeqT<'``Monad<bool>``, 'T>) (inp2: SeqT<'``Monad<bool>``, 'T>) : SeqT<'``Monad<bool>``, 'T> =
+        SeqT
+          { new IEnumerableM<'``Monad<bool>``, 'T>  with 
+                member x.GetEnumerator() = 
+                    let state = ref (AppendState.NotStarted1 (inp1, inp2) )
+                    let current = ref Option<'T>.None
+                    { new IEnumeratorM<'``Monad<bool>``, 'T>  with
+                        member _.Current =
+                            match !current with
+                            | Some c -> c
+                            | None -> invalidOp "Enumeration has not started. Call MoveNext."     
     
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
-    static member inline Lift (x: '``Monad<'T>``) : SeqT<'``Monad<seq<'T>>``> = SeqT.lift x
+                        member x.MoveNext() = 
+                            innerMonad {
+                                match !state with 
+                                    | AppendState.NotStarted1 (inp1, inp2) -> 
+                                        return! (
+                                            let enum1 = (inp1 :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
+                                            state := AppendState.HaveEnumerator1 (enum1, inp2)
+                                            x.MoveNext ())
+                                    | AppendState.HaveEnumerator1 (enum1, inp2) ->
+                                        let! (res: bool) = enum1.MoveNext ()
+                                        if res then
+                                            current := Some enum1.Current
+                                            return res
+                                        else
+                                            return! 
+                                              (state := AppendState.NotStarted2 inp2
+                                               dispose enum1
+                                               x.MoveNext ())
+                                    | AppendState.NotStarted2 inp2 ->
+                                        return! (
+                                            let enum2 = (inp2 :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
+                                            state := AppendState.HaveEnumerator2 enum2
+                                            x.MoveNext () )
+                                    | AppendState.HaveEnumerator2 enum2 ->   
+                                        let! (res: bool) = enum2.MoveNext ()
+                                        return (
+                                            if res then
+                                                current := Some enum2.Current
+                                            else
+                                                state := AppendState.Finished
+                                                dispose enum2
+                                            res)
+                                               
+                                    | _ -> 
+                                        return false }
+                          member x.Dispose() = 
+                              match !state with 
+                              | AppendState.HaveEnumerator1 (enum, _) 
+                              | AppendState.HaveEnumerator2 enum -> 
+                                  state := AppendState.Finished
+                                  dispose enum 
+                              | _ -> () } }
+
+    let inline mapM (f: 'T -> '``Monad<'U>``) (source: SeqT<'``Monad<bool>``, 'T>) : SeqT<'``Monad<bool>``, 'U> =
+        source |> collect (fun itm ->
+            f itm |> bindM<_, _, _, '``Monad<SeqT<'Monad<bool>, 'U>>``, _> (fun v ->
+                singleton v))
+
+    let inline map (f: 'T -> 'U) (inp: SeqT<'``Monad<bool>``, 'T>) : SeqT<'``Monad<bool>``, 'U> =
+        SeqT
+          { new IEnumerableM<'``Monad<bool>``, 'U> with
+                member x.GetEnumerator() =
+                    let state = ref (CollectState.NotStarted inp)
+                    let current = ref Option<'U>.None
+                    { new IEnumeratorM<'``Monad<bool>``, 'U>  with
+                        member _.Current =
+                            match !current with
+                            | Some c -> c
+                            | None -> invalidOp "Enumeration has not started. Call MoveNext."                            
+                        member x.MoveNext() =
+                              innerMonad {
+                                  match !state with
+                                      | CollectState.NotStarted inp ->
+                                          return! (
+                                              let e1 = (inp :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
+                                              state := CollectState.HaveInputEnumerator e1
+                                              x.MoveNext())
+                                      | CollectState.HaveInputEnumerator e1 ->
+                                          let! res1 = e1.MoveNext()
+                                          if res1 then
+                                              current := Some (f e1.Current)
+                                              return true
+                                          else
+                                              x.Dispose ()
+                                              return! x.MoveNext ()
+                                      | _ ->
+                                          return false }
+                          member _.Dispose() =
+                              match !state with
+                              | CollectState.HaveInputEnumerator e1 ->
+                                  state := CollectState.Finished
+                                  dispose e1
+                              | CollectState.HaveInnerEnumerator (e1, e2) ->
+                                  state := CollectState.Finished
+                                  dispose e2
+                                  dispose e1
+                              | _ -> () } }
+
+
+    let inline filter (f: 'T -> bool) (inp: SeqT<'``Monad<bool>``, 'T>) : SeqT<'``Monad<bool>``, 'T> =
+        SeqT
+          { new IEnumerableM<'``Monad<bool>``, 'T> with
+                member x.GetEnumerator() =
+                    let state = ref (CollectState.NotStarted inp)
+                    let current = ref Option<'T>.None
+                    { new IEnumeratorM<'``Monad<bool>``, 'T>  with
+                        member _.Current =
+                            match !current with
+                            | Some c -> c
+                            | None -> invalidOp "Enumeration has not started. Call MoveNext."
+                        member x.MoveNext () =
+                              innerMonad {
+                                  match !state with
+                                      | CollectState.NotStarted inp ->
+                                          return! (
+                                              let e1 = (inp :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
+                                              state := CollectState.HaveInputEnumerator e1
+                                              x.MoveNext ())
+                                      | CollectState.HaveInputEnumerator e1 ->
+                                          let! res1 = e1.MoveNext ()
+                                          if res1 && f e1.Current then
+                                              current := Some e1.Current
+                                              return true
+                                          elif res1 then
+                                              return! x.MoveNext ()
+                                          else
+                                              x.Dispose()
+                                              return! x.MoveNext ()
+                                      | _ ->
+                                          return false }
+                          member _.Dispose() =
+                              match !state with
+                              | CollectState.HaveInputEnumerator e1 ->
+                                  state := CollectState.Finished
+                                  dispose e1
+                              | CollectState.HaveInnerEnumerator (e1, e2) ->
+                                  state := CollectState.Finished
+                                  dispose e2
+                                  dispose e1
+                              | _ -> () } }
+
+    let inline iteriM<'T, .. > (f: int -> 'T -> '``Monad<unit>``) (source: SeqT<'``Monad<bool>``, 'T>) : '``Monad<unit>`` = 
+        innerMonad { 
+            use ie = (source :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
+            let count = ref 0
+            let! (move: bool) = ie.MoveNext ()
+            let b = ref move
+            while b.Value do
+                do! f !count ie.Current
+                let! moven = ie.MoveNext ()
+                do incr count
+                   b := moven
+        }
+
+    let inline iterM<'T, .. > (f: 'T -> '``Monad<unit>``) (inp: SeqT<'``Monad<bool>``, 'T>) : '``Monad<unit>`` = iteriM (fun _ x -> f x) inp    
+    let inline iteri<'T, .. > (f: int -> 'T -> unit)      (inp: SeqT<'``Monad<bool>``, 'T>) : '``Monad<unit>`` = iteriM (fun i x -> result (f i x)) inp
+    let inline iter<'T, .. > f (source: SeqT<'``Monad<bool>``, 'T>) : '``Monad<unit>`` = iterM (f >> result) source
+
+    [<RequireQualifiedAccess>]
+    type TryWithState<'``Monad<bool>``, 'T> =
+       | NotStarted of SeqT<'``Monad<bool>``, 'T>
+       | HaveBodyEnumerator of IEnumeratorM<'``Monad<bool>``, 'T>
+       | HaveHandlerEnumerator of IEnumeratorM<'``Monad<bool>``, 'T>
+       | Finished
+
+    /// Implements the 'TryWith' functionality for computation builder
+    let inline tryWith<'T, .. > (inp: SeqT<'``Monad<bool>``, 'T>) (handler : exn -> SeqT<'``Monad<bool>``, 'T>) : SeqT<'``Monad<bool>``, 'T> =
+          // Note: this is put outside the object deliberately, so the object doesn't permanently capture inp1 and inp2
+        SeqT
+          { new IEnumerableM<'``Monad<bool>``, 'T> with
+                member x.GetEnumerator() =
+                    let state = ref (TryWithState.NotStarted inp)
+                    let current = ref Option<'T>.None
+                    { new IEnumeratorM<'``Monad<bool>``, 'T>  with
+                        member _.Current =
+                            match !current with
+                            | Some c -> c
+                            | None -> invalidOp "Enumeration has not started. Call MoveNext."
+                        member x.MoveNext () =
+                            innerMonad2<_, '``Monad<unit>``> () {
+                              match !state with
+                              | TryWithState.NotStarted inp ->
+                                  let res = ref Unchecked.defaultof<_>
+                                  try
+                                      res := Choice1Of2 ((inp :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ())
+                                  with exn ->
+                                      res := Choice2Of2 exn
+                                  match res.Value with
+                                  | Choice1Of2 r ->
+                                      return!
+                                        (state := TryWithState.HaveBodyEnumerator r
+                                         x.MoveNext ())
+                                  | Choice2Of2 exn ->
+                                      return!
+                                         (x.Dispose ()
+                                          let enum = (handler exn :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
+                                          state := TryWithState.HaveHandlerEnumerator enum
+                                          x.MoveNext ())
+                              | TryWithState.HaveBodyEnumerator e ->
+                                  let res = ref Unchecked.defaultof<Choice<bool, exn>>
+                                  try
+                                      let! r = e.MoveNext ()
+                                      res := Choice1Of2 r
+                                  with exn ->
+                                      res := Choice2Of2 exn
+                                  match res.Value with
+                                  | Choice1Of2 res ->
+                                      return
+                                          (match res with
+                                           | false -> x.Dispose ()
+                                           | true  -> current := Some e.Current
+                                           res)
+                                  | Choice2Of2 exn ->
+                                      return!
+                                        (x.Dispose()
+                                         let e = (handler exn :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
+                                         state := TryWithState.HaveHandlerEnumerator e
+                                         x.MoveNext())
+                              | TryWithState.HaveHandlerEnumerator e ->
+                                  let! res = e.MoveNext()
+                                  return (match res with
+                                          | true  -> current := Some e.Current; true
+                                          | false -> x.Dispose (); false)
+                              | _ ->
+                                  return false }
+                                
+                          member _.Dispose() =
+                              match !state with
+                              | TryWithState.HaveBodyEnumerator e | TryWithState.HaveHandlerEnumerator e ->
+                                  state := TryWithState.Finished
+                                  dispose e
+                              | _ -> () } }
+
+
+    [<RequireQualifiedAccess>]
+    type TryFinallyState<'``Monad<bool>``, 'T> =
+       | NotStarted    of SeqT<'``Monad<bool>``, 'T>
+       | HaveBodyEnumerator of IEnumeratorM<'``Monad<bool>``, 'T>
+       | Finished
+
+    // This pushes the handler through all the async computations
+    // The (synchronous) compensation is run when the Dispose() is called
+    let inline tryFinally (inp: SeqT<'``Monad<bool>``, 'T>) (compensation : unit -> unit) : SeqT<'``Monad<bool>``, 'T> =
+        SeqT
+          { new IEnumerableM<'``Monad<bool>``, 'T> with
+                member x.GetEnumerator() =
+                    let state = ref (TryFinallyState.NotStarted inp)
+                    let current = ref Option<'T>.None
+                    { new IEnumeratorM<'``Monad<bool>``, 'T>  with
+                        member _.Current =
+                            match !current with
+                            | Some c -> c
+                            | None -> invalidOp "Enumeration has not started. Call MoveNext."
+                        member x.MoveNext () =
+                              innerMonad {
+                                  match !state with
+                                      | TryFinallyState.NotStarted inp ->
+                                          return! (
+                                              let e = (inp :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
+                                              state := TryFinallyState.HaveBodyEnumerator e
+                                              x.MoveNext ())
+                                      | TryFinallyState.HaveBodyEnumerator e ->
+                                          let! (res: bool) = e.MoveNext ()
+                                          return (
+                                              if res then current := Some e.Current
+                                              else x.Dispose()
+                                              res)
+                                      | _ ->
+                                          return false }
+                          member x.Dispose() =
+                              match !state with
+                              | TryFinallyState.HaveBodyEnumerator e ->
+                                  state := TryFinallyState.Finished
+                                  dispose e
+                                  compensation ()
+                              | _ -> () } }
+
+type SeqT<'``monad<bool>``, 'T> with
     
-    static member inline LiftAsync (x: Async<'T>) = SeqT.lift (liftAsync x) : SeqT<'``MonadAsync<'T>``>
-    
-    static member inline Throw (x: 'E) = x |> throw |> SeqT.lift
-    static member inline Catch (m: SeqT<'``MonadError<'E1,'T>``>, h: 'E1 -> SeqT<'``MonadError<'E2,'T>``>) = SeqT ((fun v h -> catch v h) (SeqT.run m) (SeqT.run << h)) : SeqT<'``MonadError<'E2,'T>``>
-    
-    static member inline CallCC (f: (('T -> SeqT<'``MonadCont<'R,seq<'U>>``>) -> _)) = SeqT (callCC <| fun c -> SeqT.run (f (SeqT  << c << Seq.singleton ))) : SeqT<'``MonadCont<'R, seq<'T>>``>
-    
-    static member inline get_Get ()  = SeqT.lift get         : SeqT<'``MonadState<'S,'S>``>
-    static member inline Put (x: 'S) = x |> put |> SeqT.lift : SeqT<'``MonadState<unit,'S>``>
-    
-    static member inline get_Ask () = SeqT.lift ask          : SeqT<'``MonadReader<'R,seq<'R>>``>
-    static member inline Local (SeqT (m: '``MonadReader<'R2,'T>``), f: 'R1->'R2) = SeqT (local f m)
+    static member inline Return (x: 'T) : SeqT<'``Monad<bool>``, 'T> = SeqT.singleton x
+    static member inline Map (x: SeqT<'``Monad<bool>``, 'T>, f: 'T -> 'U) : SeqT<'``Monad<bool>``, 'U> = SeqT.map f x
+    static member inline (>>=) (x: SeqT<'``Monad<bool>``, 'T>, f: 'T -> SeqT<'``Monad<bool>``, 'U>) : SeqT<'``Monad<bool>``, 'U> = SeqT.collect f x
+    static member inline get_Empty () : SeqT<'``Monad<bool>``, 'T> = SeqT.empty
+    static member inline (<|>) (x, y) : SeqT<'``Monad<bool>``, 'T> = SeqT.append x y
+
+    static member inline TryWith (source: SeqT<'``Monad<bool>``, 'T>, f: exn -> SeqT<'``Monad<bool>``, 'T>) = SeqT.tryWith<_, _, '``Monad<unit>``, _> source f
+    static member inline TryFinally (computation: SeqT<'``Monad<bool>``, 'T>, f) = SeqT.tryFinally computation f
+    static member inline Delay (body: unit -> SeqT<'``Monad<bool>``, 'T>) : SeqT<'``Monad<bool>``, 'T> = SeqT.delay body
+
+    static member inline Lift (m: '``Monad<'T>``) : SeqT<'``Monad<bool>``, 'T> = SeqT.lift<_, _, '``Monad<SeqT<'Monad<bool>, 'T>>``, _> m
 
 #endif

--- a/src/FSharpPlus/Data/Seq.fs
+++ b/src/FSharpPlus/Data/Seq.fs
@@ -192,10 +192,10 @@ module SeqT =
                                 result () )
                     >>= fun () -> result (f ra))
     
-    let inline runToArray<'T, .. > (source: SeqT<'``Monad<bool>``, 'T>) : '``Monad<'T []>`` =
+    let inline runAsArray<'T, .. > (source: SeqT<'``Monad<bool>``, 'T>) : '``Monad<'T []>`` =
         runThen<'T, 'T [], '``Monad<bool>``, '``Monad<'T []>``, '``Monad<unit>``> toArray source
     
-    let inline runToList<'T, .. > (source: SeqT<'``Monad<bool>``, 'T>) : '``Monad<'T list>`` =
+    let inline runAsList<'T, .. > (source: SeqT<'``Monad<bool>``, 'T>) : '``Monad<'T list>`` =
         runThen<'T, 'T list, '``Monad<bool>``, '``Monad<'T list>``, '``Monad<unit>``> toList source
 
     let inline run<'T, .. >       (source: SeqT<'``Monad<bool>``, 'T>) : '``Monad<'T seq>`` =

--- a/src/FSharpPlus/Data/Seq.fs
+++ b/src/FSharpPlus/Data/Seq.fs
@@ -240,13 +240,9 @@ module SeqT =
                     let stateStarted = ref None
                     { new IEnumeratorM<'``Monad<bool>``, 'T> with
                         member _.MoveNext () =
-                            let res: '``Monad<bool>`` =
-                                source
-                                |> (if opaqueId false then liftM else map) (fun v ->
-                                    match stateStarted.Value with
-                                    | None -> stateStarted := Some v; true
-                                    | Some _ -> stateStarted := None; false )
-                            res
+                            match stateStarted.Value with
+                            | Some _ -> result false
+                            | None -> source |> (if opaqueId false then liftM else map) (fun v -> stateStarted := Some v; true)
                         member _.Current =
                             match stateStarted.Value with
                             | Some v -> v

--- a/src/FSharpPlus/Data/Seq.fs
+++ b/src/FSharpPlus/Data/Seq.fs
@@ -746,6 +746,25 @@ type SeqT<'``monad<bool>``, 'T> with
     static member inline Map   (x: SeqT<'``Monad<bool>``, 'T>, f: 'T -> 'U) : SeqT<'``Monad<bool>``, 'U> = SeqT.map f x
     static member inline (<!>) (x: SeqT<'``Monad<bool>``, 'T>, f: 'T -> 'U) : SeqT<'``Monad<bool>``, 'U> = SeqT.map f x
     static member inline (<*>) (f: SeqT<'``Monad<bool>``, ('T -> 'U)>, x: SeqT<'``Monad<bool>``, 'T>) : SeqT<'``Monad<bool>``, 'U> = SeqT.apply f x
+
+    /// <summary>
+    /// Sequences two lists left-to-right, discarding the value of the first argument.
+    /// </summary>
+    /// <category index="2">Applicative</category>
+    static member inline ( *>) (x: SeqT<'``Monad<bool>``, 'T>, y: SeqT<'``Monad<bool>``, 'U>) : SeqT<'``Monad<bool>``, 'U> =
+        let (<!>) = SeqT.map
+        let (<*>) = SeqT.apply
+        ((fun (_: 'T) (k: 'U) -> k) <!> x: SeqT<'``Monad<bool>``, ('U -> 'U)>) <*> y
+    
+    /// <summary>
+    /// Sequences two lists left-to-right, discarding the value of the second argument.
+    /// </summary>
+    /// <category index="2">Applicative</category>
+    static member inline (<* ) (x: SeqT<'``Monad<bool>``, 'U>, y: SeqT<'``Monad<bool>``, 'T>) : SeqT<'``Monad<bool>``, 'U> =
+        let (<!>) = SeqT.map
+        let (<*>) = SeqT.apply
+        ((fun (k: 'U) (_: 'T) -> k) <!> x: SeqT<'``Monad<bool>``, ('T -> 'U)>) <*> y
+
     static member inline (>>=) (x: SeqT<'``Monad<bool>``, 'T>, f: 'T -> SeqT<'``Monad<bool>``, 'U>) : SeqT<'``Monad<bool>``, 'U> = SeqT.collect f x
     static member inline get_Empty () : SeqT<'``Monad<bool>``, 'T> = SeqT.empty
     static member inline (<|>) (x, y) : SeqT<'``Monad<bool>``, 'T> = SeqT.append x y

--- a/src/FSharpPlus/Data/Seq.fs
+++ b/src/FSharpPlus/Data/Seq.fs
@@ -739,6 +739,7 @@ type [<AutoOpen>]SeqTOperations =
 
 module [<AutoOpen>]SeqTOperations =
     let inline seqT<'T, .. > (source: '``Monad<seq<'T>>``) : SeqT<'``Monad<bool>``, 'T> = SeqT.wrap source
+    let inline (|SeqT|) (x: SeqT<'``Monad<bool>``, 'T>) : '``Monad<'T seq>`` = SeqT.toSeqM x
 
 
 type SeqT<'``monad<bool>``, 'T> with

--- a/src/FSharpPlus/Data/Seq.fs
+++ b/src/FSharpPlus/Data/Seq.fs
@@ -100,7 +100,7 @@ module SeqT =
     [<RequireQualifiedAccess; EditorBrowsable(EditorBrowsableState.Never)>]
     type SeqState<'``Monad<seq<'T>>``, 'T> =
        | NotStarted    of '``Monad<seq<'T>>``
-       | HaveEnumerator of IEnumerator<'T>
+       | HasEnumerator of IEnumerator<'T>
        | Finished
 
     let inline wrap (source: '``Monad<seq<'T>>``) : SeqT<'``Monad<bool>``, 'T> =
@@ -119,9 +119,9 @@ module SeqT =
                             | SeqState.NotStarted inp ->
                                 let! (s: seq<'T>) = inp
                                 let e1 = s.GetEnumerator ()
-                                state <- SeqState.HaveEnumerator e1
+                                state <- SeqState.HasEnumerator e1
                                 return! (x.MoveNext ())
-                            | SeqState.HaveEnumerator e1 ->
+                            | SeqState.HasEnumerator e1 ->
                                 let res1 = e1.MoveNext ()
                                 if res1 then
                                     current <- Some e1.Current
@@ -132,7 +132,7 @@ module SeqT =
                             | _ -> return false }
                         member _.Dispose () =
                             match state with
-                            | SeqState.HaveEnumerator e1 ->
+                            | SeqState.HasEnumerator e1 ->
                                 state <- SeqState.Finished
                                 dispose e1
                             | _ -> () } }
@@ -152,9 +152,9 @@ module SeqT =
                             match state with
                             | SeqState.NotStarted inp ->
                                 let e = inp.GetEnumerator ()
-                                state <- SeqState.HaveEnumerator e
+                                state <- SeqState.HasEnumerator e
                                 return! x.MoveNext ()
-                            | SeqState.HaveEnumerator e ->
+                            | SeqState.HasEnumerator e ->
                                 return
                                     (if e.MoveNext () then
                                          current <- Some e.Current
@@ -165,7 +165,7 @@ module SeqT =
                             | _ -> return false }
                         member _.Dispose () =
                             match state with
-                            | SeqState.HaveEnumerator e ->
+                            | SeqState.HasEnumerator e ->
                                 state <- SeqState.Finished
                                 dispose e
                             | _ -> () } }
@@ -440,9 +440,9 @@ module SeqT =
     [<RequireQualifiedAccess; EditorBrowsable(EditorBrowsableState.Never)>]
     type AppendState<'``Monad<bool>``, 'T> =
        | NotStarted1     of SeqT<'``Monad<bool>``, 'T> * SeqT<'``Monad<bool>``, 'T>
-       | HaveEnumerator1 of IEnumeratorM<'``Monad<bool>``, 'T> * SeqT<'``Monad<bool>``, 'T>
+       | HasEnumerator1 of IEnumeratorM<'``Monad<bool>``, 'T> * SeqT<'``Monad<bool>``, 'T>
        | NotStarted2     of SeqT<'``Monad<bool>``, 'T>
-       | HaveEnumerator2 of IEnumeratorM<'``Monad<bool>``, 'T> 
+       | HasEnumerator2 of IEnumeratorM<'``Monad<bool>``, 'T> 
        | Finished
 
     let inline append (source1: SeqT<'``Monad<bool>``, 'T>) (source2: SeqT<'``Monad<bool>``, 'T>) : SeqT<'``Monad<bool>``, 'T> =
@@ -461,9 +461,9 @@ module SeqT =
                             | AppendState.NotStarted1 (inp1, inp2) -> 
                                 return! (
                                     let enum1 = (inp1 :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
-                                    state <- AppendState.HaveEnumerator1 (enum1, inp2)
+                                    state <- AppendState.HasEnumerator1 (enum1, inp2)
                                     x.MoveNext ())
-                            | AppendState.HaveEnumerator1 (enum1, inp2) ->
+                            | AppendState.HasEnumerator1 (enum1, inp2) ->
                                 let! (res: bool) = enum1.MoveNext ()
                                 if res then
                                     current <- Some enum1.Current
@@ -476,9 +476,9 @@ module SeqT =
                             | AppendState.NotStarted2 inp2 ->
                                 return! (
                                     let enum2 = (inp2 :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
-                                    state <- AppendState.HaveEnumerator2 enum2
+                                    state <- AppendState.HasEnumerator2 enum2
                                     x.MoveNext ())
-                            | AppendState.HaveEnumerator2 enum2 ->   
+                            | AppendState.HasEnumerator2 enum2 ->   
                                 let! (res: bool) = enum2.MoveNext ()
                                 return (
                                     if res then current <- Some enum2.Current
@@ -489,8 +489,8 @@ module SeqT =
                             | _ -> return false }
                           member _.Dispose () = 
                               match state with 
-                              | AppendState.HaveEnumerator1 (enum, _) 
-                              | AppendState.HaveEnumerator2 enum -> 
+                              | AppendState.HasEnumerator1 (enum, _) 
+                              | AppendState.HasEnumerator2 enum -> 
                                   state <- AppendState.Finished
                                   dispose enum 
                               | _ -> () } }
@@ -503,7 +503,7 @@ module SeqT =
     [<RequireQualifiedAccess; EditorBrowsable(EditorBrowsableState.Never)>]
     type MapState<'T, '``Monad<bool>``> =
        | NotStarted     of SeqT<'``Monad<bool>``, 'T>
-       | HaveEnumerator of IEnumeratorM<'``Monad<bool>``, 'T>
+       | HasEnumerator of IEnumeratorM<'``Monad<bool>``, 'T>
        | Finished
 
     let inline map (f: 'T -> 'U) (source: SeqT<'``Monad<bool>``, 'T>) : SeqT<'``Monad<bool>``, 'U> =
@@ -522,9 +522,9 @@ module SeqT =
                               | MapState.NotStarted inp ->
                                   return! (
                                       let e = (inp :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
-                                      state <- MapState.HaveEnumerator e
+                                      state <- MapState.HasEnumerator e
                                       x.MoveNext ())
-                              | MapState.HaveEnumerator e ->
+                              | MapState.HasEnumerator e ->
                                   let! res1 = e.MoveNext ()
                                   if res1 then
                                       current <- Some (f e.Current)
@@ -535,7 +535,7 @@ module SeqT =
                               | _ -> return false }
                           member _.Dispose () =
                               match state with
-                              | MapState.HaveEnumerator e ->
+                              | MapState.HasEnumerator e ->
                                   state <- MapState.Finished
                                   dispose e
                               | _ -> () } }
@@ -543,7 +543,7 @@ module SeqT =
     [<RequireQualifiedAccess; EditorBrowsable(EditorBrowsableState.Never)>]
     type Map2State<'T1, 'T2, '``Monad<bool>``> =
        | NotStarted     of SeqT<'``Monad<bool>``, 'T1> * SeqT<'``Monad<bool>``, 'T2>
-       | HaveEnumerator of IEnumeratorM<'``Monad<bool>``, 'T1> * IEnumeratorM<'``Monad<bool>``, 'T2>
+       | HasEnumerator of IEnumeratorM<'``Monad<bool>``, 'T1> * IEnumeratorM<'``Monad<bool>``, 'T2>
        | Finished
 
     let inline map2 (f: 'T1 -> 'T2 -> 'U) (source1: SeqT<'``Monad<bool>``, 'T1>) (source2: SeqT<'``Monad<bool>``, 'T2>) : SeqT<'``Monad<bool>``, 'U> =
@@ -562,9 +562,9 @@ module SeqT =
                             | Map2State.NotStarted (s1, s2) -> return! (
                                 let e1 = (s1 :> IEnumerableM<'``Monad<bool>``, 'T1>).GetEnumerator ()
                                 let e2 = (s2 :> IEnumerableM<'``Monad<bool>``, 'T2>).GetEnumerator ()
-                                state <- Map2State.HaveEnumerator (e1, e2)
+                                state <- Map2State.HasEnumerator (e1, e2)
                                 x.MoveNext ())
-                            | Map2State.HaveEnumerator (e1, e2) ->
+                            | Map2State.HasEnumerator (e1, e2) ->
                                 let! res1 = e1.MoveNext ()
                                 let! res2 = e2.MoveNext ()
                                 if res1 && res2 then
@@ -576,7 +576,7 @@ module SeqT =
                             | _ -> return false }
                         member _.Dispose () =
                             match state with
-                            | Map2State.HaveEnumerator (e1, e2) ->
+                            | Map2State.HasEnumerator (e1, e2) ->
                                 state <- Map2State.Finished
                                 dispose e1
                                 dispose e2
@@ -599,9 +599,9 @@ module SeqT =
                                 return! (
                                     let e1 = (s1 :> IEnumerableM<'``Monad<bool>``, 'T1>).GetEnumerator ()
                                     let e2 = (s2 :> IEnumerableM<'``Monad<bool>``, 'T2>).GetEnumerator ()
-                                    state <- Map2State.HaveEnumerator (e1, e2)
+                                    state <- Map2State.HasEnumerator (e1, e2)
                                     x.MoveNext ())
-                            | Map2State.HaveEnumerator (e1, e2) ->
+                            | Map2State.HasEnumerator (e1, e2) ->
                                 let! res1 = e1.MoveNext ()
                                 let! res2 = e2.MoveNext ()
                                 if res1 && res2 then
@@ -614,7 +614,7 @@ module SeqT =
                             | _ -> return false }
                         member _.Dispose () =
                             match state with
-                            | Map2State.HaveEnumerator (e1, e2) ->
+                            | Map2State.HasEnumerator (e1, e2) ->
                                 state <- Map2State.Finished
                                 dispose e1
                                 dispose e2

--- a/src/FSharpPlus/Data/Seq.fs
+++ b/src/FSharpPlus/Data/Seq.fs
@@ -519,6 +519,8 @@ module SeqT =
                                   dispose e1
                               | _ -> () } }
 
+    let inline lift3<'T1, 'T2, 'T3, 'U, .. > (f: 'T1 -> 'T2 -> 'T3 -> 'U) (x1: SeqT<'``Monad<bool>``, 'T1>) (x2: SeqT<'``Monad<bool>``, 'T2>) (x3: SeqT<'``Monad<bool>``, 'T3>) : SeqT<'``Monad<bool>``, 'U> =
+        f </map/> x1 </apply/> x2 </apply/> x3
 
     let inline filter (f: 'T -> bool) (inp: SeqT<'``Monad<bool>``, 'T>) : SeqT<'``Monad<bool>``, 'T> =
         SeqT
@@ -749,6 +751,7 @@ type SeqT<'``monad<bool>``, 'T> with
     static member inline (<|>) (x, y) : SeqT<'``Monad<bool>``, 'T> = SeqT.append x y
 
     static member inline Lift2 (f: 'T1 -> 'T2 -> 'U, x1: SeqT<'``Monad<bool>``, 'T1>, x2: SeqT<'``Monad<bool>``, 'T2>) : SeqT<'``Monad<bool>``, 'U> = SeqT.lift2 f x1 x2
+    static member inline Lift3 (f: 'T1 -> 'T2 -> 'T3 -> 'U, x1: SeqT<'``Monad<bool>``, 'T1>, x2: SeqT<'``Monad<bool>``, 'T2>, x3: SeqT<'``Monad<bool>``, 'T3>) : SeqT<'``Monad<bool>``, 'U> = SeqT.lift3 f x1 x2 x3
 
     static member inline TryWith (source: SeqT<'``Monad<bool>``, 'T>, f: exn -> SeqT<'``Monad<bool>``, 'T>) = SeqT.tryWith<_, _, '``Monad<unit>``, _> source f
     static member inline TryFinally (computation: SeqT<'``Monad<bool>``, 'T>, f) = SeqT.tryFinally computation f
@@ -826,6 +829,12 @@ module Extension =
 
         let inline zip (source1: SeqT<'``Monad<bool>``, 'T1>) (source2: SeqT<'``Monad<bool>``, 'T2>) : SeqT<'``Monad<bool>``, ('T1 * 'T2)> =
             map2 tuple2 source1 source2
+
+        let inline map3<'T1, 'T2, 'T3, 'U, .. > (f: 'T1 -> 'T2 -> 'T3 -> 'U) (x1: SeqT<'``Monad<bool>``, 'T1>) (x2: SeqT<'``Monad<bool>``, 'T2>) (x3: SeqT<'``Monad<bool>``, 'T3>) : SeqT<'``Monad<bool>``, 'U> =
+            map2 (<|) (map2 f x1 x2) x3
+
+        let inline zip3 (source1: SeqT<'``Monad<bool>``, 'T1>) (source2: SeqT<'``Monad<bool>``, 'T2>) (source3: SeqT<'``Monad<bool>``, 'T3>) : SeqT<'``Monad<bool>``, ('T1 * 'T2 * 'T3)> =
+            map3 tuple3 source1 source2 source3
 
 type SeqT<'``monad<bool>``, 'T> with
     static member inline Take (source: SeqT<'``Monad<bool>``, 'T>, count, _: Take) : SeqT<'``Monad<bool>``, 'T> = SeqT.take count source

--- a/src/FSharpPlus/Data/Seq.fs
+++ b/src/FSharpPlus/Data/Seq.fs
@@ -880,12 +880,11 @@ module SeqT =
                         member x.MoveNext () =
                             if i > 0 then
                                 i <- i - 1
-                                innerMonad {
-                                    let! res = e.MoveNext ()
+                                e.MoveNext () |> monomorphicBind (fun res ->
                                     if not res then
                                         let msg = sprintf "The input sequence has an insufficient number of elements: tried to take %i %s past the end of the sequence. Use SeqT.truncate to get %i or less elements" (i+1) (if i = 0 then "element" else "elements") count
                                         raise (new InvalidOperationException(msg))
-                                    return res }
+                                    result res )
                             else
                                 x.Dispose ()
                                 result false

--- a/src/FSharpPlus/Data/Seq.fs
+++ b/src/FSharpPlus/Data/Seq.fs
@@ -767,6 +767,8 @@ module SeqT =
                                             return true }
                           member _.Dispose () = () } }
 
+    let inline unfold (f: 'State -> ('T * 'State) option) (s: 'State) : SeqT<'``Monad<bool>``, 'T> = unfoldM (result << f) s
+
 
 type [<AutoOpen>]SeqTOperations =
     static member inline SeqT (source: '``Monad<seq<'T>>``) : SeqT<'``Monad<bool>``, 'T> = SeqT.wrap source

--- a/src/FSharpPlus/Data/Seq.fs
+++ b/src/FSharpPlus/Data/Seq.fs
@@ -24,6 +24,7 @@ open FSharpPlus.Control
 #nowarn "0193"
 #if !FABLE_COMPILER
 
+[<EditorBrowsable(EditorBrowsableState.Never)>]
 module Internal =
     let inline monomorphicBind (binder: 'T -> '``Monad<'T>``) (source: '``Monad<'T>``) : '``Monad<'T>`` =
         let inline call (_mthd: 'M, input: 'I, _output: 'I, f) = ((^M or ^I) : (static member (>>=) : _*_ -> _) input, f)
@@ -31,14 +32,17 @@ module Internal =
 
 open Internal
 
+[<EditorBrowsable(EditorBrowsableState.Never)>]
 type MonadFxStrictBuilderMod<'``monad<'t>``> () =
     inherit FSharpPlus.GenericBuilders.MonadFxStrictBuilder<'``monad<'t>``> ()
     member inline _.Delay expr = (fun () -> Delay.Invoke expr) : unit -> '``Monad<'T>``
 
+[<EditorBrowsable(EditorBrowsableState.Never)>]
 type MonadPlusStrictBuilderMod<'``monad<'t>``> () =
     inherit FSharpPlus.GenericBuilders.MonadPlusStrictBuilder<'``monad<'t>``> ()
     member inline _.Delay expr = (fun () -> Delay.Invoke expr) : unit -> '``Monad<'T>``
 
+[<EditorBrowsable(EditorBrowsableState.Never)>]
 type MonadFxStrictBuilderMod2<'``monad<'t>``, ^``monad<unit>``>
                                     when (Return or ^``monad<unit>``) : (static member Return: ^``monad<unit>`` * Return -> (unit -> ^``monad<unit>``)) 
                                     and  (Bind   or ^``monad<unit>``) : (static member (>>=): ^``monad<unit>`` * (unit -> ^``monad<unit>``) -> ^``monad<unit>``)
@@ -62,12 +66,12 @@ type MonadFxStrictBuilderMod2<'``monad<'t>``, ^``monad<unit>``>
     member inline _.Delay expr = (fun () -> Delay.Invoke expr) : unit -> '``Monad<'T>``
 
 
+[<EditorBrowsable(EditorBrowsableState.Never)>]
 module SpecialBuilders =
     let innerMonad<'mt> = new MonadFxStrictBuilderMod<'mt> ()
     let inline innerMonad2<'mt, .. > () = new MonadFxStrictBuilderMod2<'mt, _> ()
 
 open SpecialBuilders
-
 
 
 type IEnumeratorM<'``Monad<bool>``, 'T> =
@@ -90,7 +94,7 @@ module SeqT =
 
     let ofIEnumerableM x : SeqT<'``Monad<bool>``, 'T> = SeqT x
 
-    [<RequireQualifiedAccess>]
+    [<RequireQualifiedAccess; EditorBrowsable(EditorBrowsableState.Never)>]
     type SeqState<'``Monad<seq<'T>>``, 'T> =
        | NotStarted    of '``Monad<seq<'T>>``
        | HaveEnumerator of IEnumerator<'T>
@@ -165,6 +169,7 @@ module SeqT =
 
     let inline hoist (source: seq<'T>) : SeqT<'``Monad<bool>``, 'T> = wrap (result source: '``Monad<seq<'T>>``)
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let inline runThen<'T, .. > (f: ResizeArray<'T> -> 'R) (source: SeqT<'``Monad<bool>``, 'T>) : '``Monad<'R>`` =
         let ra = new ResizeArray<_> ()
         Using.Invoke
@@ -218,6 +223,7 @@ module SeqT =
                             else invalidOp "Enumeration has not started. Call MoveNext."
                         member _.Dispose () = () } }
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let inline make (f: unit -> '``Monad<SeqT<'Monad<bool>, 'T>>``) : SeqT<'``Monad<bool>``, 'T> =
         SeqT
             { new IEnumerableM<'``Monad<bool>``, 'T> with
@@ -280,7 +286,7 @@ module SeqT =
                             | None -> invalidOp "Enumeration has not started. Call MoveNext."
                         member _.Dispose () = () } }
 
-    [<RequireQualifiedAccess>]
+    [<RequireQualifiedAccess; EditorBrowsable(EditorBrowsableState.Never)>]
     type CollectState<'T, 'U, '``Monad<bool>``> =
        | NotStarted    of SeqT<'``Monad<bool>``, 'T>
        | HaveInputEnumerator of IEnumeratorM<'``Monad<bool>``, 'T>
@@ -428,7 +434,7 @@ module SeqT =
                                 dispose e1
                             | _ -> () } }
     
-    [<RequireQualifiedAccess>]
+    [<RequireQualifiedAccess; EditorBrowsable(EditorBrowsableState.Never)>]
     type AppendState<'``Monad<bool>``, 'T> =
        | NotStarted1     of SeqT<'``Monad<bool>``, 'T> * SeqT<'``Monad<bool>``, 'T>
        | HaveEnumerator1 of IEnumeratorM<'``Monad<bool>``, 'T> * SeqT<'``Monad<bool>``, 'T>
@@ -491,7 +497,7 @@ module SeqT =
         source |> collect (fun itm ->
             f itm |> bindLift<_, _, _, '``Monad<SeqT<'Monad<bool>, 'U>>``, _> singleton)
     
-    [<RequireQualifiedAccess>]
+    [<RequireQualifiedAccess; EditorBrowsable(EditorBrowsableState.Never)>]
     type MapState<'T, '``Monad<bool>``> =
        | NotStarted     of SeqT<'``Monad<bool>``, 'T>
        | HaveEnumerator of IEnumeratorM<'``Monad<bool>``, 'T>
@@ -531,7 +537,7 @@ module SeqT =
                                   dispose e
                               | _ -> () } }
 
-    [<RequireQualifiedAccess>]
+    [<RequireQualifiedAccess; EditorBrowsable(EditorBrowsableState.Never)>]
     type Map2State<'T1, 'T2, '``Monad<bool>``> =
        | NotStarted     of SeqT<'``Monad<bool>``, 'T1> * SeqT<'``Monad<bool>``, 'T2>
        | HaveEnumerator of IEnumeratorM<'``Monad<bool>``, 'T1> * IEnumeratorM<'``Monad<bool>``, 'T2>
@@ -680,7 +686,7 @@ module SeqT =
     let inline iteri<'T, .. > (f: int -> 'T -> unit)      (source: SeqT<'``Monad<bool>``, 'T>) : '``Monad<unit>`` = iteriM (fun i x -> result (f i x)) source
     let inline iter<'T, .. > f (source: SeqT<'``Monad<bool>``, 'T>) : '``Monad<unit>`` = iterM (f >> result) source
 
-    [<RequireQualifiedAccess>]
+    [<RequireQualifiedAccess; EditorBrowsable(EditorBrowsableState.Never)>]
     type TryWithState<'``Monad<bool>``, 'T> =
        | NotStarted of SeqT<'``Monad<bool>``, 'T>
        | HaveBodyEnumerator of IEnumeratorM<'``Monad<bool>``, 'T>
@@ -751,7 +757,7 @@ module SeqT =
                                 dispose e
                             | _ -> () } }
 
-    [<RequireQualifiedAccess>]
+    [<RequireQualifiedAccess; EditorBrowsable(EditorBrowsableState.Never)>]
     type TryFinallyState<'``Monad<bool>``, 'T> =
        | NotStarted    of SeqT<'``Monad<bool>``, 'T>
        | HaveBodyEnumerator of IEnumeratorM<'``Monad<bool>``, 'T>
@@ -878,7 +884,10 @@ type SeqT<'``monad<bool>``, 'T> with
     static member inline get_Empty () : SeqT<'``Monad<bool>``, 'T> = SeqT.empty
     static member inline (<|>) (x, y) : SeqT<'``Monad<bool>``, 'T> = SeqT.append x y
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Lift2 (f: 'T1 -> 'T2 -> 'U, x1: SeqT<'``Monad<bool>``, 'T1>, x2: SeqT<'``Monad<bool>``, 'T2>) : SeqT<'``Monad<bool>``, 'U> = SeqT.lift2 f x1 x2
+    
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Lift3 (f: 'T1 -> 'T2 -> 'T3 -> 'U, x1: SeqT<'``Monad<bool>``, 'T1>, x2: SeqT<'``Monad<bool>``, 'T2>, x3: SeqT<'``Monad<bool>``, 'T3>) : SeqT<'``Monad<bool>``, 'U> = SeqT.lift3 f x1 x2 x3
 
     static member inline TryWith (source: SeqT<'``Monad<bool>``, 'T>, f: exn -> SeqT<'``Monad<bool>``, 'T>) = SeqT.tryWith<_, _, '``Monad<unit>``, _> source f
@@ -887,7 +896,9 @@ type SeqT<'``monad<bool>``, 'T> with
     static member inline Using (resource, f: _ -> SeqT<'``Monad<bool>``, 'T>) =
         SeqT.tryFinally (f resource) (fun () -> if box resource <> null then dispose resource)
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Lift (m: '``Monad<'T>``) : SeqT<'``Monad<bool>``, 'T> = SeqT.lift m
+
     static member inline LiftAsync (x: Async<'T>) = SeqT.lift (liftAsync x: '``MonadAsync<'T>``) : SeqT<'MonadAsync, 'T>
 
     static member inline Throw (x: 'E) : SeqT<'``MonadError<'E>``, 'T> = x |> throw |> SeqT.lift
@@ -907,9 +918,13 @@ type SeqT<'``monad<bool>``, 'T> with
     static member inline Local (m: SeqT<'``MonadReader<'R2>``, 'T>, f: 'R1 -> 'R2) : SeqT<'``MonadReader<'R1>``, 'T> =
         seqT (local f (SeqT.run m))
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline OfSeq (x: seq<'T>) : SeqT<'``Monad<bool>``, 'T> = SeqT.ofSeq x
+
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Take (source: SeqT<'``Monad<bool>``, 'T>, count, _: Take) : SeqT<'``Monad<bool>``, 'T> = SeqT.take count source
     
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Zip (source1: SeqT<'``Monad<bool>``, 'T1>, source2: SeqT<'``Monad<bool>``, 'T2>) : SeqT<'``Monad<bool>``, ('T1 * 'T2)> = SeqT.zip source1 source2
 
 #endif

--- a/src/FSharpPlus/Data/Seq.fs
+++ b/src/FSharpPlus/Data/Seq.fs
@@ -130,7 +130,8 @@ module SeqT =
                                 dispose e1
                             | _ -> () } }
 
-
+    let inline hoist (source: seq<'T>) : SeqT<'``Monad<bool>``, 'T> = wrap (result source: '``Monad<seq<'T>>``)
+    
     let inline toArrayM<'T, .. > (source: SeqT<'``Monad<bool>``, 'T>) : '``Monad<'T []>`` =
         let ra = new ResizeArray<_> ()
         Using.Invoke

--- a/src/FSharpPlus/Data/Seq.fs
+++ b/src/FSharpPlus/Data/Seq.fs
@@ -96,11 +96,11 @@ module SeqT =
        | HaveEnumerator of IEnumerator<'T>
        | Finished
 
-    let inline wrap (inp: '``Monad<seq<'T>>``) : SeqT<'``Monad<bool>``, 'T> =
+    let inline wrap (source: '``Monad<seq<'T>>``) : SeqT<'``Monad<bool>``, 'T> =
         SeqT
             { new IEnumerableM<'``Monad<bool>``, 'T> with
                 member _.GetEnumerator () =
-                    let state = ref (SeqState.NotStarted inp)
+                    let state = ref (SeqState.NotStarted source)
                     let current = ref Option<'T>.None
                     { new IEnumeratorM<'``Monad<bool>``, 'T> with
                         member _.Current =
@@ -130,13 +130,11 @@ module SeqT =
                                 dispose e1
                             | _ -> () } }
 
-
-
-    let inline ofSeq (inp: seq<'T>) : SeqT<'``Monad<bool>``, 'T> =
+    let inline ofSeq (source: seq<'T>) : SeqT<'``Monad<bool>``, 'T> =
         SeqT
             { new IEnumerableM<'``Monad<bool>``, 'T> with
                 member _.GetEnumerator () =
-                    let state = ref (SeqState.NotStarted inp)
+                    let state = ref (SeqState.NotStarted source)
                     let current = ref Option<'T>.None
                     { new IEnumeratorM<'``Monad<bool>``, 'T> with
                         member _.Current =
@@ -192,13 +190,12 @@ module SeqT =
     [<GeneralizableValue>]
     let inline empty<'T, .. > : SeqT<'``Monad<bool>``, 'T> =
         SeqT
-          { new IEnumerableM<'``Monad<bool>``, 'T> with
+            { new IEnumerableM<'``Monad<bool>``, 'T> with
                 member _.GetEnumerator () =
                     { new IEnumeratorM<'``Monad<bool>``, 'T> with
-                          member _.MoveNext () = result false
-                          member _.Current = invalidOp "Enumeration has not started. Call MoveNext."
-                          member _.Dispose () = () } }
-
+                        member _.MoveNext () = result false
+                        member _.Current = invalidOp "Enumeration has not started. Call MoveNext."
+                        member _.Dispose () = () } }
 
     let inline singleton (v: 'T) : SeqT<'``Monad<bool>``, 'T> =
         SeqT
@@ -206,22 +203,18 @@ module SeqT =
                 member _.GetEnumerator () = 
                     let stateStarted = ref false
                     { new IEnumeratorM<'``Monad<bool>``, 'T> with 
-                          member _.MoveNext () =
-                              innerMonad {
-                                  let res = not stateStarted.Value
-                                  stateStarted := true
-                                  return res }
-                          member _.Current =
-                              if stateStarted.Value then v
-                              else invalidOp "Enumeration has not started. Call MoveNext."
-                          member _.Dispose () = () } }
-
-
-
+                        member _.MoveNext () = innerMonad {
+                            let res = not stateStarted.Value
+                            stateStarted := true
+                            return res }
+                        member _.Current =
+                            if stateStarted.Value then v
+                            else invalidOp "Enumeration has not started. Call MoveNext."
+                        member _.Dispose () = () } }
 
     let inline make (f: unit -> '``Monad<SeqT<'Monad<bool>, 'T>>``) : SeqT<'``Monad<bool>``, 'T> =
         SeqT
-          { new IEnumerableM<'``Monad<bool>``, 'T> with
+            { new IEnumerableM<'``Monad<bool>``, 'T> with
                 member _.GetEnumerator () = 
                     let state   = ref -1
                     let enum    = ref Unchecked.defaultof<IEnumeratorM<'``Monad<bool>``, 'T>>
@@ -232,24 +225,23 @@ module SeqT =
                             | -1 -> invalidOp "Enumeration has not started. Call MoveNext."
                             | _  -> current.Value
 
-                        member x.MoveNext () = 
-                            innerMonad {
-                                match !state with
-                                    | -1 -> 
-                                        let! (s: SeqT<'``Monad<bool>``, 'T>) = f ()
-                                        return! (
-                                            let e = (s :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
-                                            enum := e
-                                            state := 0
-                                            x.MoveNext ())
-                                    | 0 ->   
-                                        let e = enum.Value
-                                        let! (res: bool) = e.MoveNext ()
-                                        do
-                                            current := e.Current
-                                            if not res then x.Dispose ()
-                                        return res
-                                    | _ -> return false }
+                        member x.MoveNext () = innerMonad {
+                            match !state with
+                            | -1 -> 
+                                let! (s: SeqT<'``Monad<bool>``, 'T>) = f ()
+                                return! (
+                                    let e = (s :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
+                                    enum := e
+                                    state := 0
+                                    x.MoveNext ())
+                            | 0 ->   
+                                let e = enum.Value
+                                let! (res: bool) = e.MoveNext ()
+                                do
+                                    current := e.Current
+                                    if not res then x.Dispose ()
+                                return res
+                            | _ -> return false }
                         member _.Dispose () = 
                             match !state with 
                             | 0 -> 
@@ -259,16 +251,13 @@ module SeqT =
                                 dispose e 
                             | _ -> () } }
 
-
-    // let inline delayO (f: unit -> SeqT<'``Monad<bool>``, 'T>) : SeqT<'``Monad<bool>``, 'T> =  make (fun () -> monad { return f() })
-
     let delay (f: unit -> SeqT<'``Monad<bool>``, 'T>) : SeqT<'``Monad<bool>``, 'T> =
         SeqT
             { new IEnumerableM<'``Monad<bool>``, 'T> with
                 member _.GetEnumerator () = (f () :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator () }
 
-    let inline bindLift<'T, 'U, .. > (f: 'T -> SeqT<'``Monad<bool>``, 'U>) (inp: '``Monad<'T>``) : SeqT<'``Monad<bool>``, 'U> =
-        make (fun () -> innerMonad<'``Monad<SeqT<'Monad<bool>, 'U>>``> { let! v = inp in return f v })
+    let inline bindLift<'T, 'U, .. > (f: 'T -> SeqT<'``Monad<bool>``, 'U>) (source: '``Monad<'T>``) : SeqT<'``Monad<bool>``, 'U> =
+        make (fun () -> innerMonad<'``Monad<SeqT<'Monad<bool>, 'U>>``> { let! v = source in return f v })
 
     let inline lift (source: '``Monad<'T>``) : SeqT<'``Monad<bool>``, 'T> =
         SeqT
@@ -286,7 +275,6 @@ module SeqT =
                             | None -> invalidOp "Enumeration has not started. Call MoveNext."
                         member _.Dispose () = () } }
 
-
     [<RequireQualifiedAccess>]
     type CollectState<'T, 'U, '``Monad<bool>``> =
        | NotStarted    of SeqT<'``Monad<bool>``, 'T>
@@ -294,46 +282,43 @@ module SeqT =
        | HaveInnerEnumerator of IEnumeratorM<'``Monad<bool>``, 'T> * IEnumeratorM<'``Monad<bool>``, 'U>
        | Finished
 
-
-    let inline collect<'T, 'U, .. > (f: 'T -> SeqT<'``Monad<bool>``, 'U>) (inp: SeqT<'``Monad<bool>``, 'T>) : SeqT<'``Monad<bool>``, 'U> =
+    let inline collect<'T, 'U, .. > (f: 'T -> SeqT<'``Monad<bool>``, 'U>) (source: SeqT<'``Monad<bool>``, 'T>) : SeqT<'``Monad<bool>``, 'U> =
         SeqT
-          { new IEnumerableM<'``Monad<bool>``, 'U> with
+            { new IEnumerableM<'``Monad<bool>``, 'U> with
                 member _.GetEnumerator () =
-                    let state = ref (CollectState.NotStarted inp)
+                    let state = ref (CollectState.NotStarted source)
                     let current = ref Option<'U>.None
                     { new IEnumeratorM<'``Monad<bool>``, 'U>  with
                         member _.Current =
                             match !current with
                             | Some c -> c
                             | None -> invalidOp "Enumeration has not started. Call MoveNext."                            
-                        member x.MoveNext () =
-                            monad' {
-                                match !state with
-                                    | CollectState.NotStarted inp ->
-                                        return! (
-                                            let e1 = (inp :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
-                                            state := CollectState.HaveInputEnumerator e1
-                                            x.MoveNext ())
-                                    | CollectState.HaveInputEnumerator e1 ->
-                                        let! res1 = e1.MoveNext ()
-                                        return! (
-                                            if res1 then
-                                                let e2 = (f e1.Current :> IEnumerableM<'``Monad<bool>``, 'U>).GetEnumerator ()
-                                                state := CollectState.HaveInnerEnumerator (e1, e2)
-                                            else
-                                                x.Dispose ()
-                                            x.MoveNext () )
-                                    | CollectState.HaveInnerEnumerator (e1, e2) ->
-                                        let! (res2: bool) = e2.MoveNext ()
-                                        if res2 then
-                                            current := Some e2.Current
-                                            return res2
-                                        else
-                                            state := CollectState.HaveInputEnumerator e1
-                                            dispose e2
-                                            return! x.MoveNext ()
-                                    | _ ->
-                                        return false }
+                        member x.MoveNext () = monad' {
+                            match !state with
+                            | CollectState.NotStarted inp ->
+                                return! (
+                                    let e1 = (inp :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
+                                    state := CollectState.HaveInputEnumerator e1
+                                    x.MoveNext ())
+                            | CollectState.HaveInputEnumerator e1 ->
+                                let! res1 = e1.MoveNext ()
+                                return! (
+                                    if res1 then
+                                        let e2 = (f e1.Current :> IEnumerableM<'``Monad<bool>``, 'U>).GetEnumerator ()
+                                        state := CollectState.HaveInnerEnumerator (e1, e2)
+                                    else
+                                        x.Dispose ()
+                                    x.MoveNext () )
+                            | CollectState.HaveInnerEnumerator (e1, e2) ->
+                                let! (res2: bool) = e2.MoveNext ()
+                                if res2 then
+                                    current := Some e2.Current
+                                    return res2
+                                else
+                                    state := CollectState.HaveInputEnumerator e1
+                                    dispose e2
+                                    return! x.MoveNext ()
+                            | _ -> return false }
                         member _.Dispose () =
                             match !state with
                             | CollectState.HaveInputEnumerator e1 ->
@@ -345,10 +330,9 @@ module SeqT =
                                 dispose e1
                             | _ -> () } }
 
-
     let inline apply<'T, 'U, .. > (f: SeqT<'``Monad<bool>``, 'T -> 'U>) (x1: SeqT<'``Monad<bool>``, 'T>) : SeqT<'``Monad<bool>``, 'U> =
         SeqT
-          { new IEnumerableM<'``Monad<bool>``, 'U> with
+            { new IEnumerableM<'``Monad<bool>``, 'U> with
                 member _.GetEnumerator () =
                     let state = ref (CollectState.NotStarted f)
                     let current = ref Option<'U>.None
@@ -357,34 +341,32 @@ module SeqT =
                             match !current with
                             | Some c -> c
                             | None -> invalidOp "Enumeration has not started. Call MoveNext."                            
-                        member x.MoveNext () =
-                            monad' {
-                                match !state with
-                                    | CollectState.NotStarted f ->
-                                        return! (
-                                            let e1 = (f :> IEnumerableM<'``Monad<bool>``, ('T -> 'U)>).GetEnumerator ()
-                                            state := CollectState.HaveInputEnumerator e1
-                                            x.MoveNext ())
-                                    | CollectState.HaveInputEnumerator e1 ->
-                                        let! res1 = e1.MoveNext ()
-                                        return! (
-                                            if res1 then
-                                                let e2 = (x1 :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
-                                                state := CollectState.HaveInnerEnumerator (e1, e2)
-                                            else
-                                                x.Dispose ()
-                                            x.MoveNext () )
-                                    | CollectState.HaveInnerEnumerator (e1, e2) ->
-                                        let! (res2: bool) = e2.MoveNext ()
-                                        if res2 then
-                                            current := Some (e1.Current e2.Current)
-                                            return res2
-                                        else
-                                            state := CollectState.HaveInputEnumerator e1
-                                            dispose e2
-                                            return! x.MoveNext ()
-                                    | _ ->
-                                        return false }
+                        member x.MoveNext () = monad' {
+                            match !state with
+                            | CollectState.NotStarted f ->
+                                return! (
+                                    let e1 = (f :> IEnumerableM<'``Monad<bool>``, ('T -> 'U)>).GetEnumerator ()
+                                    state := CollectState.HaveInputEnumerator e1
+                                    x.MoveNext ())
+                            | CollectState.HaveInputEnumerator e1 ->
+                                let! res1 = e1.MoveNext ()
+                                return! (
+                                    if res1 then
+                                        let e2 = (x1 :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
+                                        state := CollectState.HaveInnerEnumerator (e1, e2)
+                                    else
+                                        x.Dispose ()
+                                    x.MoveNext () )
+                            | CollectState.HaveInnerEnumerator (e1, e2) ->
+                                let! (res2: bool) = e2.MoveNext ()
+                                if res2 then
+                                    current := Some (e1.Current e2.Current)
+                                    return res2
+                                else
+                                    state := CollectState.HaveInputEnumerator e1
+                                    dispose e2
+                                    return! x.MoveNext ()
+                            | _ -> return false }
                         member _.Dispose () =
                             match !state with
                             | CollectState.HaveInputEnumerator e1 ->
@@ -398,7 +380,7 @@ module SeqT =
 
     let inline lift2<'T1, 'T2, 'U, .. > (f: 'T1 -> 'T2 -> 'U) (x1: SeqT<'``Monad<bool>``, 'T1>) (x2: SeqT<'``Monad<bool>``, 'T2>) : SeqT<'``Monad<bool>``, 'U> =
         SeqT
-          { new IEnumerableM<'``Monad<bool>``, 'U> with
+            { new IEnumerableM<'``Monad<bool>``, 'U> with
                 member _.GetEnumerator () =
                     let state = ref (CollectState.NotStarted x1)
                     let current = ref Option<'U>.None
@@ -407,34 +389,31 @@ module SeqT =
                             match !current with
                             | Some c -> c
                             | None -> invalidOp "Enumeration has not started. Call MoveNext."                            
-                        member x.MoveNext () =
-                            monad' {
-                                match !state with
-                                    | CollectState.NotStarted x1 ->
-                                        return! (
-                                            let e1 = (x1 :> IEnumerableM<'``Monad<bool>``, 'T1>).GetEnumerator ()
-                                            state := CollectState.HaveInputEnumerator e1
-                                            x.MoveNext ())
-                                    | CollectState.HaveInputEnumerator e1 ->
-                                        let! res1 = e1.MoveNext ()
-                                        return! (
-                                            if res1 then
-                                                let e2 = (x2 :> IEnumerableM<'``Monad<bool>``, 'T2>).GetEnumerator ()
-                                                state := CollectState.HaveInnerEnumerator (e1, e2)
-                                            else
-                                                x.Dispose ()
-                                            x.MoveNext () )
-                                    | CollectState.HaveInnerEnumerator (e1, e2) ->
-                                        let! (res2: bool) = e2.MoveNext ()
-                                        if res2 then
-                                            current := Some (f e1.Current e2.Current)
-                                            return res2
-                                        else
-                                            state := CollectState.HaveInputEnumerator e1
-                                            dispose e2
-                                            return! x.MoveNext ()
-                                    | _ ->
-                                        return false }
+                        member x.MoveNext () = monad' {
+                            match !state with
+                            | CollectState.NotStarted x1 ->
+                                return! (
+                                    let e1 = (x1 :> IEnumerableM<'``Monad<bool>``, 'T1>).GetEnumerator ()
+                                    state := CollectState.HaveInputEnumerator e1
+                                    x.MoveNext ())
+                            | CollectState.HaveInputEnumerator e1 ->
+                                let! res1 = e1.MoveNext ()
+                                return! (
+                                    if res1 then
+                                        let e2 = (x2 :> IEnumerableM<'``Monad<bool>``, 'T2>).GetEnumerator ()
+                                        state := CollectState.HaveInnerEnumerator (e1, e2)
+                                    else x.Dispose ()
+                                    x.MoveNext () )
+                            | CollectState.HaveInnerEnumerator (e1, e2) ->
+                                let! (res2: bool) = e2.MoveNext ()
+                                if res2 then
+                                    current := Some (f e1.Current e2.Current)
+                                    return res2
+                                else
+                                    state := CollectState.HaveInputEnumerator e1
+                                    dispose e2
+                                    return! x.MoveNext ()
+                            | _ -> return false }
                         member _.Dispose () =
                             match !state with
                             | CollectState.HaveInputEnumerator e1 ->
@@ -454,11 +433,11 @@ module SeqT =
        | HaveEnumerator2 of IEnumeratorM<'``Monad<bool>``, 'T> 
        | Finished
 
-    let inline append (inp1: SeqT<'``Monad<bool>``, 'T>) (inp2: SeqT<'``Monad<bool>``, 'T>) : SeqT<'``Monad<bool>``, 'T> =
+    let inline append (source1: SeqT<'``Monad<bool>``, 'T>) (source2: SeqT<'``Monad<bool>``, 'T>) : SeqT<'``Monad<bool>``, 'T> =
         SeqT
-          { new IEnumerableM<'``Monad<bool>``, 'T>  with 
+            { new IEnumerableM<'``Monad<bool>``, 'T>  with 
                 member _.GetEnumerator () = 
-                    let state = ref (AppendState.NotStarted1 (inp1, inp2) )
+                    let state = ref (AppendState.NotStarted1 (source1, source2) )
                     let current = ref Option<'T>.None
                     { new IEnumeratorM<'``Monad<bool>``, 'T>  with
                         member _.Current =
@@ -466,41 +445,37 @@ module SeqT =
                             | Some c -> c
                             | None -> invalidOp "Enumeration has not started. Call MoveNext."     
     
-                        member x.MoveNext () = 
-                            innerMonad {
-                                match !state with 
-                                    | AppendState.NotStarted1 (inp1, inp2) -> 
-                                        return! (
-                                            let enum1 = (inp1 :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
-                                            state := AppendState.HaveEnumerator1 (enum1, inp2)
-                                            x.MoveNext ())
-                                    | AppendState.HaveEnumerator1 (enum1, inp2) ->
-                                        let! (res: bool) = enum1.MoveNext ()
-                                        if res then
-                                            current := Some enum1.Current
-                                            return res
-                                        else
-                                            return! 
-                                              (state := AppendState.NotStarted2 inp2
-                                               dispose enum1
-                                               x.MoveNext ())
-                                    | AppendState.NotStarted2 inp2 ->
-                                        return! (
-                                            let enum2 = (inp2 :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
-                                            state := AppendState.HaveEnumerator2 enum2
-                                            x.MoveNext () )
-                                    | AppendState.HaveEnumerator2 enum2 ->   
-                                        let! (res: bool) = enum2.MoveNext ()
-                                        return (
-                                            if res then
-                                                current := Some enum2.Current
-                                            else
-                                                state := AppendState.Finished
-                                                dispose enum2
-                                            res)
-                                               
-                                    | _ -> 
-                                        return false }
+                        member x.MoveNext () = innerMonad {
+                            match !state with 
+                            | AppendState.NotStarted1 (inp1, inp2) -> 
+                                return! (
+                                    let enum1 = (inp1 :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
+                                    state := AppendState.HaveEnumerator1 (enum1, inp2)
+                                    x.MoveNext ())
+                            | AppendState.HaveEnumerator1 (enum1, inp2) ->
+                                let! (res: bool) = enum1.MoveNext ()
+                                if res then
+                                    current := Some enum1.Current
+                                    return res
+                                else
+                                    return! (
+                                        state := AppendState.NotStarted2 inp2
+                                        dispose enum1
+                                        x.MoveNext ())
+                            | AppendState.NotStarted2 inp2 ->
+                                return! (
+                                    let enum2 = (inp2 :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
+                                    state := AppendState.HaveEnumerator2 enum2
+                                    x.MoveNext () )
+                            | AppendState.HaveEnumerator2 enum2 ->   
+                                let! (res: bool) = enum2.MoveNext ()
+                                return (
+                                    if res then current := Some enum2.Current
+                                    else
+                                        state := AppendState.Finished
+                                        dispose enum2
+                                    res)
+                            | _ -> return false }
                           member _.Dispose () = 
                               match !state with 
                               | AppendState.HaveEnumerator1 (enum, _) 
@@ -513,13 +488,13 @@ module SeqT =
     let inline mapM (f: 'T -> '``Monad<'U>``) (source: SeqT<'``Monad<bool>``, 'T>) : SeqT<'``Monad<bool>``, 'U> =
         source |> collect (fun itm ->
             f itm |> bindLift<_, _, _, '``Monad<SeqT<'Monad<bool>, 'U>>``, _> singleton)
-
     
     [<RequireQualifiedAccess>]
     type MapState<'T, '``Monad<bool>``> =
        | NotStarted     of SeqT<'``Monad<bool>``, 'T>
        | HaveEnumerator of IEnumeratorM<'``Monad<bool>``, 'T>
        | Finished
+
     let inline map (f: 'T -> 'U) (source: SeqT<'``Monad<bool>``, 'T>) : SeqT<'``Monad<bool>``, 'U> =
         SeqT
             { new IEnumerableM<'``Monad<bool>``, 'U> with
@@ -531,24 +506,22 @@ module SeqT =
                             match !current with
                             | Some c -> c
                             | None -> invalidOp "Enumeration has not started. Call MoveNext."                            
-                        member x.MoveNext () =
-                              innerMonad {
-                                  match !state with
-                                      | MapState.NotStarted inp ->
-                                          return! (
-                                              let e = (inp :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
-                                              state := MapState.HaveEnumerator e
-                                              x.MoveNext ())
-                                      | MapState.HaveEnumerator e ->
-                                          let! res1 = e.MoveNext ()
-                                          if res1 then
-                                              current := Some (f e.Current)
-                                              return true
-                                          else
-                                              x.Dispose ()
-                                              return! x.MoveNext ()
-                                      | _ ->
-                                          return false }
+                        member x.MoveNext () = innerMonad {
+                              match !state with
+                              | MapState.NotStarted inp ->
+                                  return! (
+                                      let e = (inp :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
+                                      state := MapState.HaveEnumerator e
+                                      x.MoveNext ())
+                              | MapState.HaveEnumerator e ->
+                                  let! res1 = e.MoveNext ()
+                                  if res1 then
+                                      current := Some (f e.Current)
+                                      return true
+                                  else
+                                      x.Dispose ()
+                                      return! x.MoveNext ()
+                              | _ -> return false }
                           member _.Dispose () =
                               match !state with
                               | MapState.HaveEnumerator e ->
@@ -575,29 +548,28 @@ module SeqT =
                             | None -> invalidOp "Enumeration has not started. Call MoveNext."                            
                         member x.MoveNext () = innerMonad {
                             match !state with
-                                | Map2State.NotStarted (s1, s2) -> return! (
-                                    let e1 = (s1 :> IEnumerableM<'``Monad<bool>``, 'T1>).GetEnumerator ()
-                                    let e2 = (s2 :> IEnumerableM<'``Monad<bool>``, 'T2>).GetEnumerator ()
-                                    state := Map2State.HaveEnumerator (e1, e2)
-                                    x.MoveNext ())
-                                | Map2State.HaveEnumerator (e1, e2) ->
-                                    let! res1 = e1.MoveNext ()
-                                    let! res2 = e2.MoveNext ()
-                                    if res1 && res2 then
-                                        current := Some (f e1.Current e2.Current)
-                                        return true
-                                    else
-                                        x.Dispose ()
-                                        return! x.MoveNext ()
-                                | _ -> return false }
-                          member _.Dispose () =
-                              match !state with
-                              | Map2State.HaveEnumerator (e1, e2) ->
-                                  state := Map2State.Finished
-                                  dispose e1
-                                  dispose e2
-                              | _ -> () } }
-
+                            | Map2State.NotStarted (s1, s2) -> return! (
+                                let e1 = (s1 :> IEnumerableM<'``Monad<bool>``, 'T1>).GetEnumerator ()
+                                let e2 = (s2 :> IEnumerableM<'``Monad<bool>``, 'T2>).GetEnumerator ()
+                                state := Map2State.HaveEnumerator (e1, e2)
+                                x.MoveNext ())
+                            | Map2State.HaveEnumerator (e1, e2) ->
+                                let! res1 = e1.MoveNext ()
+                                let! res2 = e2.MoveNext ()
+                                if res1 && res2 then
+                                    current := Some (f e1.Current e2.Current)
+                                    return true
+                                else
+                                    x.Dispose ()
+                                    return! x.MoveNext ()
+                            | _ -> return false }
+                        member _.Dispose () =
+                            match !state with
+                            | Map2State.HaveEnumerator (e1, e2) ->
+                                state := Map2State.Finished
+                                dispose e1
+                                dispose e2
+                            | _ -> () } }
 
     let inline map2M (f: 'T1 -> 'T2 -> '``Monad<'U>``) (source1: SeqT<'``Monad<bool>``, 'T1>) (source2: SeqT<'``Monad<bool>``, 'T2>) : SeqT<'``Monad<bool>``, 'U> =
         SeqT
@@ -612,30 +584,30 @@ module SeqT =
                             | None -> invalidOp "Enumeration has not started. Call MoveNext."                            
                         member x.MoveNext () = innerMonad {
                             match !state with
-                                | Map2State.NotStarted (s1, s2) ->
-                                    return! (
-                                        let e1 = (s1 :> IEnumerableM<'``Monad<bool>``, 'T1>).GetEnumerator ()
-                                        let e2 = (s2 :> IEnumerableM<'``Monad<bool>``, 'T2>).GetEnumerator ()
-                                        state := Map2State.HaveEnumerator (e1, e2)
-                                        x.MoveNext ())
-                                | Map2State.HaveEnumerator (e1, e2) ->
-                                    let! res1 = e1.MoveNext ()
-                                    let! res2 = e2.MoveNext ()
-                                    if res1 && res2 then
-                                        let! x = f e1.Current e2.Current
-                                        current := Some x
-                                        return true
-                                    else
-                                        x.Dispose ()
-                                        return! x.MoveNext ()
-                                | _ -> return false }
-                          member _.Dispose () =
-                              match !state with
-                              | Map2State.HaveEnumerator (e1, e2) ->
-                                  state := Map2State.Finished
-                                  dispose e1
-                                  dispose e2
-                              | _ -> () } }
+                            | Map2State.NotStarted (s1, s2) ->
+                                return! (
+                                    let e1 = (s1 :> IEnumerableM<'``Monad<bool>``, 'T1>).GetEnumerator ()
+                                    let e2 = (s2 :> IEnumerableM<'``Monad<bool>``, 'T2>).GetEnumerator ()
+                                    state := Map2State.HaveEnumerator (e1, e2)
+                                    x.MoveNext ())
+                            | Map2State.HaveEnumerator (e1, e2) ->
+                                let! res1 = e1.MoveNext ()
+                                let! res2 = e2.MoveNext ()
+                                if res1 && res2 then
+                                    let! x = f e1.Current e2.Current
+                                    current := Some x
+                                    return true
+                                else
+                                    x.Dispose ()
+                                    return! x.MoveNext ()
+                            | _ -> return false }
+                        member _.Dispose () =
+                            match !state with
+                            | Map2State.HaveEnumerator (e1, e2) ->
+                                state := Map2State.Finished
+                                dispose e1
+                                dispose e2
+                            | _ -> () } }
 
     let inline map3<'T1, 'T2, 'T3, 'U, .. > (f: 'T1 -> 'T2 -> 'T3 -> 'U) (source1: SeqT<'``Monad<bool>``, 'T1>) (source2: SeqT<'``Monad<bool>``, 'T2>) (source3: SeqT<'``Monad<bool>``, 'T3>) : SeqT<'``Monad<bool>``, 'U> =
         map2 (<|) (map2 f source1 source2) source3
@@ -652,63 +624,58 @@ module SeqT =
     let inline lift3<'T1, 'T2, 'T3, 'U, .. > (f: 'T1 -> 'T2 -> 'T3 -> 'U) (x1: SeqT<'``Monad<bool>``, 'T1>) (x2: SeqT<'``Monad<bool>``, 'T2>) (x3: SeqT<'``Monad<bool>``, 'T3>) : SeqT<'``Monad<bool>``, 'U> =
         f </map/> x1 </apply/> x2 </apply/> x3
 
-    let inline filter (f: 'T -> bool) (inp: SeqT<'``Monad<bool>``, 'T>) : SeqT<'``Monad<bool>``, 'T> =
+    let inline filter (f: 'T -> bool) (source: SeqT<'``Monad<bool>``, 'T>) : SeqT<'``Monad<bool>``, 'T> =
         SeqT
-          { new IEnumerableM<'``Monad<bool>``, 'T> with
+            { new IEnumerableM<'``Monad<bool>``, 'T> with
                 member _.GetEnumerator () =
-                    let state = ref (CollectState.NotStarted inp)
+                    let state = ref (CollectState.NotStarted source)
                     let current = ref Option<'T>.None
                     { new IEnumeratorM<'``Monad<bool>``, 'T>  with
                         member _.Current =
                             match !current with
                             | Some c -> c
                             | None -> invalidOp "Enumeration has not started. Call MoveNext."
-                        member x.MoveNext () =
-                              innerMonad {
-                                  match !state with
-                                      | CollectState.NotStarted inp ->
-                                          return! (
-                                              let e1 = (inp :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
-                                              state := CollectState.HaveInputEnumerator e1
-                                              x.MoveNext ())
-                                      | CollectState.HaveInputEnumerator e1 ->
-                                          let! res1 = e1.MoveNext ()
-                                          if res1 && f e1.Current then
-                                              current := Some e1.Current
-                                              return true
-                                          elif res1 then
-                                              return! x.MoveNext ()
-                                          else
-                                              x.Dispose ()
-                                              return! x.MoveNext ()
-                                      | _ ->
-                                          return false }
-                          member _.Dispose () =
+                        member x.MoveNext () = innerMonad {
                               match !state with
+                              | CollectState.NotStarted inp ->
+                                  return! (
+                                      let e1 = (inp :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
+                                      state := CollectState.HaveInputEnumerator e1
+                                      x.MoveNext ())
                               | CollectState.HaveInputEnumerator e1 ->
-                                  state := CollectState.Finished
-                                  dispose e1
-                              | CollectState.HaveInnerEnumerator (e1, e2) ->
-                                  state := CollectState.Finished
-                                  dispose e2
-                                  dispose e1
-                              | _ -> () } }
+                                  let! res1 = e1.MoveNext ()
+                                  if res1 && f e1.Current then
+                                      current := Some e1.Current
+                                      return true
+                                  elif res1 then return! x.MoveNext ()
+                                  else
+                                      x.Dispose ()
+                                      return! x.MoveNext ()
+                                  | _ -> return false }
+                        member _.Dispose () =
+                            match !state with
+                            | CollectState.HaveInputEnumerator e1 ->
+                                state := CollectState.Finished
+                                dispose e1
+                            | CollectState.HaveInnerEnumerator (e1, e2) ->
+                                state := CollectState.Finished
+                                dispose e2
+                                dispose e1
+                            | _ -> () } }
 
-    let inline iteriM<'T, .. > (f: int -> 'T -> '``Monad<unit>``) (source: SeqT<'``Monad<bool>``, 'T>) : '``Monad<unit>`` = 
-        innerMonad { 
-            use ie = (source :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
-            let count = ref 0
-            let! (move: bool) = ie.MoveNext ()
-            let b = ref move
-            while b.Value do
-                do! f !count ie.Current
-                let! moven = ie.MoveNext ()
-                do incr count
-                   b := moven
-        }
+    let inline iteriM<'T, .. > (f: int -> 'T -> '``Monad<unit>``) (source: SeqT<'``Monad<bool>``, 'T>) : '``Monad<unit>`` = innerMonad { 
+        use ie = (source :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
+        let count = ref 0
+        let! (move: bool) = ie.MoveNext ()
+        let b = ref move
+        while b.Value do
+            do! f !count ie.Current
+            let! moven = ie.MoveNext ()
+            do incr count
+            b := moven }
 
-    let inline iterM<'T, .. > (f: 'T -> '``Monad<unit>``) (inp: SeqT<'``Monad<bool>``, 'T>) : '``Monad<unit>`` = iteriM (fun _ x -> f x) inp    
-    let inline iteri<'T, .. > (f: int -> 'T -> unit)      (inp: SeqT<'``Monad<bool>``, 'T>) : '``Monad<unit>`` = iteriM (fun i x -> result (f i x)) inp
+    let inline iterM<'T, .. > (f: 'T -> '``Monad<unit>``) (source: SeqT<'``Monad<bool>``, 'T>) : '``Monad<unit>`` = iteriM (fun _ x -> f x) source    
+    let inline iteri<'T, .. > (f: int -> 'T -> unit)      (source: SeqT<'``Monad<bool>``, 'T>) : '``Monad<unit>`` = iteriM (fun i x -> result (f i x)) source
     let inline iter<'T, .. > f (source: SeqT<'``Monad<bool>``, 'T>) : '``Monad<unit>`` = iterM (f >> result) source
 
     [<RequireQualifiedAccess>]
@@ -718,149 +685,139 @@ module SeqT =
        | HaveHandlerEnumerator of IEnumeratorM<'``Monad<bool>``, 'T>
        | Finished
 
-    /// Implements the 'TryWith' functionality for computation builder
-    let inline tryWith<'T, .. > (inp: SeqT<'``Monad<bool>``, 'T>) (handler : exn -> SeqT<'``Monad<bool>``, 'T>) : SeqT<'``Monad<bool>``, 'T> =
-          // Note: this is put outside the object deliberately, so the object doesn't permanently capture inp1 and inp2
+    /// Implements the 'TryWith' functionality for the computation expression builder.
+    let inline tryWith<'T, .. > (source: SeqT<'``Monad<bool>``, 'T>) (handler : exn -> SeqT<'``Monad<bool>``, 'T>) : SeqT<'``Monad<bool>``, 'T> =
         SeqT
-          { new IEnumerableM<'``Monad<bool>``, 'T> with
+            { new IEnumerableM<'``Monad<bool>``, 'T> with
                 member _.GetEnumerator () =
-                    let state = ref (TryWithState.NotStarted inp)
-                    let current = ref Option<'T>.None
-                    { new IEnumeratorM<'``Monad<bool>``, 'T>  with
-                        member _.Current =
-                            match !current with
-                            | Some c -> c
-                            | None -> invalidOp "Enumeration has not started. Call MoveNext."
-                        member x.MoveNext () =
-                            innerMonad2<_, '``Monad<unit>``> () {
-                              match !state with
-                              | TryWithState.NotStarted inp ->
-                                  let res = ref Unchecked.defaultof<_>
-                                  try
-                                      res := Choice1Of2 ((inp :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ())
-                                  with exn ->
-                                      res := Choice2Of2 exn
-                                  match res.Value with
-                                  | Choice1Of2 r ->
-                                      return!
-                                        (state := TryWithState.HaveBodyEnumerator r
-                                         x.MoveNext ())
-                                  | Choice2Of2 exn ->
-                                      return!
-                                         (x.Dispose ()
-                                          let enum = (handler exn :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
-                                          state := TryWithState.HaveHandlerEnumerator enum
-                                          x.MoveNext ())
-                              | TryWithState.HaveBodyEnumerator e ->
-                                  let res = ref Unchecked.defaultof<Choice<bool, exn>>
-                                  try
-                                      let! r = e.MoveNext ()
-                                      res := Choice1Of2 r
-                                  with exn ->
-                                      res := Choice2Of2 exn
-                                  match res.Value with
-                                  | Choice1Of2 res ->
-                                      return
-                                          (match res with
-                                           | false -> x.Dispose ()
-                                           | true  -> current := Some e.Current
-                                           res)
-                                  | Choice2Of2 exn ->
-                                      return! (
-                                         x.Dispose ()
-                                         let e = (handler exn :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
-                                         state := TryWithState.HaveHandlerEnumerator e
-                                         x.MoveNext ())
-                              | TryWithState.HaveHandlerEnumerator e ->
-                                  let! res = e.MoveNext()
-                                  return (
-                                      if res then
-                                          current := Some e.Current
-                                          true
-                                      else
-                                          x.Dispose ()
-                                          false)
-                              | _ ->
-                                  return false }
-                                
-                          member _.Dispose () =
-                              match !state with
-                              | TryWithState.HaveBodyEnumerator e | TryWithState.HaveHandlerEnumerator e ->
-                                  state := TryWithState.Finished
-                                  dispose e
-                              | _ -> () } }
-
-
-    [<RequireQualifiedAccess>]
-    type TryFinallyState<'``Monad<bool>``, 'T> =
-       | NotStarted    of SeqT<'``Monad<bool>``, 'T>
-       | HaveBodyEnumerator of IEnumeratorM<'``Monad<bool>``, 'T>
-       | Finished
-
-    // This pushes the handler through all the async computations
-    // The (synchronous) compensation is run when the Dispose () is called
-    let inline tryFinally (inp: SeqT<'``Monad<bool>``, 'T>) (compensation : unit -> unit) : SeqT<'``Monad<bool>``, 'T> =
-        SeqT
-          { new IEnumerableM<'``Monad<bool>``, 'T> with
-                member _.GetEnumerator () =
-                    let state = ref (TryFinallyState.NotStarted inp)
+                    let state = ref (TryWithState.NotStarted source)
                     let current = ref Option<'T>.None
                     { new IEnumeratorM<'``Monad<bool>``, 'T> with
                         member _.Current =
                             match !current with
                             | Some c -> c
                             | None -> invalidOp "Enumeration has not started. Call MoveNext."
-                        member x.MoveNext () =
-                              innerMonad {
-                                  match !state with
-                                      | TryFinallyState.NotStarted inp ->
-                                          return! (
-                                              let e = (inp :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
-                                              state := TryFinallyState.HaveBodyEnumerator e
-                                              x.MoveNext ())
-                                      | TryFinallyState.HaveBodyEnumerator e ->
-                                          let! (res: bool) = e.MoveNext ()
-                                          return (
-                                              if res then current := Some e.Current
-                                              else x.Dispose ()
-                                              res)
-                                      | _ ->
-                                          return false }
-                          member _.Dispose () =
-                              match !state with
-                              | TryFinallyState.HaveBodyEnumerator e ->
-                                  state := TryFinallyState.Finished
-                                  dispose e
-                                  compensation ()
-                              | _ -> () } }
+                        member x.MoveNext () = innerMonad2<_, '``Monad<unit>``> () {
+                            match !state with
+                            | TryWithState.NotStarted inp ->
+                                let res = ref Unchecked.defaultof<_>
+                                try
+                                    res := Choice1Of2 ((inp :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ())
+                                with exn ->
+                                    res := Choice2Of2 exn
+                                match res.Value with
+                                | Choice1Of2 r ->
+                                    return! (
+                                       state := TryWithState.HaveBodyEnumerator r
+                                       x.MoveNext ())
+                                | Choice2Of2 exn ->
+                                    return! (
+                                        x.Dispose ()
+                                        let enum = (handler exn :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
+                                        state := TryWithState.HaveHandlerEnumerator enum
+                                        x.MoveNext ())
+                            | TryWithState.HaveBodyEnumerator e ->
+                                let res = ref Unchecked.defaultof<Choice<bool, exn>>
+                                try
+                                    let! r = e.MoveNext ()
+                                    res := Choice1Of2 r
+                                with exn ->
+                                    res := Choice2Of2 exn
+                                match res.Value with
+                                | Choice1Of2 res ->
+                                    return (
+                                        if res then current := Some e.Current
+                                        else x.Dispose ()
+                                        res)
+                                | Choice2Of2 exn ->
+                                    return! (
+                                        x.Dispose ()
+                                        let e = (handler exn :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
+                                        state := TryWithState.HaveHandlerEnumerator e
+                                        x.MoveNext ())
+                            | TryWithState.HaveHandlerEnumerator e ->
+                                let! res = e.MoveNext()
+                                return (
+                                    if res then current := Some e.Current
+                                    else x.Dispose ()
+                                    res)
+                            | _ -> return false }
+                                
+                        member _.Dispose () =
+                            match !state with
+                            | TryWithState.HaveBodyEnumerator e | TryWithState.HaveHandlerEnumerator e ->
+                                state := TryWithState.Finished
+                                dispose e
+                            | _ -> () } }
+
+    [<RequireQualifiedAccess>]
+    type TryFinallyState<'``Monad<bool>``, 'T> =
+       | NotStarted    of SeqT<'``Monad<bool>``, 'T>
+       | HaveBodyEnumerator of IEnumeratorM<'``Monad<bool>``, 'T>
+       | Finished
+    
+    /// Implements the 'TryFinally' functionality for the computation expression builder.
+    let inline tryFinally (source: SeqT<'``Monad<bool>``, 'T>) (compensation : unit -> unit) : SeqT<'``Monad<bool>``, 'T> =
+        // This pushes the handler through all the monadic computations.
+        // The (synchronous) compensation is run when the Dispose () is called.
+        SeqT
+            { new IEnumerableM<'``Monad<bool>``, 'T> with
+                member _.GetEnumerator () =
+                    let state = ref (TryFinallyState.NotStarted source)
+                    let current = ref Option<'T>.None
+                    { new IEnumeratorM<'``Monad<bool>``, 'T> with
+                        member _.Current =
+                            match !current with
+                            | Some c -> c
+                            | None -> invalidOp "Enumeration has not started. Call MoveNext."
+                        member x.MoveNext () = innerMonad {
+                            match !state with
+                            | TryFinallyState.NotStarted inp ->
+                                return! (
+                                    let e = (inp :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ()
+                                    state := TryFinallyState.HaveBodyEnumerator e
+                                    x.MoveNext ())
+                            | TryFinallyState.HaveBodyEnumerator e ->
+                                let! (res: bool) = e.MoveNext ()
+                                return (
+                                    if res then current := Some e.Current
+                                    else x.Dispose ()
+                                    res)
+                            | _ -> return false }
+                        member _.Dispose () =
+                            match !state with
+                            | TryFinallyState.HaveBodyEnumerator e ->
+                                state := TryFinallyState.Finished
+                                dispose e
+                                compensation ()
+                            | _ -> () } }
 
     let inline unfoldM (f: 'State -> '``Monad<('T * 'State) option>``) (s: 'State) : SeqT<'``Monad<bool>``, 'T> =
         SeqT
             { new IEnumerableM<'``Monad<bool>``, 'T> with
-                  member _.GetEnumerator () =
-                      let stateStarted = ref false
-                      let currentState = ref s
-                      let current = ref Option<'T>.None
-                      { new IEnumeratorM<'``Monad<bool>``, 'T>  with
-                          member _.Current =
-                              match !current, !stateStarted with
-                              | Some c, true -> c
-                              | _     , false -> invalidOp "Enumeration has not started. Call MoveNext."
-                              | None  , true  -> invalidOp "Enumeration finished."
-                          member x.MoveNext () =
-                                monad' {
-                                    if not stateStarted.Value then
-                                        stateStarted := true
-                                        return! x.MoveNext ()
-                                    else
-                                        let! res = f currentState.Value
-                                        match res with
-                                        | None -> return false
-                                        | Some (t, newState) ->
-                                            current := Some t
-                                            currentState := newState
-                                            return true }
-                          member _.Dispose () = () } }
+                member _.GetEnumerator () =
+                    let stateStarted = ref false
+                    let currentState = ref s
+                    let current = ref Option<'T>.None
+                    { new IEnumeratorM<'``Monad<bool>``, 'T>  with
+                        member _.Current =
+                            match !current, !stateStarted with
+                            | Some c, true -> c
+                            | _     , false -> invalidOp "Enumeration has not started. Call MoveNext."
+                            | None  , true  -> invalidOp "Enumeration finished."
+                        member x.MoveNext () = monad' {
+                            if not stateStarted.Value then
+                                stateStarted := true
+                                return! x.MoveNext ()
+                            else
+                                let! res = f currentState.Value
+                                match res with
+                                | None -> return false
+                                | Some (t, newState) ->
+                                    current := Some t
+                                    currentState := newState
+                                    return true }
+                        member _.Dispose () = () } }
 
     let inline unfold (f: 'State -> ('T * 'State) option) (s: 'State) : SeqT<'``Monad<bool>``, 'T> = unfoldM (result << f: 'State -> '``Monad<('T * 'State) option>``) s
 

--- a/src/FSharpPlus/Data/Seq.fs
+++ b/src/FSharpPlus/Data/Seq.fs
@@ -164,8 +164,8 @@ module SeqT =
                             | _ -> () } }
 
     let inline hoist (source: seq<'T>) : SeqT<'``Monad<bool>``, 'T> = wrap (result source: '``Monad<seq<'T>>``)
-    
-    let inline runToArray<'T, .. > (source: SeqT<'``Monad<bool>``, 'T>) : '``Monad<'T []>`` =
+
+    let inline runThen<'T, .. > (f: ResizeArray<'T> -> 'R) (source: SeqT<'``Monad<bool>``, 'T>) : '``Monad<'R>`` =
         let ra = new ResizeArray<_> ()
         Using.Invoke
             ((source :> IEnumerableM<'``Monad<bool>``, 'T>).GetEnumerator ())
@@ -182,11 +182,17 @@ module SeqT =
                             ie.MoveNext () >>= fun moven ->
                                 b <- moven
                                 result () )
-                    >>= fun () -> result (ra.ToArray ()) )
+                    >>= fun () -> result (f ra))
     
-    let inline runToList<'T, .. > (source: SeqT<'``Monad<bool>``, 'T>) : '``Monad<'T list>`` = runToArray<_, _, '``Monad<'T []>``, '``Monad<unit>``> source |> map Array.toList<'T>
-    let inline run<'T, .. >       (source: SeqT<'``Monad<bool>``, 'T>) : '``Monad<'T seq>``  = runToArray<_, _, '``Monad<'T []>``, '``Monad<unit>``> source |> map Array.toSeq<'T>
+    let inline runToArray<'T, .. > (source: SeqT<'``Monad<bool>``, 'T>) : '``Monad<'T []>`` =
+        runThen<'T, 'T [], '``Monad<bool>``, '``Monad<'T []>``, '``Monad<unit>``> toArray source
+    
+    let inline runToList<'T, .. > (source: SeqT<'``Monad<bool>``, 'T>) : '``Monad<'T list>`` =
+        runThen<'T, 'T list, '``Monad<bool>``, '``Monad<'T list>``, '``Monad<unit>``> toList source
 
+    let inline run<'T, .. >       (source: SeqT<'``Monad<bool>``, 'T>) : '``Monad<'T seq>`` =
+        runThen<'T, 'T seq, '``Monad<bool>``, '``Monad<'T seq>``, '``Monad<unit>``> toSeq source
+    
     [<GeneralizableValue>]
     let inline empty<'T, .. > : SeqT<'``Monad<bool>``, 'T> =
         SeqT

--- a/src/FSharpPlus/Data/Seq.fs
+++ b/src/FSharpPlus/Data/Seq.fs
@@ -886,11 +886,14 @@ module Extension =
                 b1 := move1n
                 b2 := move2n }
 
+        let inline map3<'T1, 'T2, 'T3, 'U, .. > (f: 'T1 -> 'T2 -> 'T3 -> 'U) (source1: SeqT<'``Monad<bool>``, 'T1>) (source2: SeqT<'``Monad<bool>``, 'T2>) (source3: SeqT<'``Monad<bool>``, 'T3>) : SeqT<'``Monad<bool>``, 'U> =
+            map2 (<|) (map2 f source1 source2) source3
+
+        let inline map3M (f: 'T1 -> 'T2 -> 'T3 -> '``Monad<'U>``) (source1: SeqT<'``Monad<bool>``, 'T1>) (source2: SeqT<'``Monad<bool>``, 'T2>) (source3: SeqT<'``Monad<bool>``, 'T3>) : SeqT<'``Monad<bool>``, 'U> =
+            map2M (<|) (map2 f source1 source2) source3
+
         let inline zip (source1: SeqT<'``Monad<bool>``, 'T1>) (source2: SeqT<'``Monad<bool>``, 'T2>) : SeqT<'``Monad<bool>``, ('T1 * 'T2)> =
             map2 tuple2 source1 source2
-
-        let inline map3<'T1, 'T2, 'T3, 'U, .. > (f: 'T1 -> 'T2 -> 'T3 -> 'U) (x1: SeqT<'``Monad<bool>``, 'T1>) (x2: SeqT<'``Monad<bool>``, 'T2>) (x3: SeqT<'``Monad<bool>``, 'T3>) : SeqT<'``Monad<bool>``, 'U> =
-            map2 (<|) (map2 f x1 x2) x3
 
         let inline zip3 (source1: SeqT<'``Monad<bool>``, 'T1>) (source2: SeqT<'``Monad<bool>``, 'T2>) (source3: SeqT<'``Monad<bool>``, 'T3>) : SeqT<'``Monad<bool>``, ('T1 * 'T2 * 'T3)> =
             map3 tuple3 source1 source2 source3

--- a/src/FSharpPlus/Extensions/AsyncEnumerable.fs
+++ b/src/FSharpPlus/Extensions/AsyncEnumerable.fs
@@ -1,0 +1,52 @@
+﻿namespace FSharpPlus
+
+#if !FABLE_COMPILER
+
+open System
+open System.Threading
+open System.Threading.Tasks
+open FSharpPlus.Data
+
+/// Additional operations on Observable<'T>
+[<RequireQualifiedAccess>]
+module AsyncEnumerable =
+
+    let toAsyncSeq (source: Collections.Generic.IAsyncEnumerable<_>) : SeqT<Async<_>, _> = monad.plus {
+        let! ct = SeqT.lift Async.CancellationToken
+        let e = source.GetAsyncEnumerator ct
+        use _ =
+            { new IDisposable with
+                member _.Dispose () =
+                    e.DisposeAsync().AsTask () |> Async.AwaitTask |> Async.RunSynchronously }
+
+        let mutable currentResult = true
+        while currentResult do
+            let! r = e.MoveNextAsync().AsTask () |> Async.AwaitTask |> SeqT.lift
+            currentResult <- r
+            if r then yield e.Current
+    }
+
+    let ofAsyncSeq (source: SeqT<Async<_>, 'a>) = {
+        new Collections.Generic.IAsyncEnumerable<'a> with
+            member _.GetAsyncEnumerator (cancellationToken: CancellationToken) =
+                let mutable current = Unchecked.defaultof<_>
+                let enumerator = source.GetEnumerator()
+                { new Collections.Generic.IAsyncEnumerator<'a> with
+                    member _.Current = current
+                    member _.MoveNextAsync() =
+                        let moveNextAsync = async {
+                            let! enumerationResult = enumerator.MoveNext ()
+                            match enumerationResult with
+                            | Some v ->
+                                current <- v
+                                return true
+                            | _ -> return false
+                        }
+                        Async.StartAsTask(moveNextAsync, cancellationToken = cancellationToken) |> ValueTask<bool>
+                    member _.DisposeAsync () =
+                        enumerator.Dispose ()
+                        ValueTask ()
+                }
+    }
+
+#endif

--- a/src/FSharpPlus/Extensions/Observable.fs
+++ b/src/FSharpPlus/Extensions/Observable.fs
@@ -1,0 +1,80 @@
+﻿namespace FSharpPlus
+
+#if !FABLE_COMPILER
+
+open System
+open System.Threading
+open System.Threading.Tasks
+open System.Runtime.ExceptionServices
+open FSharpPlus.Data
+
+/// Additional operations on Observable<'T>
+[<RequireQualifiedAccess>]
+module Observable =
+    /// Union type that represents different messages that can be sent to the
+    /// IObserver interface. The IObserver type is equivalent to a type that has
+    /// just OnNext method that gets 'ObservableUpdate' as an argument.
+    type (*internal*) ObservableUpdate<'T> =
+        | Next of 'T
+        | Error of ExceptionDispatchInfo
+        | Completed
+
+
+    /// Turns observable into an observable that only calls OnNext method of the
+    /// observer, but gives it a discriminated union that represents different
+    /// kinds of events (error, next, completed)
+    let asUpdates (source: IObservable<'T>) = {
+        new IObservable<_> with
+            member _.Subscribe observer =
+                source.Subscribe {
+                    new IObserver<_> with
+                    member _.OnNext v = observer.OnNext (Next v)
+                    member _.OnCompleted () = observer.OnNext Completed
+                    member _.OnError e = observer.OnNext (Error (ExceptionDispatchInfo.Capture e)) }}
+
+
+
+
+    let toAsyncSeq (source: System.IObservable<'T>) : SeqT<Async<bool>, 'T> = monad.plus {
+        let cts = new CancellationTokenSource ()
+        try 
+            // The body of this agent returns immediately.  It turns out this is a valid use of an F# agent, and it
+            // leaves the agent available as a queue that supports an asynchronous receive.
+            //
+            // This makes the cancellation token is somewhat meaningless since the body has already returned.  However
+            // if we don't pass it in then the default cancellation token will be used, so we pass one in for completeness.
+            use agent = MailboxProcessor<_>.Start ((fun _inbox -> async.Return ()), cancellationToken = cts.Token)
+            use _d = source |> asUpdates |> Observable.subscribe agent.Post
+            let fin = ref false
+            while not fin.Value do 
+                let! msg = SeqT.lift (agent.Receive ())
+                match msg with
+                | ObservableUpdate.Error e -> e.Throw ()
+                | Completed -> fin := true
+                | Next v -> yield v 
+        finally 
+                // Cancel on early exit 
+                cts.Cancel () }
+
+    let toTaskSeq (source: System.IObservable<'T>) : SeqT<Task<bool>, 'T> = monad.plus {
+        let cts = new CancellationTokenSource ()
+        try 
+            // The body of this agent returns immediately.  It turns out this is a valid use of an F# agent, and it
+            // leaves the agent available as a queue that supports an asynchronous receive.
+            //
+            // This makes the cancellation token is somewhat meaningless since the body has already returned.  However
+            // if we don't pass it in then the default cancellation token will be used, so we pass one in for completeness.
+            use agent = MailboxProcessor<_>.Start ((fun _inbox -> async.Return ()), cancellationToken = cts.Token)
+            use _d = source |> asUpdates |> Observable.subscribe agent.Post
+            let fin = ref false
+            while not fin.Value do 
+                let! msg = SeqT.lift (Async.StartAsTask (agent.Receive (), cancellationToken = cts.Token))
+                match msg with
+                | ObservableUpdate.Error e -> e.Throw ()
+                | Completed -> fin := true
+                | Next v -> yield v 
+        finally 
+                // Cancel on early exit 
+                cts.Cancel () }
+
+#endif

--- a/src/FSharpPlus/FSharpPlus.fsproj
+++ b/src/FSharpPlus/FSharpPlus.fsproj
@@ -103,6 +103,8 @@
     <Compile Include="Data/Kleisli.fs" />
     <Compile Include="Data/Free.fs" />
     <Compile Include="Data/Coproduct.fs" />
+	<Compile Include="Extensions/Observable.fs" />
+	<Compile Include="Extensions/AsyncEnumerable.fs" />
     <Compile Include="Memoization.fs" />
     <Compile Include="Parsing.fs" />
     <Content Condition=" '$(TargetFramework)' == 'net45'" Include="App.config" />
@@ -111,7 +113,7 @@
   <!-- Add source files to "fable" folder in Nuget package - required for the library to be consumable by Fable -->
   <ItemGroup>
     <Content Include="*.fsproj; *.fs" PackagePath="fable/" />
-    <Content Include="Extensions/*.fs" PackagePath="fable/Extensions" />
+	<Content Include="Extensions/*.fs" PackagePath="fable/Extensions" />
     <Content Include="Control/*.fs" PackagePath="fable/Control" />
     <Content Include="Math/*.fs" PackagePath="fable/Math" />
     <Content Include="Data/*.fs" PackagePath="fable/Data" />

--- a/tests/FSharpPlus.Tests/FSharpPlus.Tests.fsproj
+++ b/tests/FSharpPlus.Tests/FSharpPlus.Tests.fsproj
@@ -20,6 +20,7 @@
     <Compile Include="Validations.fs" />
     <Compile Include="Task.fs" />
     <Compile Include="Free.fs" />
+    <Compile Include="SeqT.fs" />
     <Compile Include="ComputationExpressions.fs" />
     <Compile Include="Lens.fs" />
     <Compile Include="Extensions.fs" />

--- a/tests/FSharpPlus.Tests/SeqT.fs
+++ b/tests/FSharpPlus.Tests/SeqT.fs
@@ -18,7 +18,7 @@ module BasicTests =
         CollectionAssert.AreEqual (res, exp)
   
     [<Test>]
-    let infiniteLists () =
+    let infiniteLists1 () =
         let infinite: SeqT<Lazy<_>, _> = SeqT.unfold (fun x -> monad { return (Some (x, x + 1) ) }) 0
         let finite = take 12 infinite
         let res = finite <|> infinite
@@ -43,6 +43,10 @@ module BasicTests =
         let y2 = SeqT.run x2 |> extract |> toList
         CollectionAssert.AreEqual (y2, [("0", 0); ("0", 1); ("1", 0); ("1", 1); ("2", 0); ("2", 1); ("3", 0); ("3", 1); ("4", 0); ("4", 1); ("5", 0); ("5", 1); ("6", 0); ("6", 1)])
 
+        let x3 = SeqT.zip3 (map string infinite) (map ((*) 10) infinite) (take 3 finite)
+        let y3 = SeqT.run x3 |> extract |> toList
+        CollectionAssert.AreEqual (y3, [("0", 0, 0); ("1", 10, 1); ("2", 20, 2)])
+
     [<Test>]
     let zipLists2 () =
         let infinite: SeqT<Async<_>, _> = SeqT.unfold (fun x -> monad { return if x = 13 then failwith "Unlucky number" else (Some (x, x + 1) ) }) 0
@@ -54,6 +58,10 @@ module BasicTests =
         let x2 = lift2 tuple2 (map string finite) (take 2 infinite)
         let y2 = SeqT.run x2 |> extract |> toList
         CollectionAssert.AreEqual (y2, [("0", 0); ("0", 1); ("1", 0); ("1", 1); ("2", 0); ("2", 1); ("3", 0); ("3", 1); ("4", 0); ("4", 1); ("5", 0); ("5", 1); ("6", 0); ("6", 1)])
+        
+        let x3 = SeqT.zip3 (map string infinite) (map ((*) 10) infinite) (take 3 finite)
+        let y3 = SeqT.run x3 |> extract |> toList
+        CollectionAssert.AreEqual (y3, [("0", 0, 0); ("1", 10, 1); ("2", 20, 2)])
 
     // Compile tests
     let binds () =

--- a/tests/FSharpPlus.Tests/SeqT.fs
+++ b/tests/FSharpPlus.Tests/SeqT.fs
@@ -52,6 +52,21 @@ module BasicTests =
         let z = (+) <!> SeqT (Task.FromResult (seq [1])) <*> SeqT (Task.FromResult (seq [2]))
         ()
 
+    let monadTransOps () =
+        let fn : SeqT<Reader<int, bool>, int> = 
+            monad.plus {
+                let! x1 = ask
+                let! x2 = 
+                    if x1 > 0 then result 1
+                    else empty
+                return x1 + x2
+            }
+        
+        let x = (fn |> SeqT.run |> Reader.run) 10 |> Seq.toList
+        areEqual [11] x
+        let y = (fn |> SeqT.run |> Reader.run) -1 |> Seq.toList
+        areEqual [] y
+
 
 module ComputationExpressions =
 

--- a/tests/FSharpPlus.Tests/SeqT.fs
+++ b/tests/FSharpPlus.Tests/SeqT.fs
@@ -19,7 +19,14 @@ module BasicTests =
   
     [<Test>]
     let infiniteLists () =
-        let infinite = SeqT.unfold (fun x -> monad<Lazy<_>> { return (Some (x, x + 1) ) }) 0 // note type inference doesn't flow from result type
+        let infinite: SeqT<Lazy<_>, _> = SeqT.unfold (fun x -> monad { return (Some (x, x + 1) ) }) 0
+        let finite = take 12 infinite
+        let res = finite <|> infinite
+        CollectionAssert.AreEqual (res |> take 13 |> SeqT.run |> extract, [0;1;2;3;4;5;6;7;8;9;10;11;0])
+
+    [<Test>]
+    let infiniteLists2 () =
+        let infinite: SeqT<Async<_>, _> = SeqT.unfold (fun x -> monad { return (Some (x, x + 1) ) }) 0
         let finite = take 12 infinite
         let res = finite <|> infinite
         CollectionAssert.AreEqual (res |> take 13 |> SeqT.run |> extract, [0;1;2;3;4;5;6;7;8;9;10;11;0])

--- a/tests/FSharpPlus.Tests/SeqT.fs
+++ b/tests/FSharpPlus.Tests/SeqT.fs
@@ -19,14 +19,14 @@ module BasicTests =
   
     [<Test>]
     let infiniteLists1 () =
-        let infinite: SeqT<Lazy<_>, _> = SeqT.unfoldM (fun x -> monad { return (Some (x, x + 1) ) }) 0
+        let infinite: SeqT<Lazy<_>, _> = SeqT.unfold (fun x -> Some (x, x + 1)) 0
         let finite = take 12 infinite
         let res = finite <|> infinite
         CollectionAssert.AreEqual (res |> take 13 |> SeqT.run |> extract, [0;1;2;3;4;5;6;7;8;9;10;11;0])
 
     [<Test>]
     let infiniteLists2 () =
-        let infinite: SeqT<Async<_>, _> = SeqT.unfoldM (fun x -> monad { return (Some (x, x + 1) ) }) 0
+        let infinite: SeqT<Async<_>, _> = SeqT.unfold (fun x -> Some (x, x + 1)) 0
         let finite = take 12 infinite
         let res = finite <|> infinite
         CollectionAssert.AreEqual (res |> take 13 |> SeqT.run |> extract, [0;1;2;3;4;5;6;7;8;9;10;11;0])
@@ -34,7 +34,7 @@ module BasicTests =
     [<Test>]
     let zipLists1 () =
         let infinite: SeqT<Lazy<_>, int> = SeqT.unfoldM (fun x -> monad { return if x = 13 then failwith "Unlucky number" else (Some (x, x + 1) ) }) 0
-        let finite:   SeqT<Lazy<_>, int> = SeqT.unfoldM (fun x -> monad { return if x = 7 then None else (Some (x, x + 1) ) }) 0
+        let finite:   SeqT<Lazy<_>, int> = SeqT.unfoldM (fun x -> monad { return if x =  7 then None else (Some (x, x + 1) ) }) 0
         let x1 = zip (map string infinite) finite
         let y1 = SeqT.run x1 |> extract |> toList
         CollectionAssert.AreEqual (y1, [("0", 0); ("1", 1); ("2", 2); ("3", 3); ("4", 4); ("5", 5); ("6", 6)])
@@ -50,7 +50,7 @@ module BasicTests =
     [<Test>]
     let zipLists2 () =
         let infinite: SeqT<Async<_>, _> = SeqT.unfoldM (fun x -> monad { return if x = 13 then failwith "Unlucky number" else (Some (x, x + 1) ) }) 0
-        let finite:   SeqT<Async<_>, _> = SeqT.unfoldM (fun x -> monad { return if x = 7 then None else (Some (x, x + 1) ) }) 0
+        let finite:   SeqT<Async<_>, _> = SeqT.unfoldM (fun x -> monad { return if x =  7 then None else (Some (x, x + 1) ) }) 0
         let x1 = zip (map string infinite) finite
         let y1 = SeqT.run x1 |> extract |> toList
         CollectionAssert.AreEqual (y1, [("0", 0); ("1", 1); ("2", 2); ("3", 3); ("4", 4); ("5", 5); ("6", 6)])

--- a/tests/FSharpPlus.Tests/SeqT.fs
+++ b/tests/FSharpPlus.Tests/SeqT.fs
@@ -66,7 +66,7 @@ module BasicTests =
     // Compile tests
     let binds () =
         let res1 = SeqT [|seq [1..4] |] >>= fun x -> SeqT [|seq [x * 2] |]
-        let res2 = SeqT (Task.FromResult (seq [1..4])) >>= (fun x -> SeqT (Task.FromResult (seq [x * 2])))
+        let res2 = SeqT.hoist [1..4] >>= (fun x -> SeqT (Task.FromResult (seq [x * 2])))
         let res3 = SeqT (ResizeArray [seq [1..4] ]) >>= (fun x -> SeqT (ResizeArray [seq [x * 2] ]))
         let res4 = SeqT (lazy (seq [1..4])) >>= (fun x -> SeqT (lazy (seq [x * 2])))
         let res5 = SeqT (seq [seq [1..4] ]) >>= (fun x -> SeqT (seq [seq [x * 2] ]))

--- a/tests/FSharpPlus.Tests/SeqT.fs
+++ b/tests/FSharpPlus.Tests/SeqT.fs
@@ -14,8 +14,8 @@ module BasicTests =
     let wrap_unwrap () =
         let c = SeqT (async.Return (seq ['a'..'g']))
         let res = c |> SeqT.run |> SeqT |> SeqT.run |> extract
-        let exp = c |> SeqT.run |> extract
-        CollectionAssert.AreEqual (res, exp)
+        let (SeqT exp) = c
+        CollectionAssert.AreEqual (res, extract exp)
   
     [<Test>]
     let infiniteLists1 () =

--- a/tests/FSharpPlus.Tests/SeqT.fs
+++ b/tests/FSharpPlus.Tests/SeqT.fs
@@ -1,0 +1,53 @@
+﻿module FSharpPlus.Tests.SeqT
+
+open System
+open FSharpPlus
+open FSharpPlus.Data
+open NUnit.Framework
+open FsCheck
+open Helpers
+open System.Collections.Generic
+open System.Threading.Tasks
+
+module BasicTests =
+    [<Test>]
+    let wrap_unwrap () =
+        let c = SeqT (async.Return (seq ['a'..'g']))
+        let res = c |> SeqT.run |> SeqT |> SeqT.run |> extract
+        let exp = c |> SeqT.run |> extract
+        CollectionAssert.AreEqual (res, exp)
+  
+    [<Test>]
+    let infiniteLists () =
+        let infinite = SeqT.unfold (fun x -> monad<Lazy<_>> { return (Some (x, x + 1) ) }) 0
+        let finite = take 12 infinite
+        let res = finite <|> infinite
+        CollectionAssert.AreEqual (res |> take 13 |> SeqT.run |> extract, [0;1;2;3;4;5;6;7;8;9;10;11;0])
+        
+    // Compile tests
+    let binds () =
+        let res1 = SeqT [|seq [1..4] |] >>= fun x -> SeqT [|seq [x * 2] |]
+        let res2 = SeqT (Task.FromResult (seq [1..4])) >>= (fun x -> SeqT (Task.FromResult (seq [x * 2])))
+        let res3 = SeqT (ResizeArray [seq [1..4] ]) >>= (fun x -> SeqT (ResizeArray [seq [x * 2] ]))
+        let res4 = SeqT (lazy (seq [1..4])) >>= (fun x -> SeqT (lazy (seq [x * 2])))
+        let res5 = SeqT (seq [seq [1..4] ]) >>= (fun x -> SeqT (seq [seq [x * 2] ]))
+        ()
+        
+    let bind_for_identity () =
+        let res = SeqT (Identity (seq [1..4])) >>= fun x -> SeqT (Identity (seq [x * 2]))
+        ()    
+        
+    let computation_expressions () =
+        let oneTwoThree : SeqT<_, _> = monad.plus { 
+            do! lift <| Async.Sleep 10
+            yield 1
+            do! lift <| Async.Sleep 50
+            yield 2 
+            yield 3}
+        ()
+
+    let applicatives () =
+        let x = (+) <!> SeqT None <*> SeqT (Some (seq [1;2;3;4]))
+        let y = (+) <!> SeqT (async.Return (seq [1])) <*> SeqT (async.Return (seq [2]))
+        let z = (+) <!> SeqT (Task.FromResult (seq [1])) <*> SeqT (Task.FromResult (seq [2]))
+        ()

--- a/tests/FSharpPlus.Tests/SeqT.fs
+++ b/tests/FSharpPlus.Tests/SeqT.fs
@@ -86,7 +86,7 @@ module BasicTests =
         ()
 
     let applicatives () =
-        let x = (+) <!> SeqT None <*> SeqT (Some (seq [1;2;3;4]))
+        let x = (+) <!> SeqT None <*> SeqT.ofSeq [1;2;3;4]
         let y = (+) <!> SeqT (async.Return (seq [1])) <*> SeqT (async.Return (seq [2]))
         let z = (+) <!> SeqT (Task.FromResult (seq [1])) <*> SeqT (Task.FromResult (seq [2]))
         ()

--- a/tests/FSharpPlus.Tests/SeqT.fs
+++ b/tests/FSharpPlus.Tests/SeqT.fs
@@ -30,6 +30,22 @@ module BasicTests =
         let finite = take 12 infinite
         let res = finite <|> infinite
         CollectionAssert.AreEqual (res |> take 13 |> SeqT.run |> extract, [0;1;2;3;4;5;6;7;8;9;10;11;0])
+
+    [<Test>]
+    let zipLists1 () =
+        let infinite: SeqT<Lazy<_>, int> = SeqT.unfold (fun x -> monad { return if x = 13 then failwith "Unlucky number" else (Some (x, x + 1) ) }) 0
+        let finite:   SeqT<Lazy<_>, int> = SeqT.unfold (fun x -> monad { return if x = 7 then None else (Some (x, x + 1) ) }) 0
+        let x = zip (map string infinite) finite
+        let y = SeqT.run x |> extract |> toList
+        CollectionAssert.AreEqual (y, [("0", 0); ("1", 1); ("2", 2); ("3", 3); ("4", 4); ("5", 5); ("6", 6)])
+
+    [<Test>]
+    let zipLists2 () =
+        let infinite: SeqT<Async<_>, _> = SeqT.unfold (fun x -> monad { return if x = 13 then failwith "Unlucky number" else (Some (x, x + 1) ) }) 0
+        let finite:   SeqT<Async<_>, _> = SeqT.unfold (fun x -> monad { return if x = 7 then None else (Some (x, x + 1) ) }) 0
+        let x = zip (map string infinite) finite
+        let y = SeqT.run x |> extract |> toList
+        CollectionAssert.AreEqual (y, [("0", 0); ("1", 1); ("2", 2); ("3", 3); ("4", 4); ("5", 5); ("6", 6)])
         
     // Compile tests
     let binds () =

--- a/tests/FSharpPlus.Tests/SeqT.fs
+++ b/tests/FSharpPlus.Tests/SeqT.fs
@@ -178,8 +178,8 @@ module ComputationExpressions =
 
         /// Determines equality of two async sequences by convering them to lists, ignoring side-effects.
         let EQ (a: AsyncSeq<'a>) (b: AsyncSeq<'a>) =
-            let exp = a |> SeqT.runToList |> Async.RunSynchronously
-            let act = b |> SeqT.runToList |> Async.RunSynchronously
+            let exp = a |> SeqT.runAsList |> Async.RunSynchronously
+            let act = b |> SeqT.runAsList |> Async.RunSynchronously
             if (exp = act) then true
             else
                 printfn "expected=%A" exp
@@ -196,10 +196,10 @@ module ComputationExpressions =
 
             Assert.True ((x = 0))
 
-            let s1 = s |> SeqT.runToList |> Async.RunSynchronously
+            let s1 = s |> SeqT.runAsList |> Async.RunSynchronously
             Assert.True ((x = 3))
 
-            let s2 = s |> SeqT.runToList |> Async.RunSynchronously
+            let s2 = s |> SeqT.runAsList |> Async.RunSynchronously
             Assert.True ((x = 6))
 
 
@@ -215,11 +215,11 @@ module ComputationExpressions =
 
             Assert.True ((x = 0))
 
-            let s1 = try (s |> SeqT.runToList |> Async.RunSynchronously) with _ -> []
+            let s1 = try (s |> SeqT.runAsList |> Async.RunSynchronously) with _ -> []
             Assert.True ((s1 = []))
             Assert.True ((x = 3))
             ()
-            let s2 = try s |> SeqT.runToList |> Async.RunSynchronously with _ -> []
+            let s2 = try s |> SeqT.runAsList |> Async.RunSynchronously with _ -> []
             Assert.True ((s2 = []))
             Assert.True ((x = 6))
 
@@ -233,11 +233,11 @@ module ComputationExpressions =
             
             Assert.True ((x = 0))
 
-            let s1 = try s |> SeqT.runToList |> Async.RunSynchronously with _ -> []
+            let s1 = try s |> SeqT.runAsList |> Async.RunSynchronously with _ -> []
             Assert.True ((s1 = []))
             Assert.True ((x = 3))
 
-            let s2 = try s |> SeqT.runToList |> Async.RunSynchronously with _ -> []
+            let s2 = try s |> SeqT.runAsList |> Async.RunSynchronously with _ -> []
             Assert.True ((s2 = []))
             Assert.True ((x = 6))
 
@@ -251,11 +251,11 @@ module ComputationExpressions =
             
             Assert.True ((x = 0))
 
-            let s1 = try s |> SeqT.runToList |> Async.RunSynchronously with _ -> []
+            let s1 = try s |> SeqT.runAsList |> Async.RunSynchronously with _ -> []
             Assert.True ((s1 = [1]))
             Assert.True ((x = 0))
 
-            let s2 = try s |> SeqT.runToList |> Async.RunSynchronously with _ -> []
+            let s2 = try s |> SeqT.runAsList |> Async.RunSynchronously with _ -> []
             Assert.True ((s2 = [1]))
 
 

--- a/tests/FSharpPlus.Tests/SeqT.fs
+++ b/tests/FSharpPlus.Tests/SeqT.fs
@@ -19,22 +19,22 @@ module BasicTests =
   
     [<Test>]
     let infiniteLists1 () =
-        let infinite: SeqT<Lazy<_>, _> = SeqT.unfold (fun x -> monad { return (Some (x, x + 1) ) }) 0
+        let infinite: SeqT<Lazy<_>, _> = SeqT.unfoldM (fun x -> monad { return (Some (x, x + 1) ) }) 0
         let finite = take 12 infinite
         let res = finite <|> infinite
         CollectionAssert.AreEqual (res |> take 13 |> SeqT.run |> extract, [0;1;2;3;4;5;6;7;8;9;10;11;0])
 
     [<Test>]
     let infiniteLists2 () =
-        let infinite: SeqT<Async<_>, _> = SeqT.unfold (fun x -> monad { return (Some (x, x + 1) ) }) 0
+        let infinite: SeqT<Async<_>, _> = SeqT.unfoldM (fun x -> monad { return (Some (x, x + 1) ) }) 0
         let finite = take 12 infinite
         let res = finite <|> infinite
         CollectionAssert.AreEqual (res |> take 13 |> SeqT.run |> extract, [0;1;2;3;4;5;6;7;8;9;10;11;0])
 
     [<Test>]
     let zipLists1 () =
-        let infinite: SeqT<Lazy<_>, int> = SeqT.unfold (fun x -> monad { return if x = 13 then failwith "Unlucky number" else (Some (x, x + 1) ) }) 0
-        let finite:   SeqT<Lazy<_>, int> = SeqT.unfold (fun x -> monad { return if x = 7 then None else (Some (x, x + 1) ) }) 0
+        let infinite: SeqT<Lazy<_>, int> = SeqT.unfoldM (fun x -> monad { return if x = 13 then failwith "Unlucky number" else (Some (x, x + 1) ) }) 0
+        let finite:   SeqT<Lazy<_>, int> = SeqT.unfoldM (fun x -> monad { return if x = 7 then None else (Some (x, x + 1) ) }) 0
         let x1 = zip (map string infinite) finite
         let y1 = SeqT.run x1 |> extract |> toList
         CollectionAssert.AreEqual (y1, [("0", 0); ("1", 1); ("2", 2); ("3", 3); ("4", 4); ("5", 5); ("6", 6)])
@@ -49,8 +49,8 @@ module BasicTests =
 
     [<Test>]
     let zipLists2 () =
-        let infinite: SeqT<Async<_>, _> = SeqT.unfold (fun x -> monad { return if x = 13 then failwith "Unlucky number" else (Some (x, x + 1) ) }) 0
-        let finite:   SeqT<Async<_>, _> = SeqT.unfold (fun x -> monad { return if x = 7 then None else (Some (x, x + 1) ) }) 0
+        let infinite: SeqT<Async<_>, _> = SeqT.unfoldM (fun x -> monad { return if x = 13 then failwith "Unlucky number" else (Some (x, x + 1) ) }) 0
+        let finite:   SeqT<Async<_>, _> = SeqT.unfoldM (fun x -> monad { return if x = 7 then None else (Some (x, x + 1) ) }) 0
         let x1 = zip (map string infinite) finite
         let y1 = SeqT.run x1 |> extract |> toList
         CollectionAssert.AreEqual (y1, [("0", 0); ("1", 1); ("2", 2); ("3", 3); ("4", 4); ("5", 5); ("6", 6)])

--- a/tests/FSharpPlus.Tests/SeqT.fs
+++ b/tests/FSharpPlus.Tests/SeqT.fs
@@ -35,18 +35,26 @@ module BasicTests =
     let zipLists1 () =
         let infinite: SeqT<Lazy<_>, int> = SeqT.unfold (fun x -> monad { return if x = 13 then failwith "Unlucky number" else (Some (x, x + 1) ) }) 0
         let finite:   SeqT<Lazy<_>, int> = SeqT.unfold (fun x -> monad { return if x = 7 then None else (Some (x, x + 1) ) }) 0
-        let x = zip (map string infinite) finite
-        let y = SeqT.run x |> extract |> toList
-        CollectionAssert.AreEqual (y, [("0", 0); ("1", 1); ("2", 2); ("3", 3); ("4", 4); ("5", 5); ("6", 6)])
+        let x1 = zip (map string infinite) finite
+        let y1 = SeqT.run x1 |> extract |> toList
+        CollectionAssert.AreEqual (y1, [("0", 0); ("1", 1); ("2", 2); ("3", 3); ("4", 4); ("5", 5); ("6", 6)])
+
+        let x2 = lift2 tuple2 (map string finite) (take 2 infinite)
+        let y2 = SeqT.run x2 |> extract |> toList
+        CollectionAssert.AreEqual (y2, [("0", 0); ("0", 1); ("1", 0); ("1", 1); ("2", 0); ("2", 1); ("3", 0); ("3", 1); ("4", 0); ("4", 1); ("5", 0); ("5", 1); ("6", 0); ("6", 1)])
 
     [<Test>]
     let zipLists2 () =
         let infinite: SeqT<Async<_>, _> = SeqT.unfold (fun x -> monad { return if x = 13 then failwith "Unlucky number" else (Some (x, x + 1) ) }) 0
         let finite:   SeqT<Async<_>, _> = SeqT.unfold (fun x -> monad { return if x = 7 then None else (Some (x, x + 1) ) }) 0
-        let x = zip (map string infinite) finite
-        let y = SeqT.run x |> extract |> toList
-        CollectionAssert.AreEqual (y, [("0", 0); ("1", 1); ("2", 2); ("3", 3); ("4", 4); ("5", 5); ("6", 6)])
+        let x1 = zip (map string infinite) finite
+        let y1 = SeqT.run x1 |> extract |> toList
+        CollectionAssert.AreEqual (y1, [("0", 0); ("1", 1); ("2", 2); ("3", 3); ("4", 4); ("5", 5); ("6", 6)])
         
+        let x2 = lift2 tuple2 (map string finite) (take 2 infinite)
+        let y2 = SeqT.run x2 |> extract |> toList
+        CollectionAssert.AreEqual (y2, [("0", 0); ("0", 1); ("1", 0); ("1", 1); ("2", 0); ("2", 1); ("3", 0); ("3", 1); ("4", 0); ("4", 1); ("5", 0); ("5", 1); ("6", 0); ("6", 1)])
+
     // Compile tests
     let binds () =
         let res1 = SeqT [|seq [1..4] |] >>= fun x -> SeqT [|seq [x * 2] |]


### PR DESCRIPTION
The previous implementation was not adding any effect besides binding strategy.
With this implementation we can derive both `asyncSeq` as `type AsyncSeq<'T> = SeqT<Async<bool>, 'T>` and `taskSeq` as `type TaskSeq<'T> = SeqT<Task<bool>, 'T>` among combinations with other monads like `type AsyncResultSeq<'T, 'Error> = SeqT<ResultT<Async<Result<bool, 'Error>>, 'T>` .

This adds the interfaces `IEnumeratorM<'Monad<bool>, 'T>` and `IEnumerableM<'Monad<bool>, 'T>` which would ideally be an alias of `SeqT<'Monad<bool>, 'T>` but since as of F# 6 we can't create static members in interfaces we will have to rely in composition instead.