### PR TITLE
+ .net8 target framework and F# language version 8

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fable": {
-      "version": "4.1.4",
+      "version": "4.5.0",
       "commands": [
         "fable"
       ]

--- a/.github/workflows/fable.yml
+++ b/.github/workflows/fable.yml
@@ -17,6 +17,10 @@ jobs:
       run: git submodule update --init --recursive
     - name: Remove global json
       run: rm global.json
+    - name: Set target framework to net6 instead of net8
+      uses: Mudlet/xmlstarlet-action@master
+      with:
+        args: edit --inplace --update "/Project/PropertyGroup/TargetFrameworks" --value "netstandard2.0;netstandard2.1;net6.0" ./src/FSharpPlus/FSharpPlus.fsproj
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v3
       with:

--- a/.github/workflows/fable.yml
+++ b/.github/workflows/fable.yml
@@ -30,7 +30,7 @@ jobs:
       working-directory: tests/FSharpPlusFable.Tests
       run: mv fable3-global.json global.json
     - name: Install fable
-      run: dotnet tool install --global Fable --version 3.7.20
+      run: dotnet tool install --global Fable --version 3.7.22
     - name: Use Node.js
       uses: actions/setup-node@v1
       with:

--- a/.github/workflows/fable.yml
+++ b/.github/workflows/fable.yml
@@ -83,9 +83,6 @@ jobs:
       run: git submodule update --init --recursive
     - name: Remove global json
       run: rm global.json
-    - name: Remove global json in subfolder
-      run: rm global.json
-      working-directory: tests/FSharpPlusFable.Tests
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v3
       with:

--- a/.github/workflows/fable.yml
+++ b/.github/workflows/fable.yml
@@ -26,6 +26,9 @@ jobs:
           6.0.x
     - name: Restore tools
       run: dotnet tool restore
+    - name: Create global.json
+      working-directory: tests/FSharpPlusFable.Tests
+      run: mv fable3-global.json global.json
     - name: Install fable
       run: dotnet tool install --global Fable --version 3.7.20
     - name: Use Node.js

--- a/src/FSharpPlus/FSharpPlus.fsproj
+++ b/src/FSharpPlus/FSharpPlus.fsproj
@@ -21,12 +21,12 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Configurations>Debug;Release;Fable;Fable3;Test</Configurations>
     <Platforms>AnyCPU</Platforms>
-    <LangVersion>6.0</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <DefineConstants Condition=" '$(Configuration)' == 'Test'">$(DefineConstants);TEST_TRACE</DefineConstants>
     <DefineConstants Condition=" '$(Configuration)' == 'Fable'">$(DefineConstants);FABLE_COMPILER</DefineConstants>
     <DefineConstants Condition=" '$(Configuration)' == 'Fable3'">$(DefineConstants);FABLE_COMPILER;FABLE_COMPILER_3</DefineConstants>
     <DefineConstants Condition=" '$(Configuration)' == 'Fable4'">$(DefineConstants);FABLE_COMPILER;FABLE_COMPILER_4</DefineConstants>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
     <!--<OutputPath>..\..\bin</OutputPath>-->
   </PropertyGroup>
   <ItemGroup>

--- a/src/FSharpPlus/FSharpPlus.fsproj
+++ b/src/FSharpPlus/FSharpPlus.fsproj
@@ -22,6 +22,8 @@
     <Configurations>Debug;Release;Fable;Fable3;Test</Configurations>
     <Platforms>AnyCPU</Platforms>
     <LangVersion>8.0</LangVersion>
+    <LangVersion Condition=" '$(Configuration)' == 'Fable' OR '$(Configuration)' == 'Fable3' ">6.0</LangVersion>
+
     <DefineConstants Condition=" '$(Configuration)' == 'Test'">$(DefineConstants);TEST_TRACE</DefineConstants>
     <DefineConstants Condition=" '$(Configuration)' == 'Fable'">$(DefineConstants);FABLE_COMPILER</DefineConstants>
     <DefineConstants Condition=" '$(Configuration)' == 'Fable3'">$(DefineConstants);FABLE_COMPILER;FABLE_COMPILER_3</DefineConstants>

--- a/tests/FSharpPlus.Tests/FSharpPlus.Tests.fsproj
+++ b/tests/FSharpPlus.Tests/FSharpPlus.Tests.fsproj
@@ -12,7 +12,7 @@
     <Platforms>AnyCPU</Platforms>
     <DefineConstants Condition=" '$(Configuration)' == 'Test'">$(DefineConstants);TEST_TRACE</DefineConstants>
     <DefineConstants Condition=" '$(Configuration)' == 'Fable'">$(DefineConstants);FABLE_COMPILER</DefineConstants>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Helpers.fs" />

--- a/tests/FSharpPlus.Tests/General.fs
+++ b/tests/FSharpPlus.Tests/General.fs
@@ -1941,7 +1941,7 @@ module Memoization =
 
         let f x                       = printfn "calculating"; effs.Add "f"; string x
         let g x (y:string) z : uint32 = printfn "calculating"; effs.Add "g"; uint32 (x * int y + int z)
