### PR TITLE
Option.bindError

### DIFF
--- a/src/FSharpPlus/Extensions/Option.fs
+++ b/src/FSharpPlus/Extensions/Option.fs
@@ -70,3 +70,12 @@ module Option =
         match pair with
         | (true,  x) -> Some x
         | (false, _) -> None
+
+    /// <summary>Runs a compensation function when the value is None</summary>
+    /// <remarks>Useful for reacting to failures and chaining fallbacks.</remarks>
+    /// <param name="compensation">The componesation function.</param>
+    /// <returns><c>Some</c> if the compensation succeeded or the source value was already `Some`, <c>None</c> if the source was `None` and the compensation failed.</returns>
+    let bindError compensation (source: option<'T>) =
+        match source with
+        | Some x -> Some x
+        | None -> compensation ()


### PR DESCRIPTION
I propose to add this function which would allow to attempt to recover from an error condition.
This is similar to our generic `catch`, or the non generic `Result.bindError` but taking always `()` as input.