### PR TITLE
Address some warnings

### DIFF
--- a/src/FSharpPlus/Control/Monoid.fs
+++ b/src/FSharpPlus/Control/Monoid.fs
@@ -38,9 +38,9 @@ type Plus =
     #else
     static member        ``+`` (x: StringBuilder     , y: StringBuilder     , [<Optional>]_mthd: Plus    ) = StringBuilder().Append(string x).Append(string y)
     static member        ``+`` (_: Id0               , _: Id0               , [<Optional>]_mthd: Plus    ) = Id0 ""
-    static member        ``+`` (x: exn               , y: exn               , [<Optional>]_mthd: Plus    ) =
+    static member        ``+`` (x: exn               , y: exn               , [<Optional>]_mthd: Plus    ) : exn =
         let f (e: exn) = match e with :? AggregateException as a -> a.Data0 :> seq<_> | _ -> Seq.singleton e
-        AggregateException (seq {yield! f x; yield! f y}) :> exn
+        AggregateException (seq {yield! f x; yield! f y})
     #endif
     
     static member inline Invoke (x: 'Plus) (y: 'Plus) : 'Plus =

--- a/src/FSharpPlus/Control/Numeric.fs
+++ b/src/FSharpPlus/Control/Numeric.fs
@@ -166,17 +166,17 @@ type Zero with
 #endif
 
 type Zero with
