### PR TITLE
Add "map squared" pipe operators

### DIFF
--- a/src/FSharpPlus/Operators.fs
+++ b/src/FSharpPlus/Operators.fs
@@ -144,6 +144,19 @@ module Operators =
     let inline (|>>) (x: '``Functor<'T>``) (f: 'T->'U) : '``Functor<'U>`` = Map.Invoke f x
 
     /// <summary>
+    /// Lifts a function into two Functors.
+    /// To be used in pipe-forward style expressions
+    /// </summary>
+    /// <category index="1">Functor</category>
+    let inline (|>>>) (x: '``Functor1<Functor2<'T>>``) (f: 'T -> 'U) : '``Functor1<Functor2<'U>>`` = (Map.Invoke >> Map.Invoke) f x
+
+    /// <summary>
+    /// Lifts a function into two Functors.
+    /// </summary>
+    /// <category index="1">Functor</category>
+    let inline (<<<|) (f: 'T -> 'U) (x: '``Functor1<Functor2<'T>>``) : '``Functor1<Functor2<'U>`` = (Map.Invoke >> Map.Invoke) f x
+
+    /// <summary>
     /// Like map but ignoring the results.
     /// </summary>
     /// <category index="1">Functor</category>

--- a/tests/FSharpPlus.Tests/General.fs
+++ b/tests/FSharpPlus.Tests/General.fs
@@ -397,6 +397,13 @@ module Functor =
         areEqual 2 (testVal10 |> Async.RunSynchronously)
 
     [<Test>]
+    let mapSquared () =
+        let x =
+            [Some 1; Some 2]
+            |>>> string
+        Assert.AreEqual ([Some "1"; Some "2"], x)    
+    
+    [<Test>]
     let unzip () = 
         let testVal = unzip {Head = (1, 'a'); Tail = [(2, 'b');(3, 'b')]}
         Assert.IsInstanceOf<Option<NonEmptyList<int> * NonEmptyList<char>>> (Some testVal)


### PR DESCRIPTION
This is related to #215 

After many years using F#+ with Functors, Applicatives and Monads found out that:

- Monadic code tends to read better in CEs
- Applicative code used to read good with applicative operators but since the addition of CEs for applicatives this is becoming the default to go
- Functors on the other side reads good with pipes, either by using `|> map` (or qualified map for better type inference) or by using `|>>`.

When it comes to composed effects we have Monad transformers which are not that great IMHO but it's the best we have so far to compose them, so we can keep writing then as CEs.

For applicatives the situation is much better as although they can be easily composed with `Compose` we can take advantage of `applicative2` and `applicative3` CEs.

Now the missing piece seems to be Functors, right now for piping composed Functors I normally use something like
`|>> map ..` (or qualified) which doesn't read bad, type inference is quite good usually but I feel like we should support `|>>>` to allow that option, plus eventually we can use `|>>> map` for 3-layered Functors, at least until we decide to add `|>>>>`.

For more information, I find a lot of composed functors in the wild, namely stuff like `Task<Result< >>`  which I see many developers using custom CEs for it, but most of the time it doesn't need it as it's code that can be piped.



