### PR TITLE
Add (and use internally) Async.Await

### DIFF
--- a/src/FSharpPlus/Extensions/Async.fs
+++ b/src/FSharpPlus/Extensions/Async.fs
@@ -4,7 +4,7 @@ namespace FSharpPlus
 [<RequireQualifiedAccess>]
 module Async =
 
-    open System
+    open FSharpPlus.Extensions
 
     /// <summary>Creates an async workflow from another workflow 'x', mapping its result with 'f'.</summary>
     let map f x = async.Bind (x, async.Return << f)
@@ -43,8 +43,8 @@ module Async =
         let! ct = Async.CancellationToken
         let x = Async.StartImmediateAsTask (x, ct)
         let y = Async.StartImmediateAsTask (y, ct)
-        let! x' = Async.AwaitTask x
-        let! y' = Async.AwaitTask y
+        let! x' = Async.Await x
+        let! y' = Async.Await y
         return f x' y' }
     #endif
 
@@ -62,9 +62,9 @@ module Async =
         let x = Async.StartImmediateAsTask (x, ct)
         let y = Async.StartImmediateAsTask (y, ct)
         let z = Async.StartImmediateAsTask (z, ct)
-        let! x' = Async.AwaitTask x
-        let! y' = Async.AwaitTask y
-        let! z' = Async.AwaitTask z
+        let! x' = Async.Await x
+        let! y' = Async.Await y
+        let! z' = Async.Await z
         return f x' y' z' }
     #endif
 
@@ -83,8 +83,8 @@ module Async =
         let! ct = Async.CancellationToken
         let x = Async.StartImmediateAsTask (x, ct)
         let y = Async.StartImmediateAsTask (y, ct)
-        let! x' = Async.AwaitTask x
-        let! y' = Async.AwaitTask y
+        let! x' = Async.Await x
+        let! y' = Async.Await y
         return x', y' }
     #endif
 

--- a/src/FSharpPlus/Extensions/AsyncEnumerable.fs
+++ b/src/FSharpPlus/Extensions/AsyncEnumerable.fs
@@ -6,6 +6,7 @@ open System
 open System.Threading
 open System.Threading.Tasks
 open FSharpPlus.Data
+open FSharpPlus.Extensions
 
 /// Additional operations on Observable<'T>
 [<RequireQualifiedAccess>]
@@ -17,11 +18,11 @@ module AsyncEnumerable =
         use _ =
             { new IDisposable with
                 member _.Dispose () =
-                    e.DisposeAsync().AsTask () |> Async.AwaitTask |> Async.RunSynchronously }
+                    e.DisposeAsync().AsTask () |> Async.Await |> Async.RunSynchronously }
 
         let mutable currentResult = true
         while currentResult do
-            let! r = e.MoveNextAsync().AsTask () |> Async.AwaitTask |> SeqT.lift
+            let! r = e.MoveNextAsync().AsTask () |> Async.Await |> SeqT.lift
             currentResult <- r
             if r then yield e.Current
     }

--- a/src/FSharpPlus/FSharpPlus.fsproj
+++ b/src/FSharpPlus/FSharpPlus.fsproj
@@ -54,8 +54,8 @@
     <Compile Include="Extensions/Enumerator.fs" />
     <Compile Include="Extensions/Task.fs" />
     <Compile Include="Extensions/ValueTask.fs" />
-    <Compile Include="Extensions/Async.fs" />
     <Compile Include="Extensions/Extensions.fs" />
+    <Compile Include="Extensions/Async.fs" />
     <Compile Include="Extensions/Tuple.fs" />
     <Compile Include="Extensions/ValueTuple.fs" />
     <Compile Include="Data/NonEmptySeq.fs" />


### PR DESCRIPTION
This is Eirik Tsarpalis `Async.AwaitTaskCorrect` [implementation](https://www.fssnip.net/7Rc/title/AsyncAwaitTaskCorrect).

It's likely to be [included in FSharp.Core](https://github.com/fsharp/fslang-suggestions/issues/840) in the near future, but we need it now