### PR TITLE
Use new [Option|ValueOption|Result|Choice].Sequence in Traverse

### DIFF
--- a/src/FSharpPlus/Control/Traversable.fs
+++ b/src/FSharpPlus/Control/Traversable.fs
@@ -11,11 +11,10 @@ open FSharpPlus.Internals.Prelude
 open FSharpPlus.Internals.MonadOps
 open FSharpPlus.Extensions
 
-
 type Sequence =
     inherit Default1
     static member inline InvokeOnInstance (t: '``Traversable<Functor<'T>>``) = (^``Traversable<Functor<'T>>`` : (static member Sequence : _ -> _) t) : '``Functor<'Traversable<'T>>``
-
+    
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline ForInfiniteSequences (t: seq<_>, isFailure, conversion) =
         let add x y = y :: x
@@ -26,7 +25,6 @@ type Sequence =
             if isFailure e.Current then go <- false
             r <- Map.Invoke add r <*> e.Current
         Map.Invoke (List.rev >> conversion) r
-    
 
 type Traverse =
     inherit Default1
@@ -187,12 +185,12 @@ type Sequence with
                         Seq.foldBack cons_f t (result Seq.empty)
 
     static member inline Sequence (t: seq<'``Applicative<'T>``>, [<Optional>]_output: '``Applicative<seq<'T>>``   , [<Optional>]_impl: Default4) = Sequence.ForInfiniteSequences (t, IsLeftZero.Invoke, List.toSeq)   : '``Applicative<seq<'T>>``
-    static member        Sequence (t: seq<option<'t>>   , [<Optional>]_output: option<seq<'t>>    , [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, Option.isNone, List.toSeq)                                : option<seq<'t>>
+    static member        Sequence (t: seq<option<'t>>   , [<Optional>]_output: option<seq<'t>>    , [<Optional>]_impl: Default3) = Option.Sequence t                                : option<seq<'t>>
     #if !FABLE_COMPILER
-    static member        Sequence (t: seq<voption<'t>>  , [<Optional>]_output: voption<seq<'t>>   , [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, ValueOption.isNone, List.toSeq)                           : voption<seq<'t>>
+    static member        Sequence (t: seq<voption<'t>>  , [<Optional>]_output: voption<seq<'t>>   , [<Optional>]_impl: Default3) = ValueOption.Sequence t                           : voption<seq<'t>>
     #endif
-    static member        Sequence (t: seq<Result<'t,'e>>, [<Optional>]_output: Result<seq<'t>, 'e>, [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, (function Error _      -> true | _ -> false), List.toSeq) : Result<seq<'t>, 'e>
-    static member        Sequence (t: seq<Choice<'t,'e>>, [<Optional>]_output: Choice<seq<'t>, 'e>, [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, (function Choice2Of2 _ -> true | _ -> false), List.toSeq) : Choice<seq<'t>, 'e>
+    static member        Sequence (t: seq<Result<'t,'e>>, [<Optional>]_output: Result<seq<'t>, 'e>, [<Optional>]_impl: Default3) = Result.Sequence t : Result<seq<'t>, 'e>
+    static member        Sequence (t: seq<Choice<'t,'e>>, [<Optional>]_output: Choice<seq<'t>, 'e>, [<Optional>]_impl: Default3) = Choice.Sequence t : Choice<seq<'t>, 'e>
     static member        Sequence (t: seq<list<'t>>     , [<Optional>]_output: list<seq<'t>>      , [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, List.isEmpty, List.toSeq)                                 : list<seq<'t>>
     static member        Sequence (t: seq<'t []>        , [<Optional>]_output: seq<'t> []         , [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, Array.isEmpty, List.toSeq)                                : seq<'t> []
 
@@ -200,9 +198,9 @@ type Sequence with
     static member        Sequence (t: seq<Async<'t>>    , [<Optional>]_output: Async<seq<'t>>     , [<Optional>]_impl: Default3) = Async.Sequence t                                                          : Async<seq<'t>>
     #endif
     static member inline Sequence (t: NonEmptySeq<'``Applicative<'T>``>, [<Optional>]_output: '``Applicative<NonEmptySeq<'T>>``   , [<Optional>]_impl: Default4) = Sequence.ForInfiniteSequences (t, IsLeftZero.Invoke, NonEmptySeq.ofList)   : '``Applicative<NonEmptySeq<'T>>``
-    static member        Sequence (t: NonEmptySeq<option<'t>>   , [<Optional>]_output: option<NonEmptySeq<'t>>    , [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, Option.isNone, NonEmptySeq.ofList)                                : option<NonEmptySeq<'t>>
-    static member        Sequence (t: NonEmptySeq<Result<'t,'e>>, [<Optional>]_output: Result<NonEmptySeq<'t>, 'e>, [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, (function Error _      -> true | _ -> false), NonEmptySeq.ofList) : Result<NonEmptySeq<'t>, 'e>
-    static member        Sequence (t: NonEmptySeq<Choice<'t,'e>>, [<Optional>]_output: Choice<NonEmptySeq<'t>, 'e>, [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, (function Choice2Of2 _ -> true | _ -> false), NonEmptySeq.ofList) : Choice<NonEmptySeq<'t>, 'e>
+    static member        Sequence (t: NonEmptySeq<option<'t>>   , [<Optional>]_output: option<NonEmptySeq<'t>>    , [<Optional>]_impl: Default3) = Option.Sequence t |> Option.map NonEmptySeq.unsafeOfSeq                                : option<NonEmptySeq<'t>>
+    static member        Sequence (t: NonEmptySeq<Result<'t,'e>>, [<Optional>]_output: Result<NonEmptySeq<'t>, 'e>, [<Optional>]_impl: Default3) = Result.Sequence t |> Result.map NonEmptySeq.unsafeOfSeq : Result<NonEmptySeq<'t>, 'e>
+    static member        Sequence (t: NonEmptySeq<Choice<'t,'e>>, [<Optional>]_output: Choice<NonEmptySeq<'t>, 'e>, [<Optional>]_impl: Default3) = Choice.Sequence t |> Choice.map NonEmptySeq.unsafeOfSeq : Choice<NonEmptySeq<'t>, 'e>
     static member        Sequence (t: NonEmptySeq<list<'t>>     , [<Optional>]_output: list<NonEmptySeq<'t>>      , [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, List.isEmpty, NonEmptySeq.ofList)                                 : list<NonEmptySeq<'t>>
     static member        Sequence (t: NonEmptySeq<'t []>        , [<Optional>]_output: NonEmptySeq<'t> []         , [<Optional>]_impl: Default3) = Sequence.ForInfiniteSequences(t, Array.isEmpty, NonEmptySeq.ofList)                                : NonEmptySeq<'t> []
     #if !FABLE_COMPILER

--- a/src/FSharpPlus/Extensions/Extensions.fs
+++ b/src/FSharpPlus/Extensions/Extensions.fs
@@ -140,7 +140,7 @@ module Extensions =
             let mutable accumulator = ArrayCollector<'t> ()
             let mutable noneFound = false
             use e = t.GetEnumerator ()
-            while e.MoveNext () && noneFound do
+            while e.MoveNext () && not noneFound do
                 match e.Current with
                 | Some v -> accumulator.Add v
                 | None -> noneFound <-  true
@@ -168,7 +168,7 @@ module Extensions =
             let mutable accumulator = ArrayCollector<'t> ()
             let mutable noneFound = false
             use e = t.GetEnumerator ()
-            while e.MoveNext () && noneFound do
+            while e.MoveNext () && not noneFound do
                 match e.Current with
                 | ValueSome v -> accumulator.Add v
                 | ValueNone -> noneFound <-  true


### PR DESCRIPTION
Use specific `Sequence` for equal `Traverse` instead of the generic one.
Fix issue in `ValueOption.Sequence` and `Option.Sequence`