### PR TITLE
Snapshot of signatures from build

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -7,6 +7,10 @@
     <Exec Command='dotnet build src/FSharpPlus -c Release --version-suffix "$(VersionSuffix)" ' WorkingDirectory="$(RepoRootDir)" IgnoreStandardErrorWarningFormat="true" />
   </Target>
 
+  <Target Name="AllSigs">
+    <Exec Command='dotnet msbuild src/FSharpPlus -target:Build -property:Configuration=Release -property:OtherFlags=--allsigs' WorkingDirectory="$(RepoRootDir)" IgnoreStandardErrorWarningFormat="true" />
+  </Target>
+
   <Target Name="Pack">
     <Exec Command='dotnet build src/FSharpPlus.TypeLevel/Providers -c Release --version-suffix "$(VersionSuffix)" ' WorkingDirectory="$(RepoRootDir)" IgnoreStandardErrorWarningFormat="true" />
     <Exec Command='dotnet pack src/FSharpPlus -c Release -o "$(NupkgsDir)" --version-suffix "$(VersionSuffix)" ' WorkingDirectory="$(RepoRootDir)" IgnoreStandardErrorWarningFormat="true" />

--- a/src/FSharpPlus/FSharpPlus.fsproj
+++ b/src/FSharpPlus/FSharpPlus.fsproj
@@ -14,8 +14,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <OtherFlags Condition=" '$(TargetFramework)' == 'netstandard2.0'">--warnon:1182 --warnon:3390 $(OtherFlags)</OtherFlags>
     <OtherFlags Condition=" '$(TargetFramework)' == 'net45'">--warnon:1182 --warnon:3390 $(OtherFlags)</OtherFlags>
-    <OtherFlags Condition=" '$(TargetFramework)' == 'netstandard2.0'">--warnon:1182 $(OtherFlags)</OtherFlags>
-    <OtherFlags Condition=" '$(TargetFramework)' == 'net45'">--warnon:1182 $(OtherFlags)</OtherFlags>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>


### PR DESCRIPTION
Add all signatures during build in order to be able to get a diff of the signature differences when refactoring the project. The fsi-files are not included in the build, so should not affect the output.

- [ ] document that fsi files are snapshot of build results rather than source files
- [ ] include fsi files in the docs build in order to be able to view the changes between releases
