### PR TITLE
Limited applicative support for dictionaries

### DIFF
--- a/src/FSharpPlus/Control/Applicative.fs
+++ b/src/FSharpPlus/Control/Applicative.fs
@@ -124,6 +124,8 @@ type Lift2 =
     static member        Lift2 (f, (x: Choice<'T,'Error>  , y: Choice<'U,'Error>  ), _mthd: Lift2) = Choice.map2 f x y
     static member        Lift2 (f, (x: Map<'Key,'T>       , y : Map<'Key,'U>      ), _mthd: Lift2) = Map.mapValues2 f x y
     static member        Lift2 (f, (x: Dictionary<'Key,'T>, y: Dictionary<'Key,'U>), _mthd: Lift2) = Dictionary.map2 f x y
+    static member        Lift2 (f, (x: IDictionary<'Key,'T>, y: IDictionary<'Key,'U>), _mthd: Lift2) = Dict.map2 f x y
+    static member        Lift2 (f, (x: IReadOnlyDictionary<'Key,'T>, y: IReadOnlyDictionary<'Key,'U>), _mthd: Lift2) = IReadOnlyDictionary.map2 f x y
     #if !FABLE_COMPILER
     static member        Lift2 (f, (x: Expr<'T>           , y: Expr<'U>           ), _mthd: Lift2) = <@ f %x %y @>
     #endif
@@ -171,6 +173,8 @@ type Lift3 =
     static member        Lift3 (f, (x: Choice<'T,'Error>  , y: Choice<'U,'Error>  , z: Choice<'V, 'Error>  ), _mthd: Lift3) = Choice.map3 f x y z
     static member        Lift3 (f, (x: Map<'Key,'T>       , y: Map<'Key,'U>       , z: Map<'Key, 'V>       ), _mthd: Lift3) = Map.mapValues3 f x y z
     static member        Lift3 (f, (x: Dictionary<'Key,'T>, y: Dictionary<'Key,'U>, z: Dictionary<'Key, 'V>), _mthd: Lift3) = Dictionary.map3 f x y z