-        let h x y z                   = printfn "calculating"; effs.Add "h"; new System.DateTime (x, y, z)
+        let h (x: int) (y: int) (z: int) = printfn "calculating"; effs.Add "h"; new System.DateTime (x, y, z)
         let sum2 (a:int)       = printfn "calculating"; effs.Add "sum2"; (+) a
         let sum3 a (b:int) c   = printfn "calculating"; effs.Add "sum3"; a + b + c
         let sum4 a b c d : int = printfn "calculating"; effs.Add "sum4"; a + b + c + d

--- a/tests/FSharpPlusFable.Tests/FSharpPlusFable.Tests.fsproj
+++ b/tests/FSharpPlusFable.Tests/FSharpPlusFable.Tests.fsproj
@@ -8,7 +8,7 @@
     <DefineConstants Condition=" '$(Configuration)' == 'Fable'">$(DefineConstants);FABLE_COMPILER;FABLE_COMPILER_FAKE</DefineConstants>
     <DefineConstants Condition=" '$(Configuration)' == 'Fable3'">$(DefineConstants);FABLE_COMPILER;FABLE_COMPILER_3;FABLE_COMPILER_FAKE</DefineConstants>
     <DefineConstants Condition=" '$(Configuration)' == 'Fable4'">$(DefineConstants);FABLE_COMPILER;FABLE_COMPILER_4;FABLE_COMPILER_FAKE</DefineConstants>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
 

--- a/tests/FSharpPlusFable.Tests/FSharpPlusFable.Tests.fsproj
+++ b/tests/FSharpPlusFable.Tests/FSharpPlusFable.Tests.fsproj
@@ -8,7 +8,7 @@
     <DefineConstants Condition=" '$(Configuration)' == 'Fable'">$(DefineConstants);FABLE_COMPILER;FABLE_COMPILER_FAKE</DefineConstants>
     <DefineConstants Condition=" '$(Configuration)' == 'Fable3'">$(DefineConstants);FABLE_COMPILER;FABLE_COMPILER_3;FABLE_COMPILER_FAKE</DefineConstants>
     <DefineConstants Condition=" '$(Configuration)' == 'Fable4'">$(DefineConstants);FABLE_COMPILER;FABLE_COMPILER_4;FABLE_COMPILER_FAKE</DefineConstants>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
 

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General.fs
@@ -311,7 +311,7 @@ let memoization = testList "Memoization" [
 
         let f x                       = printfn "calculating"; effs.Add "f"; string x
         let g x (y:string) z : uint32 = printfn "calculating"; effs.Add "g"; uint32 (x * int y + int z)
-        let h x y z                   = printfn "calculating"; effs.Add "h"; new System.DateTime (x, y, z)
+        let h (x: int) (y: int) (z: int) = printfn "calculating"; effs.Add "h"; new System.DateTime (x, y, z)
         let sum2 (a:int)       = printfn "calculating"; effs.Add "sum2"; (+) a
         let sum3 a (b:int) c   = printfn "calculating"; effs.Add "sum3"; a + b + c
         let sum4 a b c d : int = printfn "calculating"; effs.Add "sum4"; a + b + c + d

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/Alternative.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/Alternative.fs
@@ -128,4 +128,4 @@ let alternative = testList "Alternative" [
         #endif
     )
 #endif
-]
+    ]

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/Applicative.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/Applicative.fs
@@ -115,4 +115,4 @@ let applicative = testList "Applicative" [
         let r3 = lift2 (+) a3 b3
         Assert.AreEqual ("Here's the state SHere's the other state S", (ReaderT.run r3 "S" |> Async.RunSynchronously)))
     #endif
-]
+    ]

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/Collections.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/Collections.fs
@@ -261,5 +261,5 @@ let collections = testList "Collections" [
         
         let m = choose Some ((ofSeq :seq<_*_> -> Map<_,_>) (seq ["a", 1; "b", 2]))
         Assert.IsInstanceOf<Option<Map<string,int>>> (Some m))
-   #endif
-]
+    #endif
+    ]

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/Foldable.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/Foldable.fs
@@ -337,5 +337,5 @@ let foldable = testList "Foldable" [
         equal None sb'
         ())
 #endif
-]
+    ]
 

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/Indexable.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/Indexable.fs
@@ -246,4 +246,4 @@ let indexable = testList "Indexable" [
         SideEffects.are ["Using WrappedListD's FindSliceIndex"]
         equal i1 1)
     #endif
-]
+    ]

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/Monad.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/Monad.fs
@@ -93,4 +93,4 @@ let monad = testList "Monad" [
     )
     #endif
 
-]
+    ]

--- a/tests/FSharpPlusFable.Tests/fable3-global.json
+++ b/tests/FSharpPlusFable.Tests/fable3-global.json
@@ -1,0 +1,1 @@
+{ "sdk": { "version": "6.0.201", "rollForward": "latestFeature" } }

--- a/tests/FSharpPlusFable.Tests/global.json
+++ b/tests/FSharpPlusFable.Tests/global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "version": "6.0.201",
-    "rollForward": "latestFeature"
-  }
-}


### PR DESCRIPTION
- Add: .net8 target framework for F#+ library
- Update: F# language version to 8
- Fix: A unique overload for method 'DateTime' could not be determined
- Fix: Indentation warnings that has turned into compilation error
- Fix: Fable 3.7 runs with downgraded .net versions and target framework