### PR TITLE
Updates to DList

### DIFF
--- a/src/FSharpPlus/Data/DList.fs
+++ b/src/FSharpPlus/Data/DList.fs
@@ -266,6 +266,20 @@ module DList =
     /// O(n). Returns a seq of the DList elements.
     let inline toSeq (l: DList<'T>) = l :> seq<'T>
 
+    let pairwise (source: DList<'T>) =
+        let (|Cons|Nil|) (l: DList<'T>) = match l.TryUncons with Some (a, b) -> Cons (a, b) | None -> Nil
+        let rec pairWiseDListData cons lastvalue = function
+            | Nil            -> cons
+            | Cons (x, Nil)  -> Join (cons, Unit (lastvalue, x))
+            | Cons (x, rest) -> pairWiseDListData (Join (cons, Unit (lastvalue, x))) x rest
+        let dlistData =
+            match source with
+            | Nil | Cons (_, Nil)        -> Nil
+            | Cons (x, (Cons (y, rest))) -> pairWiseDListData (Unit (x, y)) y rest
+        match source.Length with
+        | 0 -> DList (0, Nil)
+        | _ -> DList (source.Length - 1, dlistData)
+
     // additions to fit F#+ :
     let inline map f (x: DList<_>) = DList.foldBack (cons << f ) x empty
     let concat x = DList.fold append empty x

--- a/src/FSharpPlus/Data/DList.fs
+++ b/src/FSharpPlus/Data/DList.fs
@@ -194,17 +194,11 @@ type DList<'T> (length: int, data: DListData<'T>) =
             | Join (x, y) -> yield! walk (y::rights) x }               
         (walk [] data).GetEnumerator ()
 
-    interface IEnumerable<'T> with
-        member s.GetEnumerator () = s.toSeq ()
-
-    interface IReadOnlyCollection<'T> with
-        member s.Count = s.Length
-
     interface IReadOnlyList<'T> with
         member s.Item with get index = s.Item index
-
-    interface System.Collections.IEnumerable with
-        override s.GetEnumerator () = (s.toSeq () :> System.Collections.IEnumerator)
+        member s.Count = s.Length
+        member s.GetEnumerator () = s.toSeq ()
+        member s.GetEnumerator () = s.toSeq () :> System.Collections.IEnumerator
 
 
 [<RequireQualifiedAccess>]

--- a/src/FSharpPlus/Data/DList.fs
+++ b/src/FSharpPlus/Data/DList.fs
@@ -64,10 +64,11 @@ type DList<'T> (length: int, data: DListData<'T>) =
     // and so is more appropriately implemented under the foldBack signature
     // See http://stackoverflow.com/questions/5324623/functional-o1-append-and-on-iteration-from-first-element-list-data-structure/5334068#5334068
     static member foldBack (f: 'T -> 'State -> 'State) (l: DList<'T>) (state: 'State) =
+        let f = OptimizedClosures.FSharpFunc<_, _, _>.Adapt f
         let rec walk lefts l xs =
             match l with
             | Nil         -> finish lefts xs
-            | Unit x      -> finish lefts <| f x xs
+            | Unit x      -> finish lefts <| f.Invoke (x, xs)
             | Join (x, y) -> walk (x::lefts) y xs
         and finish lefts xs =
             match lefts with

--- a/src/FSharpPlus/Data/DList.fs
+++ b/src/FSharpPlus/Data/DList.fs
@@ -276,6 +276,16 @@ module DList =
         coll.Close ()
     #endif
 
+    /// Returns an array of the DList elements.
+    let toArray (source: DList<'T>) =
+    #if FABLE_COMPILER
+        source :> seq<'T> |> Seq.toArray
+    #else
+        let mutable coll = new ArrayCollector<_> ()
+        iter (fun x -> coll.Add x) source
+        coll.Close ()
+    #endif
+
     /// O(n). Returns a seq of the DList elements.
     let inline toSeq (l: DList<'T>) = l :> seq<'T>
 

--- a/src/FSharpPlus/Data/DList.fs
+++ b/src/FSharpPlus/Data/DList.fs
@@ -206,7 +206,7 @@ type DList<'T> (length: int, data: DListData<'T>) =
         override s.GetEnumerator () = (s.toSeq () :> System.Collections.IEnumerator)
 
 
-[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+[<RequireQualifiedAccess>]
 module DList =
     /// O(1). Returns a new DList of two lists.
     let append left right = DList<'T>.appendLists (left, right)

--- a/src/FSharpPlus/Data/DList.fs
+++ b/src/FSharpPlus/Data/DList.fs
@@ -49,7 +49,7 @@ type DList<'T> (length: int, data: DListData<'T>) =
     /// O(1). Returns the count of elememts.
     member _.Length = length
 
-    // O(n). FoldBack walks the DList using constant stack space. Implementation is from Norman Ramsey.
+    // O(2n). FoldBack walks the DList using constant stack space. Implementation is from Norman Ramsey.
     // Called a "fold" in the article processes the linear representation from right to left
     // and so is more appropriately implemented under the foldBack signature
     // See http://stackoverflow.com/questions/5324623/functional-o1-append-and-on-iteration-from-first-element-list-data-structure/5334068#5334068
@@ -212,8 +212,7 @@ module DList =
     [<GeneralizableValue>]
     let empty<'T> : DList<'T> = DList(0, Nil)
 
-    /// O(n). Fold walks the DList using constant stack space. Implementation is from Norman Ramsey.
-    /// See http://stackoverflow.com/questions/5324623/functional-o1-append-and-on-iteration-from-first-element-list-data-structure/5334068#5334068
+    /// Fold walks the DList using constant stack space.
     let foldBack (f: 'T -> 'State -> 'State) (l: DList<'T>) (state: 'State) = DList<'T>.foldBack f l state
 
     let fold (f: 'State -> 'T -> 'State) (state: 'State) (l: DList<'T>) = DList<'T>.fold f state l
@@ -248,7 +247,7 @@ module DList =
     /// O(log n). Returns option first element and tail.
     let inline tryUncons (l: DList<'T>) = l.TryUncons
 
-    /// O(n). Returns a DList of the seq.
+    /// Returns a DList of the seq.
     let ofSeq s = DList<'T>.ofSeq s
 
     /// Iterates over each element of the list.
@@ -286,7 +285,7 @@ module DList =
         coll.Close ()
     #endif
 
-    /// O(n). Returns a seq of the DList elements.
+    /// Returns a seq of the DList elements.
     let inline toSeq (l: DList<'T>) = l :> seq<'T>
 
     let pairwise (source: DList<'T>) =


### PR DESCRIPTION
This code is a bit old and is claiming for some attention.
Also it's important to note there are some false statements in the comments: walking the DList is not O(n) but O(2n).
The advantage of DList is that it can add and also append lists in O(1), whereas append for other collections is slower.