-    static member inline Zero (_: Tuple<'a>, _: Zero) = tuple1 (Zero.Invoke ()) : Tuple<'a>
-    static member inline Zero (_: Id<'a>   , _: Zero) = Id<_>  (Zero.Invoke ())
-    static member inline Zero (_: ValueTuple<'a>, _: Zero) = valueTuple1 (Zero.Invoke ()) : ValueTuple<'a>
-    
+    static member inline Zero (_: Tuple<'a>     , _: Zero) = Tuple<_>      (Zero.Invoke ()) : Tuple<'a>
+    static member inline Zero (_: Id<'a>        , _: Zero) = Id<_>         (Zero.Invoke ())
+    static member inline Zero (_: ValueTuple<'a>, _: Zero) = ValueTuple<_> (Zero.Invoke ()) : ValueTuple<'a>
+
 type Zero with static member inline Zero (_: 'a*'b               , _: Zero) = (Zero.Invoke (), Zero.Invoke ()                                                                                ) : 'a*'b
 type Zero with static member inline Zero (_: 'a*'b*'c            , _: Zero) = (Zero.Invoke (), Zero.Invoke (), Zero.Invoke ()                                                                ) : 'a*'b*'c
 type Zero with static member inline Zero (_: 'a*'b*'c*'d         , _: Zero) = (Zero.Invoke (), Zero.Invoke (), Zero.Invoke (), Zero.Invoke ()                                                ) : 'a*'b*'c*'d
 type Zero with static member inline Zero (_: 'a*'b*'c*'d*'e      , _: Zero) = (Zero.Invoke (), Zero.Invoke (), Zero.Invoke (), Zero.Invoke (), Zero.Invoke ()                                ) : 'a*'b*'c*'d*'e
 type Zero with static member inline Zero (_: 'a*'b*'c*'d*'e*'f   , _: Zero) = (Zero.Invoke (), Zero.Invoke (), Zero.Invoke (), Zero.Invoke (), Zero.Invoke (), Zero.Invoke ()                ) : 'a*'b*'c*'d*'e*'f
 type Zero with static member inline Zero (_: 'a*'b*'c*'d*'e*'f*'g, _: Zero) = (Zero.Invoke (), Zero.Invoke (), Zero.Invoke (), Zero.Invoke (), Zero.Invoke (), Zero.Invoke (), Zero.Invoke ()) : 'a*'b*'c*'d*'e*'f*'g
-    
+
 type Zero with static member inline Zero (_: ValueTuple<'a,'b>               , _: Zero) = ValueTuple.Create (Zero.Invoke (), Zero.Invoke ()                                                                                ) : ValueTuple<'a,'b>
 type Zero with static member inline Zero (_: ValueTuple<'a,'b,'c>            , _: Zero) = ValueTuple.Create (Zero.Invoke (), Zero.Invoke (), Zero.Invoke ()                                                                ) : ValueTuple<'a,'b,'c>
 type Zero with static member inline Zero (_: ValueTuple<'a,'b,'c,'d>         , _: Zero) = ValueTuple.Create (Zero.Invoke (), Zero.Invoke (), Zero.Invoke (), Zero.Invoke ()                                                ) : ValueTuple<'a,'b,'c,'d>
@@ -575,8 +575,8 @@ type MinValue =
         let (t1: 't1) = MinValue.Invoke ()
         Tuple<_,_,_,_,_,_,_,_> (t1, t2, t3, t4, t5, t6, t7, tr) |> retype : 't
 
-    static member inline MinValue (_: Tuple<'a>, _: MinValue) = tuple1 (MinValue.Invoke ()) : Tuple<'a>
-    static member inline MinValue (_: Id<'a>   , _: MinValue) = Id<_>  (MinValue.Invoke ())
+    static member inline MinValue (_: Tuple<'a>, _: MinValue) = Tuple<_> (MinValue.Invoke ()) : Tuple<'a>
+    static member inline MinValue (_: Id<'a>   , _: MinValue) = Id<_>    (MinValue.Invoke ())
 
     static member inline MinValue (_: 'a*'b               , _: MinValue) = (MinValue.Invoke (), MinValue.Invoke ())
     static member inline MinValue (_: 'a*'b*'c            , _: MinValue) = (MinValue.Invoke (), MinValue.Invoke (), MinValue.Invoke ())
@@ -625,8 +625,8 @@ type MaxValue =
         let (t1: 't1) = MaxValue.Invoke ()
         Tuple<_,_,_,_,_,_,_,_> (t1, t2, t3, t4, t5, t6, t7, tr) |> retype : 't
 
-    static member inline MaxValue (_: Tuple<'a>, _: MaxValue) = tuple1 (MaxValue.Invoke ()) : Tuple<'a>
-    static member inline MaxValue (_: Id<'a>   , _: MaxValue) = Id<_>  (MaxValue.Invoke ())
+    static member inline MaxValue (_: Tuple<'a>, _: MaxValue) = Tuple<_> (MaxValue.Invoke ()) : Tuple<'a>
+    static member inline MaxValue (_: Id<'a>   , _: MaxValue) = Id<_>    (MaxValue.Invoke ())
 
     static member inline MaxValue (_: 'a*'b               , _: MaxValue) = (MaxValue.Invoke (), MaxValue.Invoke ())
     static member inline MaxValue (_: 'a*'b*'c            , _: MaxValue) = (MaxValue.Invoke (), MaxValue.Invoke (), MaxValue.Invoke ())

--- a/src/FSharpPlus/Control/Tuple.fs
+++ b/src/FSharpPlus/Control/Tuple.fs
@@ -26,7 +26,7 @@ type MapItem1 =
         let x1 = (^t : (member Item1: 't1) t)
         Tuple<_,_,_,_,_,_,_,_> (fn x1, x2, x3, x4, x5, x6, x7, xr)
 
-    static member MapItem1 ( x: Tuple<_>         , fn) = tuple1 (fn x.Item1)
+    static member MapItem1 ( x: Tuple<_>         , fn) = Tuple<_> (fn x.Item1)
 
     #endif
 
@@ -173,7 +173,7 @@ type Curry =
             let _f _ = Constraints.whenNestedTuple t : ('t1*'t2*'t3*'t4*'t5*'t6*'t7*'tr)
             f (Tuple<'t1,'t2,'t3,'t4,'t5,'t6,'t7,'tr> (t1, t2, t3, t4, t5, t6, t7, tr) |> retype))
     
-    static member Curry (_: Tuple<'t1>        , _: Curry) = fun f t1                   -> f (tuple1 t1)
+    static member Curry (_: Tuple<'t1>        , _: Curry) = fun f t1                   -> f (Tuple<_> t1)
     static member Curry ((_, _)               , _: Curry) = fun f t1 t2                -> f (t1, t2)
     static member Curry ((_, _, _)            , _: Curry) = fun f t1 t2 t3             -> f (t1, t2, t3)
     static member Curry ((_, _, _, _)         , _: Curry) = fun f t1 t2 t3 t4          -> f (t1, t2, t3, t4)

--- a/src/FSharpPlus/Internals.fs
+++ b/src/FSharpPlus/Internals.fs
@@ -38,16 +38,6 @@ module internal Prelude =
         unbox<'U> x
     #endif
 
-    let inline tuple1<'t> (x: 't) =
-        #if FABLE_COMPILER
-        let t = ((),(),(),(),(),(),(),x)
-        t.Rest
-        #else
-        System.Tuple<_> x
-        #endif
-
-    let inline valueTuple1<'T1> (t1: 'T1) = ValueTuple.Create t1
-
 [<RequireQualifiedAccess>]
 module internal Implicit = let inline Invoke (x: ^t) = ((^R or ^t) : (static member op_Implicit : ^t -> ^R) x) : ^R
 

--- a/src/FSharpPlus/Parsing.fs
+++ b/src/FSharpPlus/Parsing.fs
@@ -73,8 +73,8 @@ module Parsing =
             Tuple<_,_,_,_,_,_,_,_> (t1, t2, t3, t4, t5, t6, t7, tr) |> retype : 't
 
         static member inline ParseArray (_: unit                        , _: ParseArray) = fun (_: (string * string) []) -> ()
-        static member inline ParseArray (_: Tuple<'t1>                  , _: ParseArray) = fun (g: (string * string) []) -> tuple1 (parse g.[0]) : Tuple<'t1>
-        static member inline ParseArray (_: Id<'t1>                     , _: ParseArray) = fun (g: (string * string) []) -> Id<_>  (parse g.[0])
+        static member inline ParseArray (_: Tuple<'t1>                  , _: ParseArray) = fun (g: (string * string) []) -> Tuple<_> (parse g.[0]) : Tuple<'t1>
+        static member inline ParseArray (_: Id<'t1>                     , _: ParseArray) = fun (g: (string * string) []) -> Id<_>    (parse g.[0])
         static member inline ParseArray (_: 't1*'t2                     , _: ParseArray) = fun (g: (string * string) []) -> parse g.[0], parse g.[1]
         static member inline ParseArray (_: 't1*'t2'*'t3                , _: ParseArray) = fun (g: (string * string) []) -> parse g.[0], parse g.[1], parse g.[2]
         static member inline ParseArray (_: 't1*'t2'*'t3*'t4            , _: ParseArray) = fun (g: (string * string) []) -> parse g.[0], parse g.[1], parse g.[2], parse g.[3]
@@ -109,8 +109,8 @@ module Parsing =
             | _ -> None
 
         static member inline TryParseArray (_: unit                        , _: TryParseArray) = fun (_: (string * string) []) -> ()
-        static member inline TryParseArray (_: Tuple<'t1>                  , _: TryParseArray) = fun (g: (string * string) []) -> tuple1 <!> tryParseElemAt 0 g : Tuple<'t1> option
-        static member inline TryParseArray (_: Id<'t1>                     , _: TryParseArray) = fun (g: (string * string) []) -> Id<_>  <!> tryParseElemAt 0 g
+        static member inline TryParseArray (_: Tuple<'t1>                  , _: TryParseArray) = fun (g: (string * string) []) -> Tuple<_> <!> tryParseElemAt 0 g : Tuple<'t1> option
+        static member inline TryParseArray (_: Id<'t1>                     , _: TryParseArray) = fun (g: (string * string) []) -> Id<_>    <!> tryParseElemAt 0 g
         static member inline TryParseArray (_: 't1*'t2                     , _: TryParseArray) = fun (g: (string * string) []) -> tuple2 <!> tryParseElemAt 0 g <*> tryParseElemAt 1 g
         static member inline TryParseArray (_: 't1*'t2'*'t3                , _: TryParseArray) = fun (g: (string * string) []) -> tuple3 <!> tryParseElemAt 0 g <*> tryParseElemAt 1 g <*> tryParseElemAt 2 g
         static member inline TryParseArray (_: 't1*'t2'*'t3*'t4            , _: TryParseArray) = fun (g: (string * string) []) -> tuple4 <!> tryParseElemAt 0 g <*> tryParseElemAt 1 g <*> tryParseElemAt 2 g <*> tryParseElemAt 3 g


### PR DESCRIPTION
Fable's helpers for tuple are no longer needed, Fable added direct support shortly after they were added.
There's also a Fable only warning about an upcast.