+    static member        Lift3 (f, (x: IDictionary<'Key,'T>, y: IDictionary<'Key,'U>, z: IDictionary<'Key, 'V>), _mthd: Lift3) = Dict.map3 f x y z
+    static member        Lift3 (f, (x: IReadOnlyDictionary<'Key,'T>, y: IReadOnlyDictionary<'Key,'U>, z: IReadOnlyDictionary<'Key, 'V>), _mthd: Lift3) = IReadOnlyDictionary.map3 f x y z
     #if !FABLE_COMPILER
     static member        Lift3 (f, (x: Expr<'T>           , y: Expr<'U>           , z: Expr<'V>            ), _mthd: Lift3) = <@ f %x %y %z @>
     #endif

--- a/src/FSharpPlus/Extensions/Dict.fs
+++ b/src/FSharpPlus/Extensions/Dict.fs
@@ -73,6 +73,23 @@ module Dict =
             | None    -> ()
         dct :> IDictionary<'Key, 'U>
 
+    /// <summary>Combines values from three dictionaries using mapping function.</summary>
+    /// <remarks>Keys that are not present on every dictionary are dropped.</remarks>
+    /// <param name="mapping">The mapping function.</param>
+    /// <param name="source1">First input dictionary.</param>
+    /// <param name="source2">Second input dictionary.</param>
+    /// <param name="source3">Third input dictionary.</param>
+    ///
+    /// <returns>The mapped dictionary.</returns>
+    let map3 mapping (source1: IDictionary<'Key, 'T1>) (source2: IDictionary<'Key, 'T2>) (source3: IDictionary<'Key, 'T3>) =
+        let dct = Dictionary<'Key, 'U> ()
+        let f = OptimizedClosures.FSharpFunc<_,_,_,_>.Adapt mapping
+        for KeyValue(k, vx) in source1 do
+            match tryGetValue k source2, tryGetValue k source3 with
+            | Some vy, Some vz -> dct.Add (k, f.Invoke (vx, vy, vz))
+            | _      , _       -> ()
+        dct :> IDictionary<'Key, 'U>
+
     /// <summary>Applies given function to each value of the given dictionary.</summary>
     /// <param name="chooser">The mapping function.</param>
     /// <param name="source">The input dictionary.</param>

--- a/src/FSharpPlus/Extensions/IReadOnlyDictionary.fs
+++ b/src/FSharpPlus/Extensions/IReadOnlyDictionary.fs
@@ -80,6 +80,24 @@ module IReadOnlyDictionary =
             | None    -> ()
         dct :> IReadOnlyDictionary<'Key, 'U>
 
+    /// <summary>Combines values from three read-only dictionaries using mapping function.</summary>
+    /// <remarks>Keys that are not present on every dictionary are dropped.</remarks>
+    /// <param name="mapping">The mapping function.</param>
+    /// <param name="source1">First input dictionary.</param>
+    /// <param name="source2">Second input dictionary.</param>
+    /// <param name="source3">Third input dictionary.</param>
+    ///
+    /// <returns>The mapped IReadOnlyDictionary.</returns>
+    let map3 mapping (source1: IReadOnlyDictionary<'Key, 'T1>) (source2: IReadOnlyDictionary<'Key, 'T2>) (source3: IReadOnlyDictionary<'Key, 'T3>) =
+        let dct = Dictionary<'Key, 'U> ()
+        let f = OptimizedClosures.FSharpFunc<_,_,_,_>.Adapt mapping
+        for KeyValue(k, vx) in source1 do
+            match tryGetValue k source2, tryGetValue k source3 with
+            | Some vy, Some vz -> dct.Add (k, f.Invoke (vx, vy, vz))
+            | _      , _       -> ()
+        dct :> IReadOnlyDictionary<'Key, 'U>
+
+
     /// <summary>Maps the given function over each key and value in the read-only dictionary.</summary>
     /// <param name="mapper">The mapping function.</param>
     /// <param name="source">The input IReadOnlyDictionary.</param>

--- a/tests/FSharpPlus.Tests/ComputationExpressions.fs
+++ b/tests/FSharpPlus.Tests/ComputationExpressions.fs
@@ -14,6 +14,17 @@ module ComputationExpressions =
     let task<'t> = monad'<Task<'t>>
 
     [<Test>]
+    let oneLayerApplicativeWithoutReturn () =
+        // dictionaries don't support Return
+        let testVal14 = applicative {
+            let! x1 = dict [1,1]
+            and! x2 = dict [1,1]
+            and! x3 = dict [1,1]
+            and! x4 = dict [1,1]
+            return x1 + x2 + x3 + x4 }
+        CollectionAssert.AreEqual (dict [1, 4], testVal14)
+    
+    [<Test>]
     let twoLayersApplicatives () =
         let id   : Task<Validation<_, string>>   = Failure (Map.ofList ["Id",   ["Negative number"]]) |> Task.FromResult
         let firstName : Validation<_, string>    = Failure (Map.ofList ["Name", ["Invalid chars"]])

--- a/tests/FSharpPlus.Tests/General.fs
+++ b/tests/FSharpPlus.Tests/General.fs
@@ -1224,6 +1224,10 @@ module Applicative =
         Assert.IsInstanceOf<Option<WrappedSeqF<int>>> (Some res5)
         CollectionAssert.AreEqual (WrappedSeqF [5], res5)
 
+        let testVal11 = (+) "h" <!> dict [1, "i"; 2, "ello"]
+        CollectionAssert.AreEqual (dict [(1, "hi"); (2, "hello")], testVal11)
+
+    [<Test>]
     let testLift2 () =
         let expectedEffects = ["Using WrappedSeqD's Return"; "Using WrappedSeqD's Apply"; "Using WrappedSeqD's Apply"]
         SideEffects.reset ()


### PR DESCRIPTION
Although dictionaries don't support the `Return` operation, we can go quite far with applicatives.

This is a good alternative to #448 instead of fighting the absence of `Return` we embrace it and add other missing methods in order to be able to use some applicative operations, including the applicative CE.