### PR TITLE
Add a function for creating a Task from a value

### DIFF
--- a/src/FSharpPlus/Extensions/Task.fs
+++ b/src/FSharpPlus/Extensions/Task.fs
@@ -285,6 +285,9 @@ module Task =
             (fun () -> body disp)
             (fun () -> if not (isNull (box disp)) then disp.Dispose ())
 
+    /// Creates a Task from a value
+    let ofValue value = Task.FromResult value
+    
     /// Raises an exception in the Task
     let raise (e: exn) =
         let tcs = TaskCompletionSource<'U> ()


### PR DESCRIPTION
We normally uses `Task.FromValue` but nowadays, using the `task` CE the namespace `System.Threading.Tasks` is not always opened and opening it only to return a task doesn't feel so good.

Sometimes what I do is I use `result` but in some places is too generic.

Another option is writing `task { return x }` but I think is overkill.

Given that we have our Task module in scope with many functions, maybe natural way is to add one there like `List.singleton` does.
