### PR TITLE
Assert proper non-seq traversals

### DIFF
--- a/src/FSharpPlus/Control/Applicative.fs
+++ b/src/FSharpPlus/Control/Applicative.fs
@@ -29,7 +29,8 @@ type Apply =
     static member        ``<*>`` (struct (f: Task<_>          , x: Task<'T>             ), _output: Task<'U>             , [<Optional>]_mthd: Apply) = Task.apply   f x : Task<'U>
     #endif
     #if !NET45 && !NETSTANDARD2_0 && !FABLE_COMPILER
-    static member        ``<*>`` (struct (f: ValueTask<_>     , x: ValueTask<'T>        ), _output: ValueTask<'U>        , [<Optional>]_mthd: Default2) = ValueTask.apply   f x : ValueTask<'U>
+    static member        ``<*>`` (struct (f: ValueTask<_>     , x: ValueTask<'T>        ), _output: ValueTask<'U>        , [<Optional>]_mthd: Apply) : ValueTask<'U> = ValueTask.apply f x
+    static member        ``<*>`` (struct (_: DmStruct1<_>     , _: DmStruct1<'T>        ), _output: DmStruct1<'U>        , [<Optional>]_mthd: Apply) : DmStruct1<'U> = Unchecked.defaultof<DmStruct1<'U>>
     #endif
     static member        ``<*>`` (struct (f: Async<_>         , x: Async<'T>            ), _output: Async<'U>            , [<Optional>]_mthd: Apply) = Async.apply  f x : Async<'U>
     static member        ``<*>`` (struct (f: option<_>        , x: option<'T>           ), _output: option<'U>           , [<Optional>]_mthd: Apply) = Option.apply f x : option<'U>

--- a/src/FSharpPlus/Control/Comonad.fs
+++ b/src/FSharpPlus/Control/Comonad.fs
@@ -67,7 +67,7 @@ type Extend =
                 tcs.Task
     #endif
 
-    #if (!NET45 && !NETSTANDARD2_0) && !FABLE_COMPILER
+    #if !NET45 && !NETSTANDARD2_0 && !FABLE_COMPILER
     static member        (=>>) (g: ValueTask<'T>     , f: ValueTask<'T> -> 'U ) : ValueTask<'U> =
         if g.IsCompletedSuccessfully then
             try

--- a/src/FSharpPlus/Control/Monad.fs
+++ b/src/FSharpPlus/Control/Monad.fs
@@ -146,6 +146,7 @@ type Return =
     #endif
     #if !NET45 && !NETSTANDARD2_0 && !FABLE_COMPILER
     static member        Return (_: 'T ValueTask   , _: Return  ) = fun (x: 'T) -> ValueTask<'T> x                : 'T ValueTask
+    static member        Return (_: 'T DmStruct1   , _: Return  ) = fun (_: 'T) -> Unchecked.defaultof<_>         : 'T DmStruct1
     #endif
     static member        Return (_: option<'a>     , _: Return  ) = fun x -> Some x                               : option<'a>
     static member        Return (_  : voption<'a>  , _: Return  ) = fun x -> ValueSome x                          : voption<'a>

--- a/src/FSharpPlus/Control/ZipApplicative.fs
+++ b/src/FSharpPlus/Control/ZipApplicative.fs
@@ -38,7 +38,7 @@ type Pure =
     #if !FABLE_COMPILER
     static member        Pure (_: 'T Task         , _: Pure) = fun x -> Task.FromResult x                     : 'T Task
     #endif
-    #if NETSTANDARD2_1 && !FABLE_COMPILER
+    #if !NET45 && !NETSTANDARD2_0 && !FABLE_COMPILER
     static member        Pure (_: 'T ValueTask    , _: Pure) = fun (x: 'T) -> ValueTask<'T> x                 : 'T ValueTask
     #endif
     static member        Pure (x: option<'a>      , _: Pure) = Return.Return (x, Unchecked.defaultof<Return>)
@@ -147,7 +147,7 @@ type Map2 =
     #if !FABLE_COMPILER
     static member        Map2 (f, (x: Task<'T>           , y: Task<'U>           ), _mthd: Map2) = Task.map2 f x y
     #endif
-    #if NETSTANDARD2_1 && !FABLE_COMPILER
+    #if !NET45 && !NETSTANDARD2_0 && !FABLE_COMPILER
     static member        Map2 (f, (x: ValueTask<'T>      , y: ValueTask<'U>      ), _mthd: Map2) = ValueTask.map2 f x y
     #endif
     static member        Map2 (f, (x                     , y                     ), _mthd: Map2) = Async.map2 f x y
@@ -194,7 +194,7 @@ type Map3 =
     #if !FABLE_COMPILER
     static member        Map3 (f, (x: Task<'T>           , y: Task<'U>           , z: Task<'V>            ), _mthd: Map3) = Task.map3 f x y z
     #endif
-    #if NETSTANDARD2_1 && !FABLE_COMPILER
+    #if !NET45 && !NETSTANDARD2_0 && !FABLE_COMPILER
     static member        Map3 (f, (x: ValueTask<'T>      , y: ValueTask<'U>      , z: ValueTask<'V>       ), _mthd: Map3) = ValueTask.map3 f x y z
     #endif
     static member        Map3 (f, (x                     , y                     , z                      ), _mthd: Map3) = Async.map3  f x y z

--- a/src/FSharpPlus/Internals.fs
+++ b/src/FSharpPlus/Internals.fs
@@ -114,6 +114,7 @@ type Either<'t,'u> =
     | Right of 'u
 
 type DmStruct = struct end
+type DmStruct1<'T1> = struct end
 
 type KeyValuePair2<'TKey, 'TValue> = struct
     val Key : 'TKey

--- a/tests/FSharpPlus.Tests/Asyncs.fs
+++ b/tests/FSharpPlus.Tests/Asyncs.fs
@@ -11,7 +11,6 @@ module Async =
     open FSharpPlus
     open FSharpPlus.Data
     open FSharpPlus.Extensions
-    open FSharpPlus.Tests.Helpers
     
     exception TestException of string
     
@@ -21,7 +20,7 @@ module Async =
             Task.WaitAny t |> ignore
             t
 
-        static member WhenAll (source: Async<'T> seq) = source |> Seq.map (fun x -> Async.AsTask x) |> Task.WhenAll |> Async.Await
+        static member WhenAll (source: Async<'T> seq) = source |> Seq.map Async.AsTask |> Task.WhenAll |> Async.Await
 
 
     module AsyncTests =
@@ -55,15 +54,15 @@ module Async =
             let t12123 = Async.zip3 t12t12 t33 t4
             let ac1 =
                 try
-                    (t12123 |> Async.AsTaskAndWait).Exception.InnerExceptions |> Seq.map (fun x -> int (Char.GetNumericValue x.Message.[35]))
+                    Async.AsTaskAndWait(t12123).Exception.InnerExceptions |> Seq.map (fun x -> int (Char.GetNumericValue x.Message.[35]))
                 with e ->
-                    failwithf "Failure in testAsyncZip. Async status is %A . Exception is %A" (t12123 |> Async.AsTaskAndWait).Status e
+                    failwithf "Failure in testAsyncZip. Async status is %A . Exception is %A" (Async.AsTaskAndWait t12123).Status e
 
             CollectionAssert.AreEquivalent ([1; 2; 1; 2; 3], ac1, "Async.zip(3) should add only non already existing exceptions.")
 
             let t13 = Async.zip3 (Async.zip t1 t3) t4 (Async.zip t5 t6)
-            Assert.AreEqual (true, (t13 |> Async.AsTaskAndWait).IsFaulted, "Async.zip(3) between a value, an exception and a cancellation -> exception wins.")
-            let ac2 = (t13 |> Async.AsTaskAndWait).Exception.InnerExceptions |> Seq.map (fun x -> int (Char.GetNumericValue x.Message.[35]))
+            Assert.AreEqual (true, Async.AsTaskAndWait(t13).IsFaulted, "Async.zip(3) between a value, an exception and a cancellation -> exception wins.")
+            let ac2 = Async.AsTaskAndWait(t13).Exception.InnerExceptions |> Seq.map (fun x -> int (Char.GetNumericValue x.Message.[35]))
             CollectionAssert.AreEquivalent ([1; 3], ac2, "Async.zip between 2 exceptions => both exceptions returned, even after combining with cancellation and values.")
 
         [<Test>]
@@ -85,15 +84,15 @@ module Async =
             let t12123 = Async.zip3 t12t12 t33 t4            
             let ac1 =
                 try
-                    (t12123 |> Async.AsTaskAndWait).Exception.InnerExceptions |> Seq.map (fun x -> int (Char.GetNumericValue x.Message.[35]))
+                    Async.AsTaskAndWait(t12123).Exception.InnerExceptions |> Seq.map (fun x -> int (Char.GetNumericValue x.Message.[35]))
                 with e ->
-                    failwithf "Failure in testAsyncZipAsync. Async status is %A . Exception is %A" (t12123  |> Async.AsTaskAndWait).Status e
+                    failwithf "Failure in testAsyncZipAsync. Async status is %A . Exception is %A" (Async.AsTaskAndWait t12123).Status e
 
             CollectionAssert.AreEquivalent ([1; 2; 1; 2; 3], ac1, "Async.zip(3)Async should add only non already existing exceptions.")
 
             let t13 = Async.zip3 (Async.zip t1 t3) t4 (Async.zip t5 t6)
-            Assert.AreEqual (true, (t13 |> Async.AsTaskAndWait).IsFaulted, "Async.zip(3)Async between a value, an exception and a cancellation -> exception wins.")
-            let ac2 = (t13 |> Async.AsTaskAndWait).Exception.InnerExceptions |> Seq.map (fun x -> int (Char.GetNumericValue x.Message.[35]))
+            Assert.AreEqual (true, Async.AsTaskAndWait(t13).IsFaulted, "Async.zip(3)Async between a value, an exception and a cancellation -> exception wins.")
+            let ac2 = Async.AsTaskAndWait(t13).Exception.InnerExceptions |> Seq.map (fun x -> int (Char.GetNumericValue x.Message.[35]))
             CollectionAssert.AreEquivalent ([1; 3], ac2, "Async.zipAsync between 2 exceptions => both exceptions returned, even after combining with cancellation and values.")
      
         [<Test>]

--- a/tests/FSharpPlus.Tests/Asyncs.fs
+++ b/tests/FSharpPlus.Tests/Asyncs.fs
@@ -104,7 +104,7 @@ module Async =
 
             let t123 = Async.map3 (fun x y z -> [x; y; z]) t1 t2 t3
             let t123' = transpose [t1; t2; t3]
-            let t123'' = sequence [t1; t2; t3]
+            let t123'' = sequence [t1; t2; t3] : Async<int list>
             CollectionAssert.AreEquivalent ((Async.AsTaskAndWait t123).Exception.InnerExceptions, (Async.AsTaskAndWait t123').Exception.InnerExceptions, "Async.map3 (fun x y z -> [x; y; z]) t1 t2 t3 is the same as transpose [t1; t2; t3]")
             CollectionAssert.AreNotEquivalent ((Async.AsTaskAndWait t123).Exception.InnerExceptions, (Async.AsTaskAndWait t123'').Exception.InnerExceptions, "Async.map3 (fun x y z -> [x; y; z]) t1 t2 t3 is not the same as sequence [t1; t2; t3]")
 

--- a/tests/FSharpPlus.Tests/Asyncs.fs
+++ b/tests/FSharpPlus.Tests/Asyncs.fs
@@ -96,4 +96,16 @@ module Async =
             let ac2 = (t13 |> Async.AsTaskAndWait).Exception.InnerExceptions |> Seq.map (fun x -> int (Char.GetNumericValue x.Message.[35]))
             CollectionAssert.AreEquivalent ([1; 3], ac2, "Async.zipAsync between 2 exceptions => both exceptions returned, even after combining with cancellation and values.")
      
+        [<Test>]
+        let testAsyncTraversals =
+            let t1 = createAsync true  20 1
+            let t2 = createAsync true  10 2
+            let t3 = createAsync false 30 3
+
+            let t123 = Async.map3 (fun x y z -> [x; y; z]) t1 t2 t3
+            let t123' = transpose [t1; t2; t3]
+            let t123'' = sequence [t1; t2; t3]
+            CollectionAssert.AreEquivalent ((Async.AsTaskAndWait t123).Exception.InnerExceptions, (Async.AsTaskAndWait t123').Exception.InnerExceptions, "Async.map3 (fun x y z -> [x; y; z]) t1 t2 t3 is the same as transpose [t1; t2; t3]")
+            CollectionAssert.AreNotEquivalent ((Async.AsTaskAndWait t123).Exception.InnerExceptions, (Async.AsTaskAndWait t123'').Exception.InnerExceptions, "Async.map3 (fun x y z -> [x; y; z]) t1 t2 t3 is not the same as sequence [t1; t2; t3]")
+
 #endif

--- a/tests/FSharpPlus.Tests/Task.fs
+++ b/tests/FSharpPlus.Tests/Task.fs
@@ -235,7 +235,7 @@ module Task =
 
             let t123 = Task.map3 (fun x y z -> [x; y; z]) t1 t2 t3
             let t123' = transpose [t1; t2; t3]
-            let t123'' = sequence [t1; t2; t3]            
+            let t123'' = sequence [t1; t2; t3]
             CollectionAssert.AreEquivalent (t123.Exception.InnerExceptions, t123'.Exception.InnerExceptions, "Task.map3 (fun x y z -> [x; y; z]) t1 t2 t3 is the same as transpose [t1; t2; t3]")
             CollectionAssert.AreNotEquivalent (t123.Exception.InnerExceptions, t123''.Exception.InnerExceptions, "Task.map3 (fun x y z -> [x; y; z]) t1 t2 t3 is not the same as sequence [t1; t2; t3]")
 

--- a/tests/FSharpPlus.Tests/Task.fs
+++ b/tests/FSharpPlus.Tests/Task.fs
@@ -227,6 +227,18 @@ module Task =
             let ac2 = t13.Exception.InnerExceptions |> Seq.map (fun x -> int (Char.GetNumericValue x.Message.[35]))
             CollectionAssert.AreEquivalent ([1; 3], ac2, "Task.zipAsync between 2 exceptions => both exceptions returned, even after combining with cancellation and values.")
 
+        [<Test>]
+        let testTaskTraversals =
+            let t1 = createTask true  20 1
+            let t2 = createTask true  10 2
+            let t3 = createTask false 30 3
+
+            let t123 = Task.map3 (fun x y z -> [x; y; z]) t1 t2 t3
+            let t123' = transpose [t1; t2; t3]
+            let t123'' = sequence [t1; t2; t3]            
+            CollectionAssert.AreEquivalent (t123.Exception.InnerExceptions, t123'.Exception.InnerExceptions, "Task.map3 (fun x y z -> [x; y; z]) t1 t2 t3 is the same as transpose [t1; t2; t3]")
+            CollectionAssert.AreNotEquivalent (t123.Exception.InnerExceptions, t123''.Exception.InnerExceptions, "Task.map3 (fun x y z -> [x; y; z]) t1 t2 t3 is not the same as sequence [t1; t2; t3]")
+
     
     module TaskBuilderTests =
         

--- a/tests/FSharpPlus.Tests/ValueTask.fs
+++ b/tests/FSharpPlus.Tests/ValueTask.fs
@@ -186,4 +186,15 @@ module ValueTask =
             let ac2 = (t13.AsTask ()).Exception.InnerExceptions |> Seq.map (fun x -> int (Char.GetNumericValue x.Message.[35]))
             CollectionAssert.AreEquivalent ([1; 3], ac2, "ValueTask.zipAsync between 2 exceptions => both exceptions returned, even after combining with cancellation and values.")
      
+        [<Test>]
+        let testTaskTraversals =
+            let t1 = createValueTask true  20 1
+            let t2 = createValueTask true  10 2
+            let t3 = createValueTask false 30 3
+
+            let t123 = ValueTask.map3 (fun x y z -> [x; y; z]) t1 t2 t3
+            let t123' = transpose [t1; t2; t3]
+            let t123'' = sequence [t1; t2; t3]            
+            CollectionAssert.AreEquivalent (t123.AsTask().Exception.InnerExceptions, t123'.AsTask().Exception.InnerExceptions, "ValueTask.map3 (fun x y z -> [x; y; z]) t1 t2 t3 is the same as transpose [t1; t2; t3]")
+            CollectionAssert.AreNotEquivalent (t123.AsTask().Exception.InnerExceptions, t123''.AsTask().Exception.InnerExceptions, "ValueTask.map3 (fun x y z -> [x; y; z]) t1 t2 t3 is not the same as sequence [t1; t2; t3]")
 #endif

--- a/tests/FSharpPlus.Tests/ValueTask.fs
+++ b/tests/FSharpPlus.Tests/ValueTask.fs
@@ -19,7 +19,6 @@ module ValueTask =
         static member WaitAny (source: ValueTask<'T>) = source.AsTask () |> Task.WaitAny |> ignore
 
     module ValueTask =
-        open System.Threading
 
         // Following is not available in F#6
 
@@ -185,7 +184,7 @@ module ValueTask =
             Assert.AreEqual (true, t13.IsFaulted, "ValueTask.zip(3)Async between a value, an exception and a cancellation -> exception wins.")
             let ac2 = (t13.AsTask ()).Exception.InnerExceptions |> Seq.map (fun x -> int (Char.GetNumericValue x.Message.[35]))
             CollectionAssert.AreEquivalent ([1; 3], ac2, "ValueTask.zipAsync between 2 exceptions => both exceptions returned, even after combining with cancellation and values.")
-     
+
         [<Test>]
         let testTaskTraversals =
             let t1 = createValueTask true  20 1
@@ -194,7 +193,7 @@ module ValueTask =
 
             let t123 = ValueTask.map3 (fun x y z -> [x; y; z]) t1 t2 t3
             let t123' = transpose [t1; t2; t3]
-            let t123'' = sequence [t1; t2; t3]            
+            let t123'' = sequence [t1; t2; t3]
             CollectionAssert.AreEquivalent (t123.AsTask().Exception.InnerExceptions, t123'.AsTask().Exception.InnerExceptions, "ValueTask.map3 (fun x y z -> [x; y; z]) t1 t2 t3 is the same as transpose [t1; t2; t3]")
             CollectionAssert.AreNotEquivalent (t123.AsTask().Exception.InnerExceptions, t123''.AsTask().Exception.InnerExceptions, "ValueTask.map3 (fun x y z -> [x; y; z]) t1 t2 t3 is not the same as sequence [t1; t2; t3]")
 #endif


### PR DESCRIPTION
We need to make sure the non-seq traversals and in sync with the zip-applicative functions