### PR TITLE
net 7.0.200 for Fable

### DIFF
--- a/.github/workflows/fable.yml
+++ b/.github/workflows/fable.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Restore
       run: git submodule update --init --recursive
     - name: Remove global json
-       run: rm global.json
+      run: rm global.json
     - name: Setup .NET Core 7
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/fable.yml
+++ b/.github/workflows/fable.yml
@@ -15,14 +15,16 @@ jobs:
     - uses: actions/checkout@v2
     - name: Restore
       run: git submodule update --init --recursive
-    - name: Remove global json
-      run: rm global.json
+    - name: Setup .NET Core 7
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 7.0.200
     - name: Setup .NET Core 6
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 6.0.201
     - name: Restore tools
-      run: dotnet tool install --global Fable --version 3.7.20
+      run: dotnet tool restore 
     - name: Use Node.js
       uses: actions/setup-node@v1
       with:
@@ -32,7 +34,7 @@ jobs:
       run: npm install
     - name: Run Fable tests
       working-directory: tests/FSharpPlusFable.Tests
-      run: fable . --outDir bin --runScript ./bin 
+      run: dotnet fable . --outDir bin --runScript ./bin 
   
   testFable3SubsetOnCore:
     runs-on: ubuntu-latest

--- a/.github/workflows/fable.yml
+++ b/.github/workflows/fable.yml
@@ -15,6 +15,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Restore
       run: git submodule update --init --recursive
+    - name: Remove global json
+       run: rm global.json
     - name: Setup .NET Core 7
       uses: actions/setup-dotnet@v1
       with:
@@ -24,7 +26,9 @@ jobs:
       with:
         dotnet-version: 6.0.201
     - name: Restore tools
-      run: dotnet tool restore 
+      run: dotnet tool restore
+    - name: Install fable
+      run: dotnet tool install --global Fable --version 3.7.20
     - name: Use Node.js
       uses: actions/setup-node@v1
       with:
@@ -34,7 +38,7 @@ jobs:
       run: npm install
     - name: Run Fable tests
       working-directory: tests/FSharpPlusFable.Tests
-      run: dotnet fable . --outDir bin --runScript ./bin 
+      run: fable . --outDir bin --runScript ./bin
   
   testFable3SubsetOnCore:
     runs-on: ubuntu-latest
@@ -51,7 +55,7 @@ jobs:
     - name: Setup .NET Core 7
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 7.0.100
+        dotnet-version: 7.0.200
     - name: Setup .NET Core 6
       uses: actions/setup-dotnet@v1
       with:


### PR DESCRIPTION
Use fable with .net 7 installed.  
See https://github.com/fsprojects/FSharpPlus/pull/525 for why we did not upgrade to net7 for Fable CI