### PR TITLE
Use strict monad in sample

### DIFF
--- a/src/FSharpPlus.Docs/Samples/Learn You a Haskell.fsx
+++ b/src/FSharpPlus.Docs/Samples/Learn You a Haskell.fsx
@@ -563,7 +563,7 @@ let loadedCoin = Prob [(Heads, 0.1); (Tails, 0.9)]                              
 // Prob [(false, 0.025); (false, 0.225); (false, 0.025); (false, 0.225);
 //       (false, 0.025); (false, 0.225); (false, 0.025); (true, 0.225)]
 let flipThree : Prob<bool> =
-    monad {
+    monad' {
         let! a = coin
         let! b = coin
         let! c = loadedCoin


### PR DESCRIPTION
There is a breaking change in the F# compiler which is now breaking our CI.

https://github.com/dotnet/fsharp/issues/15987

This will workaround that breaking change for the time being.