### PR TITLE
Remove subsumption from Applicatives

### DIFF
--- a/src/FSharpPlus/Control/Applicative.fs
+++ b/src/FSharpPlus/Control/Applicative.fs
@@ -37,6 +37,12 @@ type Apply =
     static member        ``<*>`` ((f: Result<_,'E>     , x: Result<'T,'E>        , _output: Result<'b,'E>       ) , [<Optional>]_mthd: Apply) = Result.apply f x : Result<'U,'E>
     static member        ``<*>`` ((f: Choice<_,'E>     , x: Choice<'T,'E>        , _output: Choice<'b,'E>       ) , [<Optional>]_mthd: Apply) = Choice.apply f x : Choice<'U,'E>
     static member inline ``<*>`` ((KeyValue(a: 'Key, f), KeyValue(b: 'Key, x: 'T), _output: KeyValuePair<'Key,'U>), [<Optional>]_mthd: Apply) : KeyValuePair<'Key,'U> = KeyValuePair (Plus.Invoke a b, f x)
+    static member inline ``<*>`` ((f: KeyValuePair2<'Key, _>, x: KeyValuePair2<'Key, 'T>, _output: KeyValuePair2<'Key,'U>), [<Optional>]_mthd: Apply) : KeyValuePair2<'Key,'U> =
+        let a = f.Key
+        let b = x.Key
+        let f = f.Value
+        let x = x.Value
+        KeyValuePair2 (Plus.Invoke a b, f x)
 
     static member        ``<*>`` ((f: Map<'Key,_>      , x: Map<'Key,'T>         , _output: Map<'Key,'U>        ) , [<Optional>]_mthd: Apply) : Map<'Key,'U> = Map (seq {
        for KeyValue(k, vf) in f do

--- a/src/FSharpPlus/Control/Applicative.fs
+++ b/src/FSharpPlus/Control/Applicative.fs
@@ -37,7 +37,12 @@ type Apply =
     static member        ``<*>`` ((f: Result<_,'E>     , x: Result<'T,'E>        ), _output: Result<'b,'E>        , [<Optional>]_mthd: Apply) = Result.apply f x : Result<'U,'E>
     static member        ``<*>`` ((f: Choice<_,'E>     , x: Choice<'T,'E>        ), _output: Choice<'b,'E>        , [<Optional>]_mthd: Apply) = Choice.apply f x : Choice<'U,'E>
     static member inline ``<*>`` ((KeyValue(a: 'Key, f), KeyValue(b: 'Key, x: 'T)), _output: KeyValuePair<'Key,'U>, [<Optional>]_mthd: Default3) : KeyValuePair<'Key,'U> = KeyValuePair (Plus.Invoke a b, f x)
-    static member inline ``<*>`` ((_: DmStruct2<'Key, _>, _: DmStruct2<'Key, 'T>) , _output: DmStruct2<'Key,'U>   , [<Optional>]_mthd: Default3) : DmStruct2<'Key,'U> = Unchecked.defaultof<DmStruct2<'Key,'U>>
+    static member inline ``<*>`` ((f: KeyValuePair2<'Key, _>, x: KeyValuePair2<'Key, 'T>), _output: KeyValuePair2<'Key,'U>, [<Optional>]_mthd: Default3) : KeyValuePair2<'Key,'U> =
+        let a = f.Key
+        let b = x.Key
+        let f = f.Value
+        let x = x.Value
+        KeyValuePair2 (Plus.Invoke a b, f x)
 
     static member        ``<*>`` ((f: Map<'Key,_>      , x: Map<'Key,'T>        ) , _output: Map<'Key,'U>         , [<Optional>]_mthd: Apply) : Map<'Key,'U> = Map (seq {
        for KeyValue(k, vf) in f do
@@ -60,7 +65,7 @@ type Apply =
            | true, vx -> dct.Add (k, vf vx)
            | _        -> ()
        dct :> IDictionary<'Key,'U>
-
+    
     static member        ``<*>`` ((f: IReadOnlyDictionary<'Key,_>, x: IReadOnlyDictionary<'Key,'T>) , _output: IReadOnlyDictionary<'Key,'U>  , [<Optional>]_mthd: Apply) : IReadOnlyDictionary<'Key,'U> =
        let dct = Dictionary ()
        for KeyValue(k, vf) in f do
@@ -73,7 +78,7 @@ type Apply =
     static member        ``<*>`` ((f: Expr<'T->'U>, x: Expr<'T>), _output: Expr<'U>, [<Optional>]_mthd: Apply) = Expr.Cast<'U> (Expr.Application (f, x))
     #endif
     static member        ``<*>`` ((f: ('T->'U) ResizeArray, x: 'T ResizeArray), _output: 'U ResizeArray, [<Optional>]_mthd: Apply) = ResizeArray.apply f x : 'U ResizeArray
-
+    
     static member inline Invoke (f: '``Applicative<'T -> 'U>``) (x: '``Applicative<'T>``) : '``Applicative<'U>`` =
         let inline call (mthd : ^M, input1: ^I1, input2: ^I2, output: ^R) =
             ((^M or ^I1 or ^I2 or ^R) : (static member ``<*>`` : (_*_)*_*_ -> _) (input1, input2), output, mthd)

--- a/src/FSharpPlus/Control/Applicative.fs
+++ b/src/FSharpPlus/Control/Applicative.fs
@@ -37,11 +37,9 @@ type Apply =
     static member        ``<*>`` (struct (f: Result<_,'E>     , x: Result<'T,'E>        ), _output: Result<'b,'E>        , [<Optional>]_mthd: Apply) = Result.apply f x : Result<'U,'E>
     static member        ``<*>`` (struct (f: Choice<_,'E>     , x: Choice<'T,'E>        ), _output: Choice<'b,'E>        , [<Optional>]_mthd: Apply) = Choice.apply f x : Choice<'U,'E>
     static member inline ``<*>`` (struct (KeyValue(a: 'Key, f), KeyValue(b: 'Key, x: 'T)), _output: KeyValuePair<'Key,'U>, [<Optional>]_mthd: Default3) : KeyValuePair<'Key,'U> = KeyValuePair (Plus.Invoke a b, f x)
-    static member inline ``<*>`` (struct (f: KeyValuePair2<'Key, _>, x: KeyValuePair2<'Key, 'T>), _output: KeyValuePair2<'Key,'U>, [<Optional>]_mthd: Default3) : KeyValuePair2<'Key,'U> =
-        let a = f.Key
-        let b = x.Key
-        let f = f.Value
-        let x = x.Value
+    static member inline ``<*>`` (struct (f: KeyValuePair2<_,_>, x: KeyValuePair2<_,'T> ), _output: KeyValuePair2<_,'U>  , [<Optional>]_mthd: Default3) : KeyValuePair2<'Key,'U> =
+        let a, b = f.Key, x.Key
+        let f, x = f.Value, x.Value
         KeyValuePair2 (Plus.Invoke a b, f x)
 
     static member        ``<*>`` (struct (f: Map<'Key,_>      , x: Map<'Key,'T>        ) , _output: Map<'Key,'U>         , [<Optional>]_mthd: Apply) : Map<'Key,'U> = Map (seq {
@@ -65,7 +63,7 @@ type Apply =
            | true, vx -> dct.Add (k, vf vx)
            | _        -> ()
        dct :> IDictionary<'Key,'U>
-    
+
     static member        ``<*>`` (struct (f: IReadOnlyDictionary<'Key,_>, x: IReadOnlyDictionary<'Key,'T>) , _output: IReadOnlyDictionary<'Key,'U>  , [<Optional>]_mthd: Apply) : IReadOnlyDictionary<'Key,'U> =
        let dct = Dictionary ()
        for KeyValue(k, vf) in f do
@@ -78,7 +76,7 @@ type Apply =
     static member        ``<*>`` (struct (f: Expr<'T->'U>, x: Expr<'T>), _output: Expr<'U>, [<Optional>]_mthd: Apply) = Expr.Cast<'U> (Expr.Application (f, x))
     #endif
     static member        ``<*>`` (struct (f: ('T->'U) ResizeArray, x: 'T ResizeArray), _output: 'U ResizeArray, [<Optional>]_mthd: Apply) = ResizeArray.apply f x : 'U ResizeArray
-    
+
     static member inline Invoke (f: '``Applicative<'T -> 'U>``) (x: '``Applicative<'T>``) : '``Applicative<'U>`` =
         let inline call (mthd : ^M, input1: ^I1, input2: ^I2, output: ^R) =
             ((^M or ^I1 or ^I2 or ^R) : (static member ``<*>`` : struct (_*_) * _ * _ -> _) (struct (input1, input2)), output, mthd)

--- a/src/FSharpPlus/Control/Applicative.fs
+++ b/src/FSharpPlus/Control/Applicative.fs
@@ -29,15 +29,15 @@ type Apply =
     static member        ``<*>`` (struct (f: Task<_>          , x: Task<'T>             ), _output: Task<'U>             , [<Optional>]_mthd: Apply) = Task.apply   f x : Task<'U>
     #endif
     #if !NET45 && !NETSTANDARD2_0 && !FABLE_COMPILER
-    static member        ``<*>`` (struct (f: ValueTask<_>     , x: ValueTask<'T>        ), _output: ValueTask<'U>        , [<Optional>]_mthd: Default3) = ValueTask.apply   f x : ValueTask<'U>
+    static member        ``<*>`` (struct (f: ValueTask<_>     , x: ValueTask<'T>        ), _output: ValueTask<'U>        , [<Optional>]_mthd: Default2) = ValueTask.apply   f x : ValueTask<'U>
     #endif
     static member        ``<*>`` (struct (f: Async<_>         , x: Async<'T>            ), _output: Async<'U>            , [<Optional>]_mthd: Apply) = Async.apply  f x : Async<'U>
     static member        ``<*>`` (struct (f: option<_>        , x: option<'T>           ), _output: option<'U>           , [<Optional>]_mthd: Apply) = Option.apply f x : option<'U>
     static member        ``<*>`` (struct (f: voption<_>       , x: voption<'T>          ), _output: voption<'U>          , [<Optional>]_mthd: Apply) = ValueOption.apply f x : voption<'U>
     static member        ``<*>`` (struct (f: Result<_,'E>     , x: Result<'T,'E>        ), _output: Result<'b,'E>        , [<Optional>]_mthd: Apply) = Result.apply f x : Result<'U,'E>
     static member        ``<*>`` (struct (f: Choice<_,'E>     , x: Choice<'T,'E>        ), _output: Choice<'b,'E>        , [<Optional>]_mthd: Apply) = Choice.apply f x : Choice<'U,'E>
-    static member inline ``<*>`` (struct (KeyValue(a: 'Key, f), KeyValue(b: 'Key, x: 'T)), _output: KeyValuePair<'Key,'U>, [<Optional>]_mthd: Default3) : KeyValuePair<'Key,'U> = KeyValuePair (Plus.Invoke a b, f x)
-    static member inline ``<*>`` (struct (f: KeyValuePair2<_,_>, x: KeyValuePair2<_,'T> ), _output: KeyValuePair2<_,'U>  , [<Optional>]_mthd: Default3) : KeyValuePair2<'Key,'U> =
+    static member inline ``<*>`` (struct (KeyValue(a: 'Key, f), KeyValue(b: 'Key, x: 'T)), _output: KeyValuePair<'Key,'U>, [<Optional>]_mthd: Default2) : KeyValuePair<'Key,'U> = KeyValuePair (Plus.Invoke a b, f x)
+    static member inline ``<*>`` (struct (f: KeyValuePair2<_,_>, x: KeyValuePair2<_,'T> ), _output: KeyValuePair2<_,'U>  , [<Optional>]_mthd: Default2) : KeyValuePair2<'Key,'U> =
         let a, b = f.Key, x.Key
         let f, x = f.Value, x.Value
         KeyValuePair2 (Plus.Invoke a b, f x)
@@ -90,7 +90,7 @@ type Apply =
 #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
 
 type Apply with
-    static member inline ``<*>`` (struct (f: '``Monad<'T->'U>``      , x: '``Monad<'T>``     ) , _output: '``Monad<'U>``      , [<Optional>]_mthd:Default3) : '``Monad<'U>``       = Bind.InvokeOnInstance f (fun (x1: 'T->'U) -> Bind.InvokeOnInstance x (fun x2 -> Return.InvokeOnInstance (x1 x2)))
+    static member inline ``<*>`` (struct (f: '``Monad<'T->'U>``      , x: '``Monad<'T>``     ) , _output: '``Monad<'U>``      , [<Optional>]_mthd:Default2) : '``Monad<'U>``       = Bind.InvokeOnInstance f (fun (x1: 'T->'U) -> Bind.InvokeOnInstance x (fun x2 -> Return.InvokeOnInstance (x1 x2)))
     static member inline ``<*>`` (struct (_: ^t when ^t : null and ^t: struct, _: ^u when ^u : null and ^u: struct), _output: ^r when ^r : null and ^r: struct, _mthd: Default1) = id
     
     static member inline ``<*>`` (struct (f: '``Applicative<'T->'U>``, x: '``Applicative<'T>``), _output: '``Applicative<'U>``, [<Optional>]_mthd: Default1) : '``Applicative<'U>`` = ((^``Applicative<'T->'U>`` or ^``Applicative<'T>`` or ^``Applicative<'U>``) : (static member (<*>) : _*_ -> _) f, x)

--- a/src/FSharpPlus/Control/Applicative.fs
+++ b/src/FSharpPlus/Control/Applicative.fs
@@ -29,15 +29,15 @@ type Apply =
     static member        ``<*>`` ((f: Task<_>          , x: Task<'T>             ), _output: Task<'U>             , [<Optional>]_mthd: Apply) = Task.apply   f x : Task<'U>
     #endif
     #if !NET45 && !NETSTANDARD2_0 && !FABLE_COMPILER
-    static member        ``<*>`` ((f: ValueTask<_>     , x: ValueTask<'T>        ), _output: ValueTask<'U>        , [<Optional>]_mthd: Apply) = ValueTask.apply   f x : ValueTask<'U>
+    static member        ``<*>`` ((f: ValueTask<_>     , x: ValueTask<'T>        ), _output: ValueTask<'U>        , [<Optional>]_mthd: Default1) = ValueTask.apply   f x : ValueTask<'U>
     #endif
     static member        ``<*>`` ((f: Async<_>         , x: Async<'T>            ), _output: Async<'U>            , [<Optional>]_mthd: Apply) = Async.apply  f x : Async<'U>
     static member        ``<*>`` ((f: option<_>        , x: option<'T>           ), _output: option<'U>           , [<Optional>]_mthd: Apply) = Option.apply f x : option<'U>
     static member        ``<*>`` ((f: voption<_>       , x: voption<'T>          ), _output: voption<'U>          , [<Optional>]_mthd: Apply) = ValueOption.apply f x : voption<'U>
     static member        ``<*>`` ((f: Result<_,'E>     , x: Result<'T,'E>        ), _output: Result<'b,'E>        , [<Optional>]_mthd: Apply) = Result.apply f x : Result<'U,'E>
     static member        ``<*>`` ((f: Choice<_,'E>     , x: Choice<'T,'E>        ), _output: Choice<'b,'E>        , [<Optional>]_mthd: Apply) = Choice.apply f x : Choice<'U,'E>
-    static member inline ``<*>`` ((KeyValue(a: 'Key, f), KeyValue(b: 'Key, x: 'T)), _output: KeyValuePair<'Key,'U>, [<Optional>]_mthd: Apply) : KeyValuePair<'Key,'U> = KeyValuePair (Plus.Invoke a b, f x)
-    static member inline ``<*>`` ((f: KeyValuePair2<'Key, _>, x: KeyValuePair2<'Key, 'T>), _output: KeyValuePair2<'Key,'U>, [<Optional>]_mthd: Apply) : KeyValuePair2<'Key,'U> =
+    static member inline ``<*>`` ((KeyValue(a: 'Key, f), KeyValue(b: 'Key, x: 'T)), _output: KeyValuePair<'Key,'U>, [<Optional>]_mthd: Default1) : KeyValuePair<'Key,'U> = KeyValuePair (Plus.Invoke a b, f x)
+    static member inline ``<*>`` ((f: KeyValuePair2<'Key, _>, x: KeyValuePair2<'Key, 'T>), _output: KeyValuePair2<'Key,'U>, [<Optional>]_mthd: Default1) : KeyValuePair2<'Key,'U> =
         let a = f.Key
         let b = x.Key
         let f = f.Value

--- a/src/FSharpPlus/Control/Applicative.fs
+++ b/src/FSharpPlus/Control/Applicative.fs
@@ -13,44 +13,44 @@ open FSharpPlus.Data
 
 type Apply =
     inherit Default1
- 
+
 #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
 
-    static member        ``<*>`` ((f: Lazy<'T->'U>     , x: Lazy<'T>             , _output: Lazy<'U>            ) , [<Optional>]_mthd: Apply) = Lazy.apply f x                               : Lazy<'U>
-    static member        ``<*>`` ((f: seq<_>           , x: seq<'T>              , _output: seq<'U>             ) , [<Optional>]_mthd: Apply) = Seq.apply  f x                               : seq<'U>
-    static member        ``<*>`` ((f: NonEmptySeq<_>   , x: NonEmptySeq<'T>      , _output: NonEmptySeq<'U>     ) , [<Optional>]_mthd: Apply) = NonEmptySeq.apply  f x                       : NonEmptySeq<'U>
-    static member        ``<*>`` ((f: IEnumerator<_>   , x: IEnumerator<'T>      , _output: IEnumerator<'U>     ) , [<Optional>]_mthd: Apply) = Enumerator.map2 id f x : IEnumerator<'U>
-    static member        ``<*>`` ((f: list<_>          , x: list<'T>             , _output: list<'U>            ) , [<Optional>]_mthd: Apply) = List.apply f x                               : list<'U>
-    static member        ``<*>`` ((f: _ []             , x: 'T []                , _output: 'U []               ) , [<Optional>]_mthd: Apply) = Array.apply f x                              : 'U []
-    static member        ``<*>`` ((f: 'r -> _          , g: _ -> 'T              , _output:  'r -> 'U           ) , [<Optional>]_mthd: Apply) = fun x -> let f' = f x in f' (g x)            : 'U
-    static member inline ``<*>`` (((a: 'Monoid, f)     , (b: 'Monoid, x: 'T)     , _output: 'Monoid * 'U        ) , [<Optional>]_mthd: Apply) = (Plus.Invoke a b, f x)                       : 'Monoid *'U
-    static member inline ``<*>`` ((struct (a: 'Monoid, f), struct (b: 'Monoid, x: 'T), _output: struct ('Monoid * 'U)), [<Optional>]_mthd: Apply) = struct (Plus.Invoke a b, f x)            : struct ('Monoid * 'U)
+    static member        ``<*>`` ((f: Lazy<'T->'U>     , x: Lazy<'T>           )  , _output: Lazy<'U>             , [<Optional>]_mthd: Apply) = Lazy.apply f x                               : Lazy<'U>
+    static member        ``<*>`` ((f: seq<_>           , x: seq<'T>            )  , _output: seq<'U>              , [<Optional>]_mthd: Apply) = Seq.apply  f x                               : seq<'U>
+    static member        ``<*>`` ((f: NonEmptySeq<_>   , x: NonEmptySeq<'T>    )  , _output: NonEmptySeq<'U>      , [<Optional>]_mthd: Apply) = NonEmptySeq.apply  f x                       : NonEmptySeq<'U>
+    static member        ``<*>`` ((f: IEnumerator<_>   , x: IEnumerator<'T>    )  , _output: IEnumerator<'U>      , [<Optional>]_mthd: Apply) = Enumerator.map2 id f x : IEnumerator<'U>
+    static member        ``<*>`` ((f: list<_>          , x: list<'T>           )  , _output: list<'U>             , [<Optional>]_mthd: Apply) = List.apply f x                               : list<'U>
+    static member        ``<*>`` ((f: _ []             , x: 'T []              )  , _output: 'U []                , [<Optional>]_mthd: Apply) = Array.apply f x                              : 'U []
+    static member        ``<*>`` ((f: 'r -> _          , g: _ -> 'T            )  , _output:  'r -> 'U            , [<Optional>]_mthd: Apply) = fun x -> let f' = f x in f' (g x)            : 'U
+    static member inline ``<*>`` (((a: 'Monoid, f)     , (b: 'Monoid, x: 'T)   )  , _output: 'Monoid * 'U         , [<Optional>]_mthd: Apply) = (Plus.Invoke a b, f x)                       : 'Monoid *'U
+    static member inline ``<*>`` ((struct (a: 'Monoid, f), struct (b: 'Monoid, x: 'T)), _output: struct ('Monoid * 'U), [<Optional>]_mthd: Apply) = struct (Plus.Invoke a b, f x)            : struct ('Monoid * 'U)
     #if !FABLE_COMPILER
-    static member        ``<*>`` ((f: Task<_>          , x: Task<'T>             , _output: Task<'U>            ) , [<Optional>]_mthd: Apply) = Task.apply   f x : Task<'U>
+    static member        ``<*>`` ((f: Task<_>          , x: Task<'T>             ), _output: Task<'U>             , [<Optional>]_mthd: Apply) = Task.apply   f x : Task<'U>
     #endif
     #if !NET45 && !NETSTANDARD2_0 && !FABLE_COMPILER
-    static member        ``<*>`` ((f: ValueTask<_>     , x: ValueTask<'T>        , _output: ValueTask<'U>       ) , [<Optional>]_mthd: Apply) = ValueTask.apply   f x : ValueTask<'U>
+    static member        ``<*>`` ((f: ValueTask<_>     , x: ValueTask<'T>        ), _output: ValueTask<'U>        , [<Optional>]_mthd: Apply) = ValueTask.apply   f x : ValueTask<'U>
     #endif
-    static member        ``<*>`` ((f: Async<_>         , x: Async<'T>            , _output: Async<'U>           ) , [<Optional>]_mthd: Apply) = Async.apply  f x : Async<'U>
-    static member        ``<*>`` ((f: option<_>        , x: option<'T>           , _output: option<'U>          ) , [<Optional>]_mthd: Apply) = Option.apply f x : option<'U>
-    static member        ``<*>`` ((f: voption<_>       , x: voption<'T>          , _output: voption<'U>         ) , [<Optional>]_mthd: Apply) = ValueOption.apply f x : voption<'U>
-    static member        ``<*>`` ((f: Result<_,'E>     , x: Result<'T,'E>        , _output: Result<'b,'E>       ) , [<Optional>]_mthd: Apply) = Result.apply f x : Result<'U,'E>
-    static member        ``<*>`` ((f: Choice<_,'E>     , x: Choice<'T,'E>        , _output: Choice<'b,'E>       ) , [<Optional>]_mthd: Apply) = Choice.apply f x : Choice<'U,'E>
-    static member inline ``<*>`` ((KeyValue(a: 'Key, f), KeyValue(b: 'Key, x: 'T), _output: KeyValuePair<'Key,'U>), [<Optional>]_mthd: Apply) : KeyValuePair<'Key,'U> = KeyValuePair (Plus.Invoke a b, f x)
-    static member inline ``<*>`` ((f: KeyValuePair2<'Key, _>, x: KeyValuePair2<'Key, 'T>, _output: KeyValuePair2<'Key,'U>), [<Optional>]_mthd: Apply) : KeyValuePair2<'Key,'U> =
+    static member        ``<*>`` ((f: Async<_>         , x: Async<'T>            ), _output: Async<'U>            , [<Optional>]_mthd: Apply) = Async.apply  f x : Async<'U>
+    static member        ``<*>`` ((f: option<_>        , x: option<'T>           ), _output: option<'U>           , [<Optional>]_mthd: Apply) = Option.apply f x : option<'U>
+    static member        ``<*>`` ((f: voption<_>       , x: voption<'T>          ), _output: voption<'U>          , [<Optional>]_mthd: Apply) = ValueOption.apply f x : voption<'U>
+    static member        ``<*>`` ((f: Result<_,'E>     , x: Result<'T,'E>        ), _output: Result<'b,'E>        , [<Optional>]_mthd: Apply) = Result.apply f x : Result<'U,'E>
+    static member        ``<*>`` ((f: Choice<_,'E>     , x: Choice<'T,'E>        ), _output: Choice<'b,'E>        , [<Optional>]_mthd: Apply) = Choice.apply f x : Choice<'U,'E>
+    static member inline ``<*>`` ((KeyValue(a: 'Key, f), KeyValue(b: 'Key, x: 'T)), _output: KeyValuePair<'Key,'U>, [<Optional>]_mthd: Apply) : KeyValuePair<'Key,'U> = KeyValuePair (Plus.Invoke a b, f x)
+    static member inline ``<*>`` ((f: KeyValuePair2<'Key, _>, x: KeyValuePair2<'Key, 'T>), _output: KeyValuePair2<'Key,'U>, [<Optional>]_mthd: Apply) : KeyValuePair2<'Key,'U> =
         let a = f.Key
         let b = x.Key
         let f = f.Value
         let x = x.Value
         KeyValuePair2 (Plus.Invoke a b, f x)
 
-    static member        ``<*>`` ((f: Map<'Key,_>      , x: Map<'Key,'T>         , _output: Map<'Key,'U>        ) , [<Optional>]_mthd: Apply) : Map<'Key,'U> = Map (seq {
+    static member        ``<*>`` ((f: Map<'Key,_>      , x: Map<'Key,'T>        ) , _output: Map<'Key,'U>         , [<Optional>]_mthd: Apply) : Map<'Key,'U> = Map (seq {
        for KeyValue(k, vf) in f do
            match Map.tryFind k x with
            | Some vx -> yield k, vf vx
            | _       -> () })
 
-    static member        ``<*>`` ((f: Dictionary<'Key,_>, x: Dictionary<'Key,'T> , _output: Dictionary<'Key,'U> ) , [<Optional>]_mthd: Apply) : Dictionary<'Key,'U> =
+    static member        ``<*>`` ((f: Dictionary<'Key,_>, x: Dictionary<'Key,'T>) , _output: Dictionary<'Key,'U>  , [<Optional>]_mthd: Apply) : Dictionary<'Key,'U> =
        let dct = Dictionary ()
        for KeyValue(k, vf) in f do
            match x.TryGetValue k with
@@ -58,7 +58,7 @@ type Apply =
            | _        -> ()
        dct
 
-    static member        ``<*>`` ((f: IDictionary<'Key,_>, x: IDictionary<'Key,'T> , _output: IDictionary<'Key,'U> ) , [<Optional>]_mthd: Apply) : IDictionary<'Key,'U> =
+    static member        ``<*>`` ((f: IDictionary<'Key,_>, x: IDictionary<'Key,'T>) , _output: IDictionary<'Key,'U>  , [<Optional>]_mthd: Apply) : IDictionary<'Key,'U> =
        let dct = Dictionary ()
        for KeyValue(k, vf) in f do
            match x.TryGetValue k with
@@ -66,7 +66,7 @@ type Apply =
            | _        -> ()
        dct :> IDictionary<'Key,'U>
 
-    static member        ``<*>`` ((f: IReadOnlyDictionary<'Key,_>, x: IReadOnlyDictionary<'Key,'T> , _output: IReadOnlyDictionary<'Key,'U> ) , [<Optional>]_mthd: Apply) : IReadOnlyDictionary<'Key,'U> =
+    static member        ``<*>`` ((f: IReadOnlyDictionary<'Key,_>, x: IReadOnlyDictionary<'Key,'T>) , _output: IReadOnlyDictionary<'Key,'U>  , [<Optional>]_mthd: Apply) : IReadOnlyDictionary<'Key,'U> =
        let dct = Dictionary ()
        for KeyValue(k, vf) in f do
            match x.TryGetValue k with
@@ -75,13 +75,13 @@ type Apply =
        dct :> IReadOnlyDictionary<'Key,'U>
 
     #if !FABLE_COMPILER
-    static member        ``<*>`` ((f: Expr<'T->'U>, x: Expr<'T>, _output: Expr<'U>), [<Optional>]_mthd: Apply) = Expr.Cast<'U> (Expr.Application (f, x))
+    static member        ``<*>`` ((f: Expr<'T->'U>, x: Expr<'T>), _output: Expr<'U>, [<Optional>]_mthd: Apply) = Expr.Cast<'U> (Expr.Application (f, x))
     #endif
-    static member        ``<*>`` ((f: ('T->'U) ResizeArray, x: 'T ResizeArray, _output: 'U ResizeArray), [<Optional>]_mthd: Apply) = ResizeArray.apply f x : 'U ResizeArray
+    static member        ``<*>`` ((f: ('T->'U) ResizeArray, x: 'T ResizeArray), _output: 'U ResizeArray, [<Optional>]_mthd: Apply) = ResizeArray.apply f x : 'U ResizeArray
 
     static member inline Invoke (f: '``Applicative<'T -> 'U>``) (x: '``Applicative<'T>``) : '``Applicative<'U>`` =
         let inline call (mthd : ^M, input1: ^I1, input2: ^I2, output: ^R) =
-            ((^M or ^I1 or ^I2 or ^R) : (static member ``<*>`` : (_*_*_)*_ -> _) (input1, input2, output), mthd)
+            ((^M or ^I1 or ^I2 or ^R) : (static member ``<*>`` : (_*_)*_*_ -> _) (input1, input2), output, mthd)
         call(Unchecked.defaultof<Apply>, f, x, Unchecked.defaultof<'``Applicative<'U>``>)
 
 
@@ -93,9 +93,10 @@ type Apply =
 #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
 
 type Apply with
-    static member inline ``<*>`` ((f: '``Monad<'T->'U>``      , x: '``Monad<'T>``      , _output: '``Monad<'U>``      ), [<Optional>]_mthd:Default2) : '``Monad<'U>``       = Bind.InvokeOnInstance f (fun (x1: 'T->'U) -> Bind.InvokeOnInstance x (fun x2 -> Return.InvokeOnInstance (x1 x2)))
-    static member inline ``<*>`` ((_: ^t when ^t : null and ^t: struct, _: ^u when ^u : null and ^u: struct, _output: ^r when ^r : null and ^r: struct), _mthd: Default1) = id
-    static member inline ``<*>`` ((f: '``Applicative<'T->'U>``, x: '``Applicative<'T>``, _output: '``Applicative<'U>``), [<Optional>]_mthd:Default1) : '``Applicative<'U>`` = ((^``Applicative<'T->'U>`` or ^``Applicative<'T>`` or ^``Applicative<'U>``) : (static member (<*>) : _*_ -> _) f, x)
+    static member inline ``<*>`` ((f: '``Monad<'T->'U>``      , x: '``Monad<'T>``     ) , _output: '``Monad<'U>``      , [<Optional>]_mthd:Default2) : '``Monad<'U>``       = Bind.InvokeOnInstance f (fun (x1: 'T->'U) -> Bind.InvokeOnInstance x (fun x2 -> Return.InvokeOnInstance (x1 x2)))
+    static member inline ``<*>`` ((_: ^t when ^t : null and ^t: struct, _: ^u when ^u : null and ^u: struct), _output: ^r when ^r : null and ^r: struct, _mthd: Default1) = id
+    
+    static member inline ``<*>`` ((f: '``Applicative<'T->'U>``, x: '``Applicative<'T>``), _output: '``Applicative<'U>``, [<Optional>]_mthd: Default1) : '``Applicative<'U>`` = ((^``Applicative<'T->'U>`` or ^``Applicative<'T>`` or ^``Applicative<'U>``) : (static member (<*>) : _*_ -> _) f, x)
 
 
 type Lift2 =

--- a/src/FSharpPlus/Control/Applicative.fs
+++ b/src/FSharpPlus/Control/Applicative.fs
@@ -29,15 +29,15 @@ type Apply =
     static member        ``<*>`` ((f: Task<_>          , x: Task<'T>             ), _output: Task<'U>             , [<Optional>]_mthd: Apply) = Task.apply   f x : Task<'U>
     #endif
     #if !NET45 && !NETSTANDARD2_0 && !FABLE_COMPILER
-    static member        ``<*>`` ((f: ValueTask<_>     , x: ValueTask<'T>        ), _output: ValueTask<'U>        , [<Optional>]_mthd: Default1) = ValueTask.apply   f x : ValueTask<'U>
+    static member        ``<*>`` ((f: ValueTask<_>     , x: ValueTask<'T>        ), _output: ValueTask<'U>        , [<Optional>]_mthd: Default3) = ValueTask.apply   f x : ValueTask<'U>
     #endif
     static member        ``<*>`` ((f: Async<_>         , x: Async<'T>            ), _output: Async<'U>            , [<Optional>]_mthd: Apply) = Async.apply  f x : Async<'U>
     static member        ``<*>`` ((f: option<_>        , x: option<'T>           ), _output: option<'U>           , [<Optional>]_mthd: Apply) = Option.apply f x : option<'U>
     static member        ``<*>`` ((f: voption<_>       , x: voption<'T>          ), _output: voption<'U>          , [<Optional>]_mthd: Apply) = ValueOption.apply f x : voption<'U>
     static member        ``<*>`` ((f: Result<_,'E>     , x: Result<'T,'E>        ), _output: Result<'b,'E>        , [<Optional>]_mthd: Apply) = Result.apply f x : Result<'U,'E>
     static member        ``<*>`` ((f: Choice<_,'E>     , x: Choice<'T,'E>        ), _output: Choice<'b,'E>        , [<Optional>]_mthd: Apply) = Choice.apply f x : Choice<'U,'E>
-    static member inline ``<*>`` ((KeyValue(a: 'Key, f), KeyValue(b: 'Key, x: 'T)), _output: KeyValuePair<'Key,'U>, [<Optional>]_mthd: Default1) : KeyValuePair<'Key,'U> = KeyValuePair (Plus.Invoke a b, f x)
-    static member inline ``<*>`` ((f: KeyValuePair2<'Key, _>, x: KeyValuePair2<'Key, 'T>), _output: KeyValuePair2<'Key,'U>, [<Optional>]_mthd: Default1) : KeyValuePair2<'Key,'U> =
+    static member inline ``<*>`` ((KeyValue(a: 'Key, f), KeyValue(b: 'Key, x: 'T)), _output: KeyValuePair<'Key,'U>, [<Optional>]_mthd: Default3) : KeyValuePair<'Key,'U> = KeyValuePair (Plus.Invoke a b, f x)
+    static member inline ``<*>`` ((f: KeyValuePair2<'Key, _>, x: KeyValuePair2<'Key, 'T>), _output: KeyValuePair2<'Key,'U>, [<Optional>]_mthd: Default3) : KeyValuePair2<'Key,'U> =
         let a = f.Key
         let b = x.Key
         let f = f.Value
@@ -93,7 +93,7 @@ type Apply =
 #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
 
 type Apply with
-    static member inline ``<*>`` ((f: '``Monad<'T->'U>``      , x: '``Monad<'T>``     ) , _output: '``Monad<'U>``      , [<Optional>]_mthd:Default2) : '``Monad<'U>``       = Bind.InvokeOnInstance f (fun (x1: 'T->'U) -> Bind.InvokeOnInstance x (fun x2 -> Return.InvokeOnInstance (x1 x2)))
+    static member inline ``<*>`` ((f: '``Monad<'T->'U>``      , x: '``Monad<'T>``     ) , _output: '``Monad<'U>``      , [<Optional>]_mthd:Default3) : '``Monad<'U>``       = Bind.InvokeOnInstance f (fun (x1: 'T->'U) -> Bind.InvokeOnInstance x (fun x2 -> Return.InvokeOnInstance (x1 x2)))
     static member inline ``<*>`` ((_: ^t when ^t : null and ^t: struct, _: ^u when ^u : null and ^u: struct), _output: ^r when ^r : null and ^r: struct, _mthd: Default1) = id
     
     static member inline ``<*>`` ((f: '``Applicative<'T->'U>``, x: '``Applicative<'T>``), _output: '``Applicative<'U>``, [<Optional>]_mthd: Default1) : '``Applicative<'U>`` = ((^``Applicative<'T->'U>`` or ^``Applicative<'T>`` or ^``Applicative<'U>``) : (static member (<*>) : _*_ -> _) f, x)

--- a/src/FSharpPlus/Control/Applicative.fs
+++ b/src/FSharpPlus/Control/Applicative.fs
@@ -37,12 +37,7 @@ type Apply =
     static member        ``<*>`` ((f: Result<_,'E>     , x: Result<'T,'E>        ), _output: Result<'b,'E>        , [<Optional>]_mthd: Apply) = Result.apply f x : Result<'U,'E>
     static member        ``<*>`` ((f: Choice<_,'E>     , x: Choice<'T,'E>        ), _output: Choice<'b,'E>        , [<Optional>]_mthd: Apply) = Choice.apply f x : Choice<'U,'E>
     static member inline ``<*>`` ((KeyValue(a: 'Key, f), KeyValue(b: 'Key, x: 'T)), _output: KeyValuePair<'Key,'U>, [<Optional>]_mthd: Default3) : KeyValuePair<'Key,'U> = KeyValuePair (Plus.Invoke a b, f x)
-    static member inline ``<*>`` ((f: KeyValuePair2<'Key, _>, x: KeyValuePair2<'Key, 'T>), _output: KeyValuePair2<'Key,'U>, [<Optional>]_mthd: Default3) : KeyValuePair2<'Key,'U> =
-        let a = f.Key
-        let b = x.Key
-        let f = f.Value
-        let x = x.Value
-        KeyValuePair2 (Plus.Invoke a b, f x)
+    static member inline ``<*>`` ((_: DmStruct2<'Key, _>, _: DmStruct2<'Key, 'T>) , _output: DmStruct2<'Key,'U>   , [<Optional>]_mthd: Default3) : DmStruct2<'Key,'U> = Unchecked.defaultof<DmStruct2<'Key,'U>>
 
     static member        ``<*>`` ((f: Map<'Key,_>      , x: Map<'Key,'T>        ) , _output: Map<'Key,'U>         , [<Optional>]_mthd: Apply) : Map<'Key,'U> = Map (seq {
        for KeyValue(k, vf) in f do

--- a/src/FSharpPlus/Control/Applicative.fs
+++ b/src/FSharpPlus/Control/Applicative.fs
@@ -16,38 +16,35 @@ type Apply =
  
 #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
 
-    static member inline ``<*>`` (f: '``Monad<'T->'U>``      , x: '``Monad<'T>``      , [<Optional>]_output: '``Monad<'U>``      , [<Optional>]_mthd:Default2) : '``Monad<'U>``       = Bind.InvokeOnInstance f (fun (x1: 'T->'U) -> Bind.InvokeOnInstance x (fun x2 -> Return.InvokeOnInstance (x1 x2)))
-    static member inline ``<*>`` (f: '``Applicative<'T->'U>``, x: '``Applicative<'T>``, [<Optional>]_output: '``Applicative<'U>``, [<Optional>]_mthd:Default1) : '``Applicative<'U>`` = ((^``Applicative<'T->'U>`` or ^``Applicative<'T>`` or ^``Applicative<'U>``) : (static member (<*>) : _*_ -> _) f, x)
-
-    static member        ``<*>`` (f: Lazy<'T->'U>     , x: Lazy<'T>             , [<Optional>]_output: Lazy<'U>             , [<Optional>]_mthd: Apply) = Lazy.apply f x                               : Lazy<'U>
-    static member        ``<*>`` (f: seq<_>           , x: seq<'T>              , [<Optional>]_output: seq<'U>              , [<Optional>]_mthd: Apply) = Seq.apply  f x                               : seq<'U>
-    static member        ``<*>`` (f: NonEmptySeq<_>   , x: NonEmptySeq<'T>      , [<Optional>]_output: NonEmptySeq<'U>      , [<Optional>]_mthd: Apply) = NonEmptySeq.apply  f x                       : NonEmptySeq<'U>
-    static member        ``<*>`` (f: IEnumerator<_>   , x: IEnumerator<'T>      , [<Optional>]_output: IEnumerator<'U>      , [<Optional>]_mthd: Apply) = Enumerator.map2 id f x : IEnumerator<'U>
-    static member        ``<*>`` (f: list<_>          , x: list<'T>             , [<Optional>]_output: list<'U>             , [<Optional>]_mthd: Apply) = List.apply f x                               : list<'U>
-    static member        ``<*>`` (f: _ []             , x: 'T []                , [<Optional>]_output: 'U []                , [<Optional>]_mthd: Apply) = Array.apply f x                              : 'U []
-    static member        ``<*>`` (f: 'r -> _          , g: _ -> 'T              , [<Optional>]_output:  'r -> 'U            , [<Optional>]_mthd: Apply) = fun x -> let f' = f x in f' (g x)            : 'U
-    static member inline ``<*>`` ((a: 'Monoid, f)     , (b: 'Monoid, x: 'T)     , [<Optional>]_output: 'Monoid * 'U         , [<Optional>]_mthd: Apply) = (Plus.Invoke a b, f x)                       : 'Monoid *'U
-    static member inline ``<*>`` (struct (a: 'Monoid, f), struct (b: 'Monoid, x: 'T), [<Optional>]_output: struct ('Monoid * 'U), [<Optional>]_mthd: Apply) = struct (Plus.Invoke a b, f x)            : struct ('Monoid * 'U)
+    static member        ``<*>`` ((f: Lazy<'T->'U>     , x: Lazy<'T>             , _output: Lazy<'U>            ) , [<Optional>]_mthd: Apply) = Lazy.apply f x                               : Lazy<'U>
+    static member        ``<*>`` ((f: seq<_>           , x: seq<'T>              , _output: seq<'U>             ) , [<Optional>]_mthd: Apply) = Seq.apply  f x                               : seq<'U>
+    static member        ``<*>`` ((f: NonEmptySeq<_>   , x: NonEmptySeq<'T>      , _output: NonEmptySeq<'U>     ) , [<Optional>]_mthd: Apply) = NonEmptySeq.apply  f x                       : NonEmptySeq<'U>
+    static member        ``<*>`` ((f: IEnumerator<_>   , x: IEnumerator<'T>      , _output: IEnumerator<'U>     ) , [<Optional>]_mthd: Apply) = Enumerator.map2 id f x : IEnumerator<'U>
+    static member        ``<*>`` ((f: list<_>          , x: list<'T>             , _output: list<'U>            ) , [<Optional>]_mthd: Apply) = List.apply f x                               : list<'U>
+    static member        ``<*>`` ((f: _ []             , x: 'T []                , _output: 'U []               ) , [<Optional>]_mthd: Apply) = Array.apply f x                              : 'U []
+    static member        ``<*>`` ((f: 'r -> _          , g: _ -> 'T              , _output:  'r -> 'U           ) , [<Optional>]_mthd: Apply) = fun x -> let f' = f x in f' (g x)            : 'U
+    static member inline ``<*>`` (((a: 'Monoid, f)     , (b: 'Monoid, x: 'T)     , _output: 'Monoid * 'U        ) , [<Optional>]_mthd: Apply) = (Plus.Invoke a b, f x)                       : 'Monoid *'U
+    static member inline ``<*>`` ((struct (a: 'Monoid, f), struct (b: 'Monoid, x: 'T), _output: struct ('Monoid * 'U)), [<Optional>]_mthd: Apply) = struct (Plus.Invoke a b, f x)            : struct ('Monoid * 'U)
     #if !FABLE_COMPILER
-    static member        ``<*>`` (f: Task<_>          , x: Task<'T>             , [<Optional>]_output: Task<'U>             , [<Optional>]_mthd: Apply) = Task.apply   f x : Task<'U>
+    static member        ``<*>`` ((f: Task<_>          , x: Task<'T>             , _output: Task<'U>            ) , [<Optional>]_mthd: Apply) = Task.apply   f x : Task<'U>
     #endif
     #if !NET45 && !NETSTANDARD2_0 && !FABLE_COMPILER
-    static member        ``<*>`` (f: ValueTask<_>     , x: ValueTask<'T>        , [<Optional>]_output: ValueTask<'U>        , [<Optional>]_mthd: Apply) = ValueTask.apply   f x : ValueTask<'U>
+    static member        ``<*>`` ((f: ValueTask<_>     , x: ValueTask<'T>        , _output: ValueTask<'U>       ) , [<Optional>]_mthd: Apply) = ValueTask.apply   f x : ValueTask<'U>
     #endif
-    static member        ``<*>`` (f: Async<_>         , x: Async<'T>            , [<Optional>]_output: Async<'U>            , [<Optional>]_mthd: Apply) = Async.apply  f x : Async<'U>
-    static member        ``<*>`` (f: option<_>        , x: option<'T>           , [<Optional>]_output: option<'U>           , [<Optional>]_mthd: Apply) = Option.apply f x : option<'U>
-    static member        ``<*>`` (f: voption<_>       , x: voption<'T>          , [<Optional>]_output: voption<'U>          , [<Optional>]_mthd: Apply) = ValueOption.apply f x : voption<'U>
-    static member        ``<*>`` (f: Result<_,'E>     , x: Result<'T,'E>        , [<Optional>]_output: Result<'b,'E>        , [<Optional>]_mthd: Apply) = Result.apply f x : Result<'U,'E>
-    static member        ``<*>`` (f: Choice<_,'E>     , x: Choice<'T,'E>        , [<Optional>]_output: Choice<'b,'E>        , [<Optional>]_mthd: Apply) = Choice.apply f x : Choice<'U,'E>
-    static member inline ``<*>`` (KeyValue(a: 'Key, f), KeyValue(b: 'Key, x: 'T), [<Optional>]_output: KeyValuePair<'Key,'U>, [<Optional>]_mthd: Apply) : KeyValuePair<'Key,'U> = KeyValuePair (Plus.Invoke a b, f x)
+    static member        ``<*>`` ((f: Async<_>         , x: Async<'T>            , _output: Async<'U>           ) , [<Optional>]_mthd: Apply) = Async.apply  f x : Async<'U>
+    static member        ``<*>`` ((f: option<_>        , x: option<'T>           , _output: option<'U>          ) , [<Optional>]_mthd: Apply) = Option.apply f x : option<'U>
+    static member        ``<*>`` ((f: voption<_>       , x: voption<'T>          , _output: voption<'U>         ) , [<Optional>]_mthd: Apply) = ValueOption.apply f x : voption<'U>
+    static member        ``<*>`` ((f: Result<_,'E>     , x: Result<'T,'E>        , _output: Result<'b,'E>       ) , [<Optional>]_mthd: Apply) = Result.apply f x : Result<'U,'E>
+    static member        ``<*>`` ((f: Choice<_,'E>     , x: Choice<'T,'E>        , _output: Choice<'b,'E>       ) , [<Optional>]_mthd: Apply) = Choice.apply f x : Choice<'U,'E>
+    static member inline ``<*>`` ((KeyValue(a: 'Key, f), KeyValue(b: 'Key, x: 'T), _output: KeyValuePair<'Key,'U>), [<Optional>]_mthd: Apply) : KeyValuePair<'Key,'U> = KeyValuePair (Plus.Invoke a b, f x)
 
-    static member        ``<*>`` (f: Map<'Key,_>      , x: Map<'Key,'T>         , [<Optional>]_output: Map<'Key,'U>         , [<Optional>]_mthd: Apply) : Map<'Key,'U> = Map (seq {
+    static member        ``<*>`` ((f: Map<'Key,_>      , x: Map<'Key,'T>         , _output: Map<'Key,'U>        ) , [<Optional>]_mthd: Apply) : Map<'Key,'U> = Map (seq {
        for KeyValue(k, vf) in f do
            match Map.tryFind k x with
            | Some vx -> yield k, vf vx
            | _       -> () })
 
-    static member        ``<*>`` (f: Dictionary<'Key,_>, x: Dictionary<'Key,'T> , [<Optional>]_output: Dictionary<'Key,'U>  , [<Optional>]_mthd: Apply) : Dictionary<'Key,'U> =
+    static member        ``<*>`` ((f: Dictionary<'Key,_>, x: Dictionary<'Key,'T> , _output: Dictionary<'Key,'U> ) , [<Optional>]_mthd: Apply) : Dictionary<'Key,'U> =
        let dct = Dictionary ()
        for KeyValue(k, vf) in f do
            match x.TryGetValue k with
@@ -55,7 +52,7 @@ type Apply =
            | _        -> ()
        dct
 
-    static member        ``<*>`` (f: IDictionary<'Key,_>, x: IDictionary<'Key,'T> , [<Optional>]_output: IDictionary<'Key,'U>  , [<Optional>]_mthd: Apply) : IDictionary<'Key,'U> =
+    static member        ``<*>`` ((f: IDictionary<'Key,_>, x: IDictionary<'Key,'T> , _output: IDictionary<'Key,'U> ) , [<Optional>]_mthd: Apply) : IDictionary<'Key,'U> =
        let dct = Dictionary ()
        for KeyValue(k, vf) in f do
            match x.TryGetValue k with
@@ -63,7 +60,7 @@ type Apply =
            | _        -> ()
        dct :> IDictionary<'Key,'U>
 
-    static member        ``<*>`` (f: IReadOnlyDictionary<'Key,_>, x: IReadOnlyDictionary<'Key,'T> , [<Optional>]_output: IReadOnlyDictionary<'Key,'U>  , [<Optional>]_mthd: Apply) : IReadOnlyDictionary<'Key,'U> =
+    static member        ``<*>`` ((f: IReadOnlyDictionary<'Key,_>, x: IReadOnlyDictionary<'Key,'T> , _output: IReadOnlyDictionary<'Key,'U> ) , [<Optional>]_mthd: Apply) : IReadOnlyDictionary<'Key,'U> =
        let dct = Dictionary ()
        for KeyValue(k, vf) in f do
            match x.TryGetValue k with
@@ -72,13 +69,13 @@ type Apply =
        dct :> IReadOnlyDictionary<'Key,'U>
 
     #if !FABLE_COMPILER
-    static member        ``<*>`` (f: Expr<'T->'U>, x: Expr<'T>, [<Optional>]_output: Expr<'U>, [<Optional>]_mthd: Apply) = Expr.Cast<'U> (Expr.Application (f, x))
+    static member        ``<*>`` ((f: Expr<'T->'U>, x: Expr<'T>, _output: Expr<'U>), [<Optional>]_mthd: Apply) = Expr.Cast<'U> (Expr.Application (f, x))
     #endif
-    static member        ``<*>`` (f: ('T->'U) ResizeArray, x: 'T ResizeArray, [<Optional>]_output: 'U ResizeArray, [<Optional>]_mthd: Apply) = ResizeArray.apply f x : 'U ResizeArray
+    static member        ``<*>`` ((f: ('T->'U) ResizeArray, x: 'T ResizeArray, _output: 'U ResizeArray), [<Optional>]_mthd: Apply) = ResizeArray.apply f x : 'U ResizeArray
 
     static member inline Invoke (f: '``Applicative<'T -> 'U>``) (x: '``Applicative<'T>``) : '``Applicative<'U>`` =
         let inline call (mthd : ^M, input1: ^I1, input2: ^I2, output: ^R) =
-            ((^M or ^I1 or ^I2 or ^R) : (static member ``<*>`` : _*_*_*_ -> _) input1, input2, output, mthd)
+            ((^M or ^I1 or ^I2 or ^R) : (static member ``<*>`` : (_*_*_)*_ -> _) (input1, input2, output), mthd)
         call(Unchecked.defaultof<Apply>, f, x, Unchecked.defaultof<'``Applicative<'U>``>)
 
 
@@ -88,6 +85,12 @@ type Apply =
         ((^``Applicative<'T->'U>`` or ^``Applicative<'T>`` or ^``Applicative<'U>``) : (static member (<*>) : _*_ -> _) (f, x))
 
 #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+
+type Apply with
+    static member inline ``<*>`` ((f: '``Monad<'T->'U>``      , x: '``Monad<'T>``      , _output: '``Monad<'U>``      ), [<Optional>]_mthd:Default2) : '``Monad<'U>``       = Bind.InvokeOnInstance f (fun (x1: 'T->'U) -> Bind.InvokeOnInstance x (fun x2 -> Return.InvokeOnInstance (x1 x2)))
+    static member inline ``<*>`` ((_: ^t when ^t : null and ^t: struct, _: ^u when ^u : null and ^u: struct, _output: ^r when ^r : null and ^r: struct), _mthd: Default1) = id
+    static member inline ``<*>`` ((f: '``Applicative<'T->'U>``, x: '``Applicative<'T>``, _output: '``Applicative<'U>``), [<Optional>]_mthd:Default1) : '``Applicative<'U>`` = ((^``Applicative<'T->'U>`` or ^``Applicative<'T>`` or ^``Applicative<'U>``) : (static member (<*>) : _*_ -> _) f, x)
+
 
 type Lift2 =
     inherit Default1

--- a/src/FSharpPlus/Control/Applicative.fs
+++ b/src/FSharpPlus/Control/Applicative.fs
@@ -16,41 +16,41 @@ type Apply =
 
 #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
 
-    static member        ``<*>`` ((f: Lazy<'T->'U>     , x: Lazy<'T>           )  , _output: Lazy<'U>             , [<Optional>]_mthd: Apply) = Lazy.apply f x                               : Lazy<'U>
-    static member        ``<*>`` ((f: seq<_>           , x: seq<'T>            )  , _output: seq<'U>              , [<Optional>]_mthd: Apply) = Seq.apply  f x                               : seq<'U>
-    static member        ``<*>`` ((f: NonEmptySeq<_>   , x: NonEmptySeq<'T>    )  , _output: NonEmptySeq<'U>      , [<Optional>]_mthd: Apply) = NonEmptySeq.apply  f x                       : NonEmptySeq<'U>
-    static member        ``<*>`` ((f: IEnumerator<_>   , x: IEnumerator<'T>    )  , _output: IEnumerator<'U>      , [<Optional>]_mthd: Apply) = Enumerator.map2 id f x : IEnumerator<'U>
-    static member        ``<*>`` ((f: list<_>          , x: list<'T>           )  , _output: list<'U>             , [<Optional>]_mthd: Apply) = List.apply f x                               : list<'U>
-    static member        ``<*>`` ((f: _ []             , x: 'T []              )  , _output: 'U []                , [<Optional>]_mthd: Apply) = Array.apply f x                              : 'U []
-    static member        ``<*>`` ((f: 'r -> _          , g: _ -> 'T            )  , _output:  'r -> 'U            , [<Optional>]_mthd: Apply) = fun x -> let f' = f x in f' (g x)            : 'U
-    static member inline ``<*>`` (((a: 'Monoid, f)     , (b: 'Monoid, x: 'T)   )  , _output: 'Monoid * 'U         , [<Optional>]_mthd: Apply) = (Plus.Invoke a b, f x)                       : 'Monoid *'U
-    static member inline ``<*>`` ((struct (a: 'Monoid, f), struct (b: 'Monoid, x: 'T)), _output: struct ('Monoid * 'U), [<Optional>]_mthd: Apply) = struct (Plus.Invoke a b, f x)            : struct ('Monoid * 'U)
+    static member        ``<*>`` (struct (f: Lazy<'T->'U>     , x: Lazy<'T>           )  , _output: Lazy<'U>             , [<Optional>]_mthd: Apply) = Lazy.apply f x                               : Lazy<'U>
+    static member        ``<*>`` (struct (f: seq<_>           , x: seq<'T>            )  , _output: seq<'U>              , [<Optional>]_mthd: Apply) = Seq.apply  f x                               : seq<'U>
+    static member        ``<*>`` (struct (f: NonEmptySeq<_>   , x: NonEmptySeq<'T>    )  , _output: NonEmptySeq<'U>      , [<Optional>]_mthd: Apply) = NonEmptySeq.apply  f x                       : NonEmptySeq<'U>
+    static member        ``<*>`` (struct (f: IEnumerator<_>   , x: IEnumerator<'T>    )  , _output: IEnumerator<'U>      , [<Optional>]_mthd: Apply) = Enumerator.map2 id f x : IEnumerator<'U>
+    static member        ``<*>`` (struct (f: list<_>          , x: list<'T>           )  , _output: list<'U>             , [<Optional>]_mthd: Apply) = List.apply f x                               : list<'U>
+    static member        ``<*>`` (struct (f: _ []             , x: 'T []              )  , _output: 'U []                , [<Optional>]_mthd: Apply) = Array.apply f x                              : 'U []
+    static member        ``<*>`` (struct (f: 'r -> _          , g: _ -> 'T            )  , _output:  'r -> 'U            , [<Optional>]_mthd: Apply) = fun x -> let f' = f x in f' (g x)            : 'U
+    static member inline ``<*>`` (struct ((a: 'Monoid, f)     , (b: 'Monoid, x: 'T)   )  , _output: 'Monoid * 'U         , [<Optional>]_mthd: Apply) = (Plus.Invoke a b, f x)                       : 'Monoid *'U
+    static member inline ``<*>`` (struct (struct (a: 'Monoid, f), struct (b: 'Monoid, x: 'T)), _output: struct ('Monoid * 'U), [<Optional>]_mthd: Apply) = struct (Plus.Invoke a b, f x)            : struct ('Monoid * 'U)
     #if !FABLE_COMPILER
-    static member        ``<*>`` ((f: Task<_>          , x: Task<'T>             ), _output: Task<'U>             , [<Optional>]_mthd: Apply) = Task.apply   f x : Task<'U>
+    static member        ``<*>`` (struct (f: Task<_>          , x: Task<'T>             ), _output: Task<'U>             , [<Optional>]_mthd: Apply) = Task.apply   f x : Task<'U>
     #endif
     #if !NET45 && !NETSTANDARD2_0 && !FABLE_COMPILER
-    static member        ``<*>`` ((f: ValueTask<_>     , x: ValueTask<'T>        ), _output: ValueTask<'U>        , [<Optional>]_mthd: Default3) = ValueTask.apply   f x : ValueTask<'U>
+    static member        ``<*>`` (struct (f: ValueTask<_>     , x: ValueTask<'T>        ), _output: ValueTask<'U>        , [<Optional>]_mthd: Default3) = ValueTask.apply   f x : ValueTask<'U>
     #endif
-    static member        ``<*>`` ((f: Async<_>         , x: Async<'T>            ), _output: Async<'U>            , [<Optional>]_mthd: Apply) = Async.apply  f x : Async<'U>
-    static member        ``<*>`` ((f: option<_>        , x: option<'T>           ), _output: option<'U>           , [<Optional>]_mthd: Apply) = Option.apply f x : option<'U>
-    static member        ``<*>`` ((f: voption<_>       , x: voption<'T>          ), _output: voption<'U>          , [<Optional>]_mthd: Apply) = ValueOption.apply f x : voption<'U>
-    static member        ``<*>`` ((f: Result<_,'E>     , x: Result<'T,'E>        ), _output: Result<'b,'E>        , [<Optional>]_mthd: Apply) = Result.apply f x : Result<'U,'E>
-    static member        ``<*>`` ((f: Choice<_,'E>     , x: Choice<'T,'E>        ), _output: Choice<'b,'E>        , [<Optional>]_mthd: Apply) = Choice.apply f x : Choice<'U,'E>
-    static member inline ``<*>`` ((KeyValue(a: 'Key, f), KeyValue(b: 'Key, x: 'T)), _output: KeyValuePair<'Key,'U>, [<Optional>]_mthd: Default3) : KeyValuePair<'Key,'U> = KeyValuePair (Plus.Invoke a b, f x)
-    static member inline ``<*>`` ((f: KeyValuePair2<'Key, _>, x: KeyValuePair2<'Key, 'T>), _output: KeyValuePair2<'Key,'U>, [<Optional>]_mthd: Default3) : KeyValuePair2<'Key,'U> =
+    static member        ``<*>`` (struct (f: Async<_>         , x: Async<'T>            ), _output: Async<'U>            , [<Optional>]_mthd: Apply) = Async.apply  f x : Async<'U>
+    static member        ``<*>`` (struct (f: option<_>        , x: option<'T>           ), _output: option<'U>           , [<Optional>]_mthd: Apply) = Option.apply f x : option<'U>
+    static member        ``<*>`` (struct (f: voption<_>       , x: voption<'T>          ), _output: voption<'U>          , [<Optional>]_mthd: Apply) = ValueOption.apply f x : voption<'U>
+    static member        ``<*>`` (struct (f: Result<_,'E>     , x: Result<'T,'E>        ), _output: Result<'b,'E>        , [<Optional>]_mthd: Apply) = Result.apply f x : Result<'U,'E>
+    static member        ``<*>`` (struct (f: Choice<_,'E>     , x: Choice<'T,'E>        ), _output: Choice<'b,'E>        , [<Optional>]_mthd: Apply) = Choice.apply f x : Choice<'U,'E>
+    static member inline ``<*>`` (struct (KeyValue(a: 'Key, f), KeyValue(b: 'Key, x: 'T)), _output: KeyValuePair<'Key,'U>, [<Optional>]_mthd: Default3) : KeyValuePair<'Key,'U> = KeyValuePair (Plus.Invoke a b, f x)
+    static member inline ``<*>`` (struct (f: KeyValuePair2<'Key, _>, x: KeyValuePair2<'Key, 'T>), _output: KeyValuePair2<'Key,'U>, [<Optional>]_mthd: Default3) : KeyValuePair2<'Key,'U> =
         let a = f.Key
         let b = x.Key
         let f = f.Value
         let x = x.Value
         KeyValuePair2 (Plus.Invoke a b, f x)
 
-    static member        ``<*>`` ((f: Map<'Key,_>      , x: Map<'Key,'T>        ) , _output: Map<'Key,'U>         , [<Optional>]_mthd: Apply) : Map<'Key,'U> = Map (seq {
+    static member        ``<*>`` (struct (f: Map<'Key,_>      , x: Map<'Key,'T>        ) , _output: Map<'Key,'U>         , [<Optional>]_mthd: Apply) : Map<'Key,'U> = Map (seq {
        for KeyValue(k, vf) in f do
            match Map.tryFind k x with
            | Some vx -> yield k, vf vx
            | _       -> () })
 
-    static member        ``<*>`` ((f: Dictionary<'Key,_>, x: Dictionary<'Key,'T>) , _output: Dictionary<'Key,'U>  , [<Optional>]_mthd: Apply) : Dictionary<'Key,'U> =
+    static member        ``<*>`` (struct (f: Dictionary<'Key,_>, x: Dictionary<'Key,'T>) , _output: Dictionary<'Key,'U>  , [<Optional>]_mthd: Apply) : Dictionary<'Key,'U> =
        let dct = Dictionary ()
        for KeyValue(k, vf) in f do
            match x.TryGetValue k with
@@ -58,7 +58,7 @@ type Apply =
            | _        -> ()
        dct
 
-    static member        ``<*>`` ((f: IDictionary<'Key,_>, x: IDictionary<'Key,'T>) , _output: IDictionary<'Key,'U>  , [<Optional>]_mthd: Apply) : IDictionary<'Key,'U> =
+    static member        ``<*>`` (struct (f: IDictionary<'Key,_>, x: IDictionary<'Key,'T>) , _output: IDictionary<'Key,'U>  , [<Optional>]_mthd: Apply) : IDictionary<'Key,'U> =
        let dct = Dictionary ()
        for KeyValue(k, vf) in f do
            match x.TryGetValue k with
@@ -66,7 +66,7 @@ type Apply =
            | _        -> ()
        dct :> IDictionary<'Key,'U>
     
-    static member        ``<*>`` ((f: IReadOnlyDictionary<'Key,_>, x: IReadOnlyDictionary<'Key,'T>) , _output: IReadOnlyDictionary<'Key,'U>  , [<Optional>]_mthd: Apply) : IReadOnlyDictionary<'Key,'U> =
+    static member        ``<*>`` (struct (f: IReadOnlyDictionary<'Key,_>, x: IReadOnlyDictionary<'Key,'T>) , _output: IReadOnlyDictionary<'Key,'U>  , [<Optional>]_mthd: Apply) : IReadOnlyDictionary<'Key,'U> =
        let dct = Dictionary ()
        for KeyValue(k, vf) in f do
            match x.TryGetValue k with
@@ -75,15 +75,14 @@ type Apply =
        dct :> IReadOnlyDictionary<'Key,'U>
 
     #if !FABLE_COMPILER
-    static member        ``<*>`` ((f: Expr<'T->'U>, x: Expr<'T>), _output: Expr<'U>, [<Optional>]_mthd: Apply) = Expr.Cast<'U> (Expr.Application (f, x))
+    static member        ``<*>`` (struct (f: Expr<'T->'U>, x: Expr<'T>), _output: Expr<'U>, [<Optional>]_mthd: Apply) = Expr.Cast<'U> (Expr.Application (f, x))
     #endif
-    static member        ``<*>`` ((f: ('T->'U) ResizeArray, x: 'T ResizeArray), _output: 'U ResizeArray, [<Optional>]_mthd: Apply) = ResizeArray.apply f x : 'U ResizeArray
+    static member        ``<*>`` (struct (f: ('T->'U) ResizeArray, x: 'T ResizeArray), _output: 'U ResizeArray, [<Optional>]_mthd: Apply) = ResizeArray.apply f x : 'U ResizeArray
     
     static member inline Invoke (f: '``Applicative<'T -> 'U>``) (x: '``Applicative<'T>``) : '``Applicative<'U>`` =
         let inline call (mthd : ^M, input1: ^I1, input2: ^I2, output: ^R) =
-            ((^M or ^I1 or ^I2 or ^R) : (static member ``<*>`` : (_*_)*_*_ -> _) (input1, input2), output, mthd)
+            ((^M or ^I1 or ^I2 or ^R) : (static member ``<*>`` : struct (_*_) * _ * _ -> _) (struct (input1, input2)), output, mthd)
         call(Unchecked.defaultof<Apply>, f, x, Unchecked.defaultof<'``Applicative<'U>``>)
-
 
 #endif
 
@@ -93,10 +92,10 @@ type Apply =
 #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
 
 type Apply with
-    static member inline ``<*>`` ((f: '``Monad<'T->'U>``      , x: '``Monad<'T>``     ) , _output: '``Monad<'U>``      , [<Optional>]_mthd:Default3) : '``Monad<'U>``       = Bind.InvokeOnInstance f (fun (x1: 'T->'U) -> Bind.InvokeOnInstance x (fun x2 -> Return.InvokeOnInstance (x1 x2)))
-    static member inline ``<*>`` ((_: ^t when ^t : null and ^t: struct, _: ^u when ^u : null and ^u: struct), _output: ^r when ^r : null and ^r: struct, _mthd: Default1) = id
+    static member inline ``<*>`` (struct (f: '``Monad<'T->'U>``      , x: '``Monad<'T>``     ) , _output: '``Monad<'U>``      , [<Optional>]_mthd:Default3) : '``Monad<'U>``       = Bind.InvokeOnInstance f (fun (x1: 'T->'U) -> Bind.InvokeOnInstance x (fun x2 -> Return.InvokeOnInstance (x1 x2)))
+    static member inline ``<*>`` (struct (_: ^t when ^t : null and ^t: struct, _: ^u when ^u : null and ^u: struct), _output: ^r when ^r : null and ^r: struct, _mthd: Default1) = id
     
-    static member inline ``<*>`` ((f: '``Applicative<'T->'U>``, x: '``Applicative<'T>``), _output: '``Applicative<'U>``, [<Optional>]_mthd: Default1) : '``Applicative<'U>`` = ((^``Applicative<'T->'U>`` or ^``Applicative<'T>`` or ^``Applicative<'U>``) : (static member (<*>) : _*_ -> _) f, x)
+    static member inline ``<*>`` (struct (f: '``Applicative<'T->'U>``, x: '``Applicative<'T>``), _output: '``Applicative<'U>``, [<Optional>]_mthd: Default1) : '``Applicative<'U>`` = ((^``Applicative<'T->'U>`` or ^``Applicative<'T>`` or ^``Applicative<'U>``) : (static member (<*>) : _*_ -> _) f, x)
 
 
 type Lift2 =

--- a/src/FSharpPlus/Control/Functor.fs
+++ b/src/FSharpPlus/Control/Functor.fs
@@ -89,7 +89,7 @@ type Map =
     static member Map ((x: Result<_,'E>        , f: 'T->'U), _mthd: Map) = Result.map f x
     static member Map ((x: Choice<_,'E>        , f: 'T->'U), _mthd: Map) = Choice.map f x
     static member Map ((KeyValue(k, x)         , f: 'T->'U), _mthd: Map) = KeyValuePair (k, f x)
-    static member Map ((x: KeyValuePair2<_, _> , f: 'T->'U), _mthd: Map) = let k, x = x.Key, x.Value in KeyValuePair2 (k, f x)
+    static member Map ((_: DmStruct2<'T, 'E>   , _: 'T->'U), _mthd: Map) = Unchecked.defaultof<DmStruct2<'U, 'E>>
     static member Map ((x: Map<'Key,'T>        , f: 'T->'U), _mthd: Map) = Map.map (const' f) x : Map<'Key,'U>
     static member Map ((x: Dictionary<_,_>     , f: 'T->'U), _mthd: Map) = Dictionary.map f x : Dictionary<'Key,'U>
     #if !FABLE_COMPILER

--- a/src/FSharpPlus/Control/Functor.fs
+++ b/src/FSharpPlus/Control/Functor.fs
@@ -89,7 +89,7 @@ type Map =
     static member Map ((x: Result<_,'E>        , f: 'T->'U), _mthd: Map) = Result.map f x
     static member Map ((x: Choice<_,'E>        , f: 'T->'U), _mthd: Map) = Choice.map f x
     static member Map ((KeyValue(k, x)         , f: 'T->'U), _mthd: Map) = KeyValuePair (k, f x)
-    static member Map ((_: DmStruct2<'T, 'E>   , _: 'T->'U), _mthd: Map) = Unchecked.defaultof<DmStruct2<'U, 'E>>
+    static member Map ((x: KeyValuePair2<_, _> , f: 'T->'U), _mthd: Map) = let k, x = x.Key, x.Value in KeyValuePair2 (k, f x)
     static member Map ((x: Map<'Key,'T>        , f: 'T->'U), _mthd: Map) = Map.map (const' f) x : Map<'Key,'U>
     static member Map ((x: Dictionary<_,_>     , f: 'T->'U), _mthd: Map) = Dictionary.map f x : Dictionary<'Key,'U>
     #if !FABLE_COMPILER

--- a/src/FSharpPlus/Control/Functor.fs
+++ b/src/FSharpPlus/Control/Functor.fs
@@ -89,6 +89,7 @@ type Map =
     static member Map ((x: Result<_,'E>        , f: 'T->'U), _mthd: Map) = Result.map f x
     static member Map ((x: Choice<_,'E>        , f: 'T->'U), _mthd: Map) = Choice.map f x
     static member Map ((KeyValue(k, x)         , f: 'T->'U), _mthd: Map) = KeyValuePair (k, f x)
+    static member Map ((x: KeyValuePair2<_, _> , f: 'T->'U), _mthd: Map) = let k, x = x.Key, x.Value in KeyValuePair2 (k, f x)
     static member Map ((x: Map<'Key,'T>        , f: 'T->'U), _mthd: Map) = Map.map (const' f) x : Map<'Key,'U>
     static member Map ((x: Dictionary<_,_>     , f: 'T->'U), _mthd: Map) = Dictionary.map f x : Dictionary<'Key,'U>
     #if !FABLE_COMPILER

--- a/src/FSharpPlus/Internals.fs
+++ b/src/FSharpPlus/Internals.fs
@@ -125,6 +125,12 @@ type Either<'t,'u> =
 
 type DmStruct = struct end
 
+type KeyValuePair2<'TKey, 'TValue> = struct
+    val Key : 'TKey
+    val Value : 'TValue
+    new (key, value) = { Key = key; Value = value }
+end
+
 [<Sealed>]
 type Set2<'T when 'T: comparison >() = class end
 

--- a/src/FSharpPlus/Internals.fs
+++ b/src/FSharpPlus/Internals.fs
@@ -124,7 +124,6 @@ type Either<'t,'u> =
     | Right of 'u
 
 type DmStruct = struct end
-type DmStruct2<'T1, 'T2> = struct end
 
 type KeyValuePair2<'TKey, 'TValue> = struct
     val Key : 'TKey

--- a/src/FSharpPlus/Internals.fs
+++ b/src/FSharpPlus/Internals.fs
@@ -124,6 +124,7 @@ type Either<'t,'u> =
     | Right of 'u
 
 type DmStruct = struct end
+type DmStruct2<'T1, 'T2> = struct end
 
 type KeyValuePair2<'TKey, 'TValue> = struct
     val Key : 'TKey


### PR DESCRIPTION
Same as #207 but rebased.

I gave it another try and looks like I found a way not to break anything, so no need to wait for v2.

This will allow Vector and Matrix to implement `IEnumerable`.
Another reason to implement this is removing dependencies between `NonEmptySeq<'T>` (now that F#8 allows static member on interfaces) and `FSharpPlus.Control` by creating its own static members #552 

Also to the original issues:

> Right now there are 2 issues ..

>  - Types implementing `IEnumerable<_>` would default to the `seq<_>` instance. This might be arguably desired.

>  - Types implementing `IEnumerable<_>` would default to the `seq<_>` instance, even if they implement their own applicative > instance. This is not acceptable.

.. I will amend the former like this:

  - Types implementing `IEnumerable<_>` would default to the seq<_> instance. This might be arguably desired, but it will result in unexpected behavior: different IEnumerables can have different applicative instances, this is becoming more evident in #559  for example a ZipList can be an IEnumerable but its applicative instance won't have the same result as if you cast it to seq and then use the applicative for sequences, therefore it's better to require either an explicit applicative implementation, or an explicit cast to `seq`. The other issue is the resulting type will be a `seq<_>` instead of the original type, which would break many things.

**TODO**

- [x] Add tests for the new functionality
- [x] Rebase on #570 just to be sure nothing breaks
- [x] Reconsider final shape of the overloads (tuple, ref, struct tuple)
- [x] Reconsider the dummy type KeyValuePair2, move it to internals, use instead a DmStruct2<_,_>, ... -> DmStruct2 didn't work.