### PR TITLE
Ensure proper 'zip-applicative' behavior for async computations

### DIFF
--- a/src/FSharpPlus/Control/Comonad.fs
+++ b/src/FSharpPlus/Control/Comonad.fs
@@ -5,17 +5,18 @@ open System.Runtime.InteropServices
 open System.Threading.Tasks
 
 open FSharpPlus
+open FSharpPlus.Extensions
 open FSharpPlus.Internals
 #if !FABLE_COMPILER4
 
 // Comonad class ----------------------------------------------------------
 
 type Extract =
-    static member        Extract (x: Async<'T>    ) =
+    static member        Extract (x: Async<'T>) =
     #if FABLE_COMPILER_3 || FABLE_COMPILER_4
         Async.RunSynchronously x
     #else
-        Async.StartImmediateAsTask(x).Result
+        Async.AsTask(x).Result
     #endif
     static member        Extract (x: Lazy<'T>     ) = x.Value
     static member        Extract ((_: 'W, a: 'T)  ) = a

--- a/src/FSharpPlus/Control/Functor.fs
+++ b/src/FSharpPlus/Control/Functor.fs
@@ -11,6 +11,7 @@ open Microsoft.FSharp.Quotations
 open FSharpPlus.Internals
 open FSharpPlus.Internals.Prelude
 open FSharpPlus
+open FSharpPlus.Extensions
 open FSharpPlus.Data
 
 #if (!FABLE_COMPILER || FABLE_COMPILER_3) && ! FABLE_COMPILER_4
@@ -21,7 +22,7 @@ type Iterate =
     static member Iterate (x: Lazy<'T>   , action) = action x.Value : unit
     static member Iterate (x: seq<'T>    , action) = Seq.iter action x
     static member Iterate (x: option<'T> , action) = match x with Some x -> action x | _ -> ()
-    static member Iterate (x: voption<'T> , action) = match x with ValueSome x -> action x | _ -> ()
+    static member Iterate (x: voption<'T>, action) = match x with ValueSome x -> action x | _ -> ()
     static member Iterate (x: list<'T>   , action) = List.iter action x
     static member Iterate ((_: 'W, a: 'T), action) = action a :unit
     static member Iterate (x: 'T []      , action) = Array.iter   action x
@@ -35,10 +36,10 @@ type Iterate =
                                 for l = 0 to Array4D.length4 x - 1 do
                                     action x.[i,j,k,l]
     #endif
-    #if !FABLE_COMPILER
+    #if FABLE_COMPILER
     static member Iterate (x: Async<'T>            , action) = action (Async.RunSynchronously x) : unit
     #else
-    static member Iterate (x: Async<'T>            , action) = action (x |> Async.Ignore |> Async.StartImmediate) : unit
+    static member Iterate (x: Async<'T>            , action: 'T -> unit) = (x |> Async.map action |> Async.AsTask).Wait ()
     #endif
     static member Iterate (x: Result<'T, 'E>       , action) = match x with Ok x         -> action x | _ -> ()
     static member Iterate (x: Choice<'T, 'E>       , action) = match x with Choice1Of2 x -> action x | _ -> ()

--- a/src/FSharpPlus/Control/Monoid.fs
+++ b/src/FSharpPlus/Control/Monoid.fs
@@ -31,11 +31,8 @@ type Plus =
     #if !FABLE_COMPILER
     static member        ``+`` (x: StringBuilder     , y: StringBuilder     , [<Optional>]_mthd: Plus    ) = StringBuilder().Append(x).Append(y)
     static member        ``+`` (_: Id0               , _: Id0               , [<Optional>]_mthd: Plus    ) = Id0 ""    
-    static member        ``+`` (x: AggregateException, y: AggregateException, [<Optional>]_mthd: Plus    ) = new AggregateException (seq {yield! x.InnerExceptions; yield! y.InnerExceptions})
-    static member        ``+`` (x: exn               , y: exn               , [<Optional>]_mthd: Plus    ) =
-        let f (e: exn) = match e with :? AggregateException as a -> a.InnerExceptions :> seq<_> | _ -> Seq.singleton e
-        let left = f x
-        new AggregateException (seq { yield! left; yield! Seq.except left (f y) }) :> exn
+    static member        ``+`` (x: AggregateException, y: AggregateException, [<Optional>]_mthd: Plus    ) = Exception.add x y
+    static member        ``+`` (x: exn               , y: exn               , [<Optional>]_mthd: Plus    ) = Exception.add x y :> exn
     #else
     static member        ``+`` (x: StringBuilder     , y: StringBuilder     , [<Optional>]_mthd: Plus    ) = StringBuilder().Append(string x).Append(string y)
     static member        ``+`` (_: Id0               , _: Id0               , [<Optional>]_mthd: Plus    ) = Id0 ""

--- a/src/FSharpPlus/Control/Traversable.fs
+++ b/src/FSharpPlus/Control/Traversable.fs
@@ -89,7 +89,7 @@ type Traverse =
         return seq {
             use enum = t.GetEnumerator ()
             while enum.MoveNext() do
-                yield Async.RunSynchronously (f enum.Current, cancellationToken = ct) }}
+                yield Async.AsTask(f enum.Current, cancellationToken = ct).Result }}
     #endif
 
     #if !FABLE_COMPILER
@@ -102,7 +102,7 @@ type Traverse =
         return seq {
             use enum = t.GetEnumerator ()
             while enum.MoveNext() do
-                yield Async.RunSynchronously (f enum.Current, cancellationToken = ct) } |> NonEmptySeq.unsafeOfSeq }
+                yield Async.AsTask(f enum.Current, cancellationToken = ct).Result } |> NonEmptySeq.unsafeOfSeq }
     #endif
     
     static member Traverse (t: Id<'t>, f: 't -> option<'u>, [<Optional>]_output: option<Id<'u>>, [<Optional>]_impl: Traverse) =
@@ -332,7 +332,7 @@ type Gather =
         return seq {
             use enum = t.GetEnumerator ()
             while enum.MoveNext() do
-                yield Async.RunSynchronously (f enum.Current, cancellationToken = ct) }}
+                yield Async.AsTask(f enum.Current, cancellationToken = ct).Result }}
     #endif
 
     #if !FABLE_COMPILER
@@ -345,7 +345,7 @@ type Gather =
         return seq {
             use enum = t.GetEnumerator ()
             while enum.MoveNext() do
-                yield Async.RunSynchronously (f enum.Current, cancellationToken = ct) } |> NonEmptySeq.unsafeOfSeq }
+                yield Async.AsTask(f enum.Current, cancellationToken = ct).Result } |> NonEmptySeq.unsafeOfSeq }
     #endif
     
     static member Gather (t: Id<'t>, f: 't -> option<'u>, [<Optional>]_output: option<Id<'u>>, [<Optional>]_impl: Gather) =

--- a/src/FSharpPlus/Extensions/Async.fs
+++ b/src/FSharpPlus/Extensions/Async.fs
@@ -4,6 +4,23 @@ namespace FSharpPlus
 [<RequireQualifiedAccess>]
 module Async =
 
+    open System
+    open System.Threading.Tasks
+    
+    #if !FABLE_COMPILER
+    // Proper Async.StartImmediateAsTask implementation, without aggregate exception wrapping.
+    let private startImmediateAsTask (computation: Async<'T>, cancellationToken) : Task<'T> =        
+        let ts = TaskCompletionSource<'T> ()
+        Async.StartWithContinuations (
+            computation,
+            ts.SetResult,
+            (function
+                | :? AggregateException as agg -> ts.SetException agg.InnerExceptions
+                | exn -> ts.SetException exn),
+            (fun _ -> ts.SetCanceled ()),
+            cancellationToken)
+        ts.Task
+    #endif
     open FSharpPlus.Extensions
 
     /// <summary>Creates an async workflow from another workflow 'x', mapping its result with 'f'.</summary>
@@ -31,62 +48,61 @@ module Async =
         let! c = z
         return f a b c}
 
-    /// <summary>Creates an async workflow from two workflows 'x' and 'y', mapping its results with 'f'.</summary>
-    /// <remarks>Similar to lift2 but although workflows are started in sequence they might end independently in different order.</remarks>
-    /// <param name="f">The mapping function.</param>
-    /// <param name="x">First async workflow.</param>
-    /// <param name="y">Second async workflow.</param>
+    /// <summary>Creates an async workflow from two workflows, mapping its results with a specified function.</summary>
+    /// <remarks>Similar to lift2 but although workflows are started in sequence they might end independently in different order
+    /// and all errors are collected.
+    /// </remarks>
+    /// <param name="mapper">The mapping function.</param>
+    /// <param name="async1">First async workflow.</param>
+    /// <param name="async2">Second async workflow.</param>
     #if FABLE_COMPILER
-    let map2 f x y = lift2 f x y
+    let map2 mapper (async1: Async<'T1>) (async2: Async<'T2>) : Async<'U> =
+        lift2 mapper async1 async2
     #else
-    let map2 f x y = async {
+    let map2 mapper (async1: Async<'T1>) (async2: Async<'T2>) : Async<'U> = async {
         let! ct = Async.CancellationToken
-        let x = Async.StartImmediateAsTask (x, ct)
-        let y = Async.StartImmediateAsTask (y, ct)
-        let! x' = Async.Await x
-        let! y' = Async.Await y
-        return f x' y' }
+        let t1 = startImmediateAsTask (async1, ct)
+        let t2 = startImmediateAsTask (async2, ct)
+        return! Async.Await (Task.map2 mapper t1 t2) }
     #endif
 
-    /// <summary>Creates an async workflow from three workflows 'x', 'y' and 'z', mapping its results with 'f'.</summary>
-    /// <remarks>Similar to lift3 but although workflows are started in sequence they might end independently in different order.</remarks>
-    /// <param name="f">The mapping function.</param>
-    /// <param name="x">First async workflow.</param>
-    /// <param name="y">Second async workflow.</param>
-    /// <param name="z">third async workflow.</param>
+    /// <summary>Creates an async workflow from three workflows, mapping its results with a specified function.</summary>
+    /// <remarks>Similar to lift3 but although workflows are started in sequence they might end independently in different order
+    /// and all errors are collected.
+    /// </remarks>
+    /// <param name="mapper">The mapping function.</param>
+    /// <param name="async1">First async workflow.</param>
+    /// <param name="async2">Second async workflow.</param>
+    /// <param name="async3">third async workflow.</param>
     #if FABLE_COMPILER
-    let map3 f x y z = lift3 f x y z
+    let map3 mapper (async1: Async<'T1>) (async2: Async<'T2>) (async3: Async<'T3>) : Async<'U> =
+        lift3 mapper async1 async2 async3
     #else
-    let map3 f x y z = async {
+    let map3 mapper (async1: Async<'T1>) (async2: Async<'T2>) (async3: Async<'T3>) : Async<'U> = async {
         let! ct = Async.CancellationToken
-        let x = Async.StartImmediateAsTask (x, ct)
-        let y = Async.StartImmediateAsTask (y, ct)
-        let z = Async.StartImmediateAsTask (z, ct)
-        let! x' = Async.Await x
-        let! y' = Async.Await y
-        let! z' = Async.Await z
-        return f x' y' z' }
+        let t1 = startImmediateAsTask (async1, ct)
+        let t2 = startImmediateAsTask (async2, ct)
+        let t3 = startImmediateAsTask (async3, ct)
+        return! Async.Await (Task.map3 mapper t1 t2 t3) }
     #endif
 
     /// <summary>Creates an async workflow from two workflows 'x' and 'y', tupling its results.</summary>
     let zipSequentially x y = async {
         let! a = x
         let! b = y
-        return a, b}
+        return a, b }
 
-    /// <summary>Creates an async workflow from two workflows 'x' and 'y', tupling its results.</summary>
-    /// <remarks>Similar to zipSequentially but although workflows are started in sequence they might end independently in different order.</remarks>
-    #if FABLE_COMPILER
-    let zip x y = zipSequentially x y
-    #else
-    let zip x y = async {
-        let! ct = Async.CancellationToken
-        let x = Async.StartImmediateAsTask (x, ct)
-        let y = Async.StartImmediateAsTask (y, ct)
-        let! x' = Async.Await x
-        let! y' = Async.Await y
-        return x', y' }
-    #endif
+    /// <summary>Creates an async workflow from two workflows, tupling its results.</summary>
+    /// <remarks>Similar to zipSequentially but although workflows are started in sequence they might end independently in different order
+    /// and all errors are collected.
+    /// </remarks>
+    let zip (async1: Async<'T1>) (async2: Async<'T2>) = map2 (fun x y -> x, y) async1 async2
+
+    /// <summary>Creates an async workflow from three workflows, tupling its results.</summary>
+    /// <remarks>Similar to zipSequentially but although workflows are started in sequence they might end independently in different order
+    /// and all errors are collected.
+    /// </remarks>
+    let zip3 (async1: Async<'T1>) (async2: Async<'T2>) (async3: Async<'T3>) = map3 (fun x y z -> x, y, z) async1 async2 async3
 
     /// Flatten two nested asyncs into one.
     let join x = async.Bind (x, id)

--- a/src/FSharpPlus/Extensions/AsyncEnumerable.fs
+++ b/src/FSharpPlus/Extensions/AsyncEnumerable.fs
@@ -15,10 +15,7 @@ module AsyncEnumerable =
     let toAsyncSeq (source: Collections.Generic.IAsyncEnumerable<_>) : SeqT<Async<_>, _> = monad.plus {
         let! ct = SeqT.lift Async.CancellationToken
         let e = source.GetAsyncEnumerator ct
-        use _ =
-            { new IDisposable with
-                member _.Dispose () =
-                    e.DisposeAsync().AsTask () |> Async.Await |> Async.RunSynchronously }
+        use _ = { new IDisposable with member _.Dispose () = e.DisposeAsync().AsTask().Wait () }
 
         let mutable currentResult = true
         while currentResult do

--- a/src/FSharpPlus/Extensions/Exception.fs
+++ b/src/FSharpPlus/Extensions/Exception.fs
@@ -1,0 +1,30 @@
+﻿namespace FSharpPlus
+
+/// Additional operations on Exception
+[<RequireQualifiedAccess>]
+module Exception =
+    open System
+    open System.Runtime.ExceptionServices
+    open FSharpPlus.Internals.Errors
+    
+    #if !FABLE_COMPILER
+
+    /// Throws the given exception with its original stacktrace.
+    let inline rethrow<'T> (exn: exn) =
+        raiseIfNull (nameof exn) exn
+        (ExceptionDispatchInfo.Capture exn).Throw ()
+        Unchecked.defaultof<'T>    
+    
+    /// Combines exceptions from 2 exceptions into a single AggregateException.
+    /// Exceptions already present in the first argument won't be added.
+    let add (exn1: exn) (exn2: exn) =
+        raiseIfNull (nameof exn1) exn1
+        raiseIfNull (nameof exn2) exn2
+        let f (e: exn) =
+            match e with
+            :? AggregateException as a -> a.InnerExceptions :> seq<_>
+            | _ -> Seq.singleton e
+        let left = f exn1
+        new AggregateException (seq { yield! left; yield! Seq.except left (f exn2) })
+
+    #endif

--- a/src/FSharpPlus/Extensions/Extensions.fs
+++ b/src/FSharpPlus/Extensions/Extensions.fs
@@ -86,13 +86,13 @@ module Extensions =
         /// at the point where the overall async is started.
         /// </remarks>
         static member Await (task: Task<'T>) : Async<'T> =
-            Async.FromContinuations (fun (sc, ec, _) ->
+            Async.FromContinuations (fun (sc, ec, cc) ->
                 task.ContinueWith (fun (task: Task<'T>) ->
                     if task.IsFaulted then
                         let e = task.Exception
                         if e.InnerExceptions.Count = 1 then ec e.InnerExceptions[0]
                         else ec e
-                    elif task.IsCanceled then ec (TaskCanceledException ())
+                    elif task.IsCanceled then cc (TaskCanceledException ())
                     else sc task.Result)
                 |> ignore)
         
@@ -113,13 +113,13 @@ module Extensions =
         /// at the point where the overall async is started.
         /// </remarks>
         static member Await (task: Task) : Async<unit> =
-            Async.FromContinuations (fun (sc, ec, _) ->
+            Async.FromContinuations (fun (sc, ec, cc) ->
                 task.ContinueWith (fun (task: Task) ->
                     if task.IsFaulted then
                         let e = task.Exception
                         if e.InnerExceptions.Count = 1 then ec e.InnerExceptions[0]
                         else ec e
-                    elif task.IsCanceled then ec (TaskCanceledException ())
+                    elif task.IsCanceled then cc (TaskCanceledException ())
                     else sc ())
                 |> ignore)
 

--- a/src/FSharpPlus/Extensions/IReadOnlyCollection.fs
+++ b/src/FSharpPlus/Extensions/IReadOnlyCollection.fs
@@ -5,8 +5,11 @@ namespace FSharpPlus
 module IReadOnlyCollection =
     open System.Collections.Generic
 
+    [<GeneralizableValue>]
+    let empty<'T> = [||]                                  :> IReadOnlyCollection<'T>
     let ofArray (source: 'T[]   ) = source                :> IReadOnlyCollection<'T>
     let ofList  (source: 'T list) = source                :> IReadOnlyCollection<'T>
     let ofSeq   (source: seq<'T>) = source |> Array.ofSeq :> IReadOnlyCollection<'T>
     let map  mapping (source: IReadOnlyCollection<'T>) = Seq.map  mapping source |> Seq.toArray :> IReadOnlyCollection<'U>
     let iter mapping (source: IReadOnlyCollection<'T>) = Seq.iter mapping source
+    let isEmpty (source: IReadOnlyCollection<'T>) = source.Count = 0

--- a/src/FSharpPlus/FSharpPlus.fsproj
+++ b/src/FSharpPlus/FSharpPlus.fsproj
@@ -38,6 +38,7 @@
     <Compile Include="Extensions/Nullable.fs" />
     <Compile Include="Extensions/Result.fs" />
     <Compile Include="Extensions/Choice.fs" />
+    <Compile Include="Extensions/Exception.fs" />
     <Compile Include="Extensions/Seq.fs" />
     <Compile Include="Extensions/IList.fs" />
     <Compile Include="Extensions/List.fs" />

--- a/tests/FSharpPlus.Tests/Asyncs.fs
+++ b/tests/FSharpPlus.Tests/Asyncs.fs
@@ -1,0 +1,112 @@
+﻿namespace FSharpPlus.Tests
+
+#if !NET462 && !NETSTANDARD2_0
+
+module Async =
+
+    open System
+    open System.Threading
+    open System.Threading.Tasks
+    open NUnit.Framework
+    open FSharpPlus
+    open FSharpPlus.Data
+    open FSharpPlus.Extensions
+    open FSharpPlus.Tests.Helpers
+    
+    exception TestException of string
+    
+    type Async with
+        static member StartImmediateAsTaskCorrect (computation: Async<'T>, ?cancellationToken) : Task<'T> =
+            let cancellationToken = defaultArg cancellationToken (new CancellationToken ())
+            let ts = TaskCompletionSource<'T> ()
+            Async.StartWithContinuations (
+                computation,
+                ts.SetResult,
+                (function
+                    | :? AggregateException as agg -> ts.SetException agg.InnerExceptions
+                    | exn -> ts.SetException exn),
+                (fun _ -> ts.SetCanceled ()),
+                cancellationToken)
+            ts.Task
+
+        static member AsTaskAndWait computation =
+            let t = Async.StartImmediateAsTaskCorrect computation
+            Task.WaitAny t |> ignore
+            t
+
+        static member WhenAll (source: Async<'T> seq) = source |> Seq.map (fun x -> Async.StartImmediateAsTaskCorrect x) |> Task.WhenAll |> Async.Await
+
+
+    module AsyncTests =
+
+        let createAsync isFailed delay (value: 'T) =
+            if not isFailed && delay = 0 then async.Return value
+            else
+                async {
+                    if delay = 0 then do! Async.raise (TestException (sprintf "Ouch, can't create: %A" value ))
+                    do! Async.Sleep delay
+                    if isFailed then do! Async.raise (TestException (sprintf "Ouch, can't create: %A" value ))
+                    return value }
+
+
+        [<Test>]
+        let testAsyncZip () =
+            let t1 = createAsync true 0 1
+            let t2 = createAsync true 0 2
+            let t3 = createAsync true 0 3
+
+            let c = new CancellationToken true
+            let t4 = Task.FromCanceled<int> c |> Async.Await
+
+            let t5 = createAsync false 0 5
+            let t6 = createAsync false 0 6
+
+            let t12 =    Async.WhenAll [t1; t2]
+            let t12t12 = Async.WhenAll [t12; t12]
+            let t33    = Async.WhenAll [t3; t3]
+
+            let t12123 = Async.zip3 t12t12 t33 t4
+            let ac1 =
+                try
+                    (t12123 |> Async.AsTaskAndWait).Exception.InnerExceptions |> Seq.map (fun x -> int (Char.GetNumericValue x.Message.[35]))
+                with e ->
+                    failwithf "Failure in testAsyncZip. Async status is %A . Exception is %A" (t12123 |> Async.AsTaskAndWait).Status e
+
+            CollectionAssert.AreEquivalent ([1; 2; 1; 2; 3], ac1, "Async.zip(3) should add only non already existing exceptions.")
+
+            let t13 = Async.zip3 (Async.zip t1 t3) t4 (Async.zip t5 t6)
+            Assert.AreEqual (true, (t13 |> Async.AsTaskAndWait).IsFaulted, "Async.zip(3) between a value, an exception and a cancellation -> exception wins.")
+            let ac2 = (t13 |> Async.AsTaskAndWait).Exception.InnerExceptions |> Seq.map (fun x -> int (Char.GetNumericValue x.Message.[35]))
+            CollectionAssert.AreEquivalent ([1; 3], ac2, "Async.zip between 2 exceptions => both exceptions returned, even after combining with cancellation and values.")
+
+        [<Test>]
+        let testAsyncZipAsync () =
+            let t1 = createAsync true 20 1
+            let t2 = createAsync true 10 2
+            let t3 = createAsync true 30 3
+
+            let c = new CancellationToken true
+            let t4 = Task.FromCanceled<int> c |> Async.Await
+
+            let t5 = createAsync false 20 5
+            let t6 = createAsync false 10 6
+
+            let t12 =    Async.WhenAll [t1; t2]
+            let t12t12 = Async.WhenAll [t12; t12]
+            let t33    = Async.WhenAll [t3; t3]
+
+            let t12123 = Async.zip3 t12t12 t33 t4            
+            let ac1 =
+                try
+                    (t12123 |> Async.AsTaskAndWait).Exception.InnerExceptions |> Seq.map (fun x -> int (Char.GetNumericValue x.Message.[35]))
+                with e ->
+                    failwithf "Failure in testAsyncZipAsync. Async status is %A . Exception is %A" (t12123  |> Async.AsTaskAndWait).Status e
+
+            CollectionAssert.AreEquivalent ([1; 2; 1; 2; 3], ac1, "Async.zip(3)Async should add only non already existing exceptions.")
+
+            let t13 = Async.zip3 (Async.zip t1 t3) t4 (Async.zip t5 t6)
+            Assert.AreEqual (true, (t13 |> Async.AsTaskAndWait).IsFaulted, "Async.zip(3)Async between a value, an exception and a cancellation -> exception wins.")
+            let ac2 = (t13 |> Async.AsTaskAndWait).Exception.InnerExceptions |> Seq.map (fun x -> int (Char.GetNumericValue x.Message.[35]))
+            CollectionAssert.AreEquivalent ([1; 3], ac2, "Async.zipAsync between 2 exceptions => both exceptions returned, even after combining with cancellation and values.")
+     
+#endif

--- a/tests/FSharpPlus.Tests/Asyncs.fs
+++ b/tests/FSharpPlus.Tests/Asyncs.fs
@@ -16,25 +16,12 @@ module Async =
     exception TestException of string
     
     type Async with
-        static member StartImmediateAsTaskCorrect (computation: Async<'T>, ?cancellationToken) : Task<'T> =
-            let cancellationToken = defaultArg cancellationToken (new CancellationToken ())
-            let ts = TaskCompletionSource<'T> ()
-            Async.StartWithContinuations (
-                computation,
-                ts.SetResult,
-                (function
-                    | :? AggregateException as agg -> ts.SetException agg.InnerExceptions
-                    | exn -> ts.SetException exn),
-                (fun _ -> ts.SetCanceled ()),
-                cancellationToken)
-            ts.Task
-
         static member AsTaskAndWait computation =
-            let t = Async.StartImmediateAsTaskCorrect computation
+            let t = Async.AsTask computation
             Task.WaitAny t |> ignore
             t
 
-        static member WhenAll (source: Async<'T> seq) = source |> Seq.map (fun x -> Async.StartImmediateAsTaskCorrect x) |> Task.WhenAll |> Async.Await
+        static member WhenAll (source: Async<'T> seq) = source |> Seq.map (fun x -> Async.AsTask x) |> Task.WhenAll |> Async.Await
 
 
     module AsyncTests =

--- a/tests/FSharpPlus.Tests/FSharpPlus.Tests.fsproj
+++ b/tests/FSharpPlus.Tests/FSharpPlus.Tests.fsproj
@@ -28,6 +28,7 @@
     <Compile Include="Validations.fs" />
     <Compile Include="Task.fs" />
     <Compile Include="ValueTask.fs" />
+    <Compile Include="Asyncs.fs" />
     <Compile Include="Free.fs" />
     <Compile Include="SeqT.fs" />
     <Compile Include="ComputationExpressions.fs" />

--- a/tests/FSharpPlus.Tests/ValueTask.fs
+++ b/tests/FSharpPlus.Tests/ValueTask.fs
@@ -5,6 +5,7 @@
 module ValueTask =
 
     open System
+    open System.Threading
     open System.Threading.Tasks
     open NUnit.Framework
     open FSharpPlus
@@ -13,17 +14,14 @@ module ValueTask =
     
     exception TestException of string
     
+    type ValueTask<'T> with
+        static member WhenAll (source: ValueTask<'T> seq) = source |> Seq.map (fun x -> x.AsTask ()) |> Task.WhenAll |> ValueTask<'T []>
+        static member WaitAny (source: ValueTask<'T>) = source.AsTask () |> Task.WaitAny |> ignore
 
     module ValueTask =
         open System.Threading
 
         // Following is not available in F#6
-
-        /// <summary>Creates a <see cref="ValueTask{TResult}"/> that's completed successfully with the specified result.</summary>
-        /// <typeparam name="TResult">The type of the result returned by the task.</typeparam>
-        /// <param name="result">The result to store into the completed task.</param>
-        /// <returns>The successfully completed task.</returns>
-        let FromResult<'TResult> (result: 'TResult) = ValueTask<'TResult> result
 
         /// <summary>Creates a <see cref="ValueTask{TResult}"/> that's completed exceptionally with the specified exception.</summary>
         /// <typeparam name="TResult">The type of the result returned by the task.</typeparam>
@@ -39,10 +37,14 @@ module ValueTask =
 
     module ValueTaskTests =
 
-        let createValueTask isFailed value =
-            if not isFailed then ValueTask.FromResult<_> value
+        let createValueTask isFailed delay (value: 'T) =
+            if not isFailed && delay = 0 then ValueTask.result value
             else
-                ValueTask.FromException<_> (TestException (sprintf "Ouch, can't create: %A" value ))
+                let tcs = TaskCompletionSource<_> ()
+                if delay = 0 then tcs.SetException (TestException (sprintf "Ouch, can't create: %A" value ))
+                else (Task.Delay delay).ContinueWith (fun _ ->
+                    if isFailed then tcs.SetException (TestException (sprintf "Ouch, can't create: %A" value )) else tcs.SetResult value) |> ignore
+                tcs.Task |> ValueTask<'T>
 
         let (|AggregateException|_|) (x: exn) =
             match x with
@@ -53,9 +55,9 @@ module ValueTask =
         
         [<Test>]
         let shortCircuits () =
-            let x1 = createValueTask false 1
-            let x2 = createValueTask false 2
-            let x3 = createValueTask false 3
+            let x1 = createValueTask false 0 1
+            let x2 = createValueTask false 0 2
+            let x3 = createValueTask false 0 3
 
             let a = ValueTask.map string x1
             require a.IsCompleted "ValueTask.map didn't short-circuit"
@@ -77,11 +79,11 @@ module ValueTask =
         
         [<Test>]
         let erroredValueTasks () =
-            let e1 () = createValueTask true  1
-            let e2 () = createValueTask true  2
-            let e3 () = createValueTask true  3
-            let x1 () = createValueTask false 1
-            let x2 () = createValueTask false 2
+            let e1 () = createValueTask true  0 1
+            let e2 () = createValueTask true  0 2
+            let e3 () = createValueTask true  0 3
+            let x1 () = createValueTask false 0 1
+            let x2 () = createValueTask false 0 2
         
             let mapping  isFailure x     = if isFailure then raise (TestException "I was told to fail") else x
             let mapping2 isFailure x y   = if isFailure then raise (TestException "I was told to fail") else x + y
@@ -94,19 +96,19 @@ module ValueTask =
             let r02 = ValueTask.map (mapping true) (x1 ())
             r02.AsTask().Exception.InnerExceptions |> areEquivalent [TestException "I was told to fail"]
         
-            let r03 = ValueTask.zip (e1 ()) (x2 ())
+            let r03 = ValueTask.zipSequentially (e1 ()) (x2 ())
             r03.AsTask().Exception.InnerExceptions |> areEquivalent [TestException "Ouch, can't create: 1"]
         
-            let r04 = ValueTask.zip (e1 ()) (e2 ())
+            let r04 = ValueTask.zipSequentially (e1 ()) (e2 ())
             r04.AsTask().Exception.InnerExceptions |> areEquivalent [TestException "Ouch, can't create: 1"]
         
-            let r05 = ValueTask.map2 (mapping2 false) (e1 ()) (x2 ())
+            let r05 = ValueTask.lift2 (mapping2 false) (e1 ()) (x2 ())
             r05.AsTask().Exception.InnerExceptions |> areEquivalent [TestException "Ouch, can't create: 1"]
         
-            let r06 = ValueTask.map3 (mapping3 false) (e1 ()) (e2 ()) (e3 ())
+            let r06 = ValueTask.lift3 (mapping3 false) (e1 ()) (e2 ()) (e3 ())
             r06.AsTask().Exception.InnerExceptions |> areEquivalent [TestException "Ouch, can't create: 1"]
             
-            let r07 = ValueTask.map3 (mapping3 false) (x1 ()) (e2 ()) (e3 ())
+            let r07 = ValueTask.lift3 (mapping3 false) (x1 ()) (e2 ()) (e3 ())
             r07.AsTask().Exception.InnerExceptions |> areEquivalent [TestException "Ouch, can't create: 2"]
         
             let r08 = ValueTask.bind (binding true) (e1 ())
@@ -114,5 +116,74 @@ module ValueTask =
         
             let r09 = ValueTask.bind (binding true) (x1 ())
             r09.AsTask().Exception.InnerExceptions |> areEquivalent [TestException "I was told to fail"]
+
+
+        [<Test>]
+        let testValueTaskZip () =
+            let t1 = createValueTask true 0 1
+            let t2 = createValueTask true 0 2
+            let t3 = createValueTask true 0 3
+
+            let c = new CancellationToken true
+            let t4 = ValueTask.FromCanceled<int> c
+
+            let t5 = createValueTask false 0 5
+            let t6 = createValueTask false 0 6
+
+            let t12 =    ValueTask.WhenAll [t1; t2]
+            let t12t12 = ValueTask.WhenAll [t12; t12]
+            let t33    = ValueTask.WhenAll [t3; t3]
+
+            ValueTask.WaitAny t12    |> ignore
+            ValueTask.WaitAny t12t12 |> ignore
+            ValueTask.WaitAny t33    |> ignore
+
+            let t12123 = ValueTask.zip3 t12t12 t33 t4
+            let ac1 =
+                try
+                    (t12123.AsTask ()).Exception.InnerExceptions |> Seq.map (fun x -> int (Char.GetNumericValue x.Message.[35]))
+                with e ->
+                    failwithf "Failure in testValueTaskZip. ValueTask status is %A . Exception is %A" (t12123.AsTask ()).Status e
+
+            CollectionAssert.AreEquivalent ([1; 2; 1; 2; 3], ac1, "ValueTask.zip(3) should add only non already existing exceptions.")
+
+            let t13 = ValueTask.zip3 (ValueTask.zip t1 t3) t4 (ValueTask.zip t5 t6)
+            Assert.AreEqual (true, t13.IsFaulted, "ValueTask.zip(3) between a value, an exception and a cancellation -> exception wins.")
+            let ac2 = (t13.AsTask ()).Exception.InnerExceptions |> Seq.map (fun x -> int (Char.GetNumericValue x.Message.[35]))
+            CollectionAssert.AreEquivalent ([1; 3], ac2, "ValueTask.zip between 2 exceptions => both exceptions returned, even after combining with cancellation and values.")
+
+        [<Test>]
+        let testValueTaskZipAsync () =
+            let t1 = createValueTask true 20 1
+            let t2 = createValueTask true 10 2
+            let t3 = createValueTask true 30 3
+
+            let c = new CancellationToken true
+            let t4 = ValueTask.FromCanceled<int> c
+
+            let t5 = createValueTask false 20 5
+            let t6 = createValueTask false 10 6
+
+            let t12 =    ValueTask.WhenAll [t1; t2]
+            let t12t12 = ValueTask.WhenAll [t12; t12]
+            let t33    = ValueTask.WhenAll [t3; t3]
+
+            ValueTask.WaitAny t12    |> ignore
+            ValueTask.WaitAny t12t12 |> ignore
+            ValueTask.WaitAny t33    |> ignore
+
+            let t12123 = ValueTask.zip3 t12t12 t33 t4            
+            let ac1 =
+                try
+                    (t12123.AsTask ()).Exception.InnerExceptions |> Seq.map (fun x -> int (Char.GetNumericValue x.Message.[35]))
+                with e ->
+                    failwithf "Failure in testValueTaskZipAsync. ValueTask status is %A . Exception is %A" (t12123.AsTask ()).Status e
+
+            CollectionAssert.AreEquivalent ([1; 2; 1; 2; 3], ac1, "ValueTask.zip(3)Async should add only non already existing exceptions.")
+
+            let t13 = ValueTask.zip3 (ValueTask.zip t1 t3) t4 (ValueTask.zip t5 t6)
+            Assert.AreEqual (true, t13.IsFaulted, "ValueTask.zip(3)Async between a value, an exception and a cancellation -> exception wins.")
+            let ac2 = (t13.AsTask ()).Exception.InnerExceptions |> Seq.map (fun x -> int (Char.GetNumericValue x.Message.[35]))
+            CollectionAssert.AreEquivalent ([1; 3], ac2, "ValueTask.zipAsync between 2 exceptions => both exceptions returned, even after combining with cancellation and values.")
      
 #endif


### PR DESCRIPTION
We expect that `computation.zip` accumulates errors, for async, task and valueTask.
While trying to assert it, we realized we need to fix some stuff, including some FSharp.Core functions.
