### PR TITLE
Bump to net8 and drop net45, fable3, netstandard

### DIFF
--- a/.github/workflows/fable.yml
+++ b/.github/workflows/fable.yml
@@ -8,44 +8,6 @@ on:
 
 
 jobs:
-  testfable3:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Restore
-      run: git submodule update --init --recursive
-    - name: Remove global json
-      run: rm global.json
-    - name: Set target framework to net6 instead of net8
-      uses: Mudlet/xmlstarlet-action@master
-      with:
-        args: edit --inplace --update "/Project/PropertyGroup/TargetFrameworks" --value "netstandard2.0;netstandard2.1;net6.0" ./src/FSharpPlus/FSharpPlus.fsproj
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: |
-          8.0.x
-          7.0.x
-          6.0.x
-    - name: Restore tools
-      run: dotnet tool restore
-    - name: Create global.json
-      working-directory: tests/FSharpPlusFable.Tests
-      run: mv fable3-global.json global.json
-    - name: Install fable
-      run: dotnet tool install --global Fable --version 3.7.22
-    - name: Use Node.js
-      uses: actions/setup-node@v1
-      with:
-        node-version: '12.x'
-    - name: Install npm dependencies
-      working-directory: tests/FSharpPlusFable.Tests
-      run: npm install
-    - name: Run Fable tests
-      working-directory: tests/FSharpPlusFable.Tests
-      run: fable . --outDir bin --runScript ./bin
-
   testfable4:
     runs-on: ubuntu-latest
 
@@ -81,30 +43,3 @@ jobs:
       working-directory: tests/FSharpPlusFable.Tests
       run: fable . --outDir bin --runScript ./bin
 
-  testFable3SubsetOnCore:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Restore
-      run: git submodule update --init --recursive
-    - name: Remove global json
-      run: rm global.json
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: |
-          8.0.x
-          7.0.x
-          6.0.x
-    - name: Restore tools
-      run: dotnet tool restore
-    # - name: Run tests (Fable2 subset but on .net)
-    #   working-directory: tests/FSharpPlusFable.Tests
-    #   run: dotnet run -c Fable
-    - name: Run tests (Fable3 subset but on .net)
-      working-directory: tests/FSharpPlusFable.Tests
-      run: dotnet run -c Fable3
-    - name: Run tests (Full subset for of tests .net)
-      working-directory: tests/FSharpPlusFable.Tests
-      run: dotnet run -c Release

--- a/docsrc/content/abstraction-alternative.fsx
+++ b/docsrc/content/abstraction-alternative.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 
 (**
 Alternative

--- a/docsrc/content/abstraction-applicative.fsx
+++ b/docsrc/content/abstraction-applicative.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 
 (**
 Applicative

--- a/docsrc/content/abstraction-bifoldable.fsx
+++ b/docsrc/content/abstraction-bifoldable.fsx
@@ -94,7 +94,7 @@ Examples
 --------
 *)
 
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 
 open FSharpPlus
 open FSharpPlus.Control

--- a/docsrc/content/abstraction-bifunctor.fsx
+++ b/docsrc/content/abstraction-bifunctor.fsx
@@ -2,7 +2,7 @@
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
 
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 (**
 Bifunctor
 =======

--- a/docsrc/content/abstraction-bitraversable.fsx
+++ b/docsrc/content/abstraction-bitraversable.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 
 (**
 Bitraversable

--- a/docsrc/content/abstraction-comonad.fsx
+++ b/docsrc/content/abstraction-comonad.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 
 (**
 Comonad

--- a/docsrc/content/abstraction-contravariant.fsx
+++ b/docsrc/content/abstraction-contravariant.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 
 (**
 Contravariant

--- a/docsrc/content/abstraction-foldable.fsx
+++ b/docsrc/content/abstraction-foldable.fsx
@@ -81,7 +81,7 @@ Examples
 
 
 
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 
 open FSharpPlus
 open FSharpPlus.Data

--- a/docsrc/content/abstraction-functor.fsx
+++ b/docsrc/content/abstraction-functor.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 
 (**
 Functor

--- a/docsrc/content/abstraction-misc.fsx
+++ b/docsrc/content/abstraction-misc.fsx
@@ -16,7 +16,7 @@ Here are some other abstractions, not present in the diagram.
 
 
 
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 
 open System
 open FSharpPlus

--- a/docsrc/content/abstraction-monad.fsx
+++ b/docsrc/content/abstraction-monad.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 
 (**
 Monad

--- a/docsrc/content/abstraction-monoid.fsx
+++ b/docsrc/content/abstraction-monoid.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 
 (**
 Monoid

--- a/docsrc/content/abstraction-profunctor.fsx
+++ b/docsrc/content/abstraction-profunctor.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 
 (**
 Profunctor

--- a/docsrc/content/abstraction-traversable.fsx
+++ b/docsrc/content/abstraction-traversable.fsx
@@ -2,7 +2,7 @@
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
 
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 
 (**
 Traversable

--- a/docsrc/content/abstraction-zipapplicative.fsx
+++ b/docsrc/content/abstraction-zipapplicative.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 
 (**
 Zip Applicative (aka Non-sequential Applicative)

--- a/docsrc/content/applicative-functors.fsx
+++ b/docsrc/content/applicative-functors.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 
 (**
 Functors and Applicatives

--- a/docsrc/content/computation-expressions.fsx
+++ b/docsrc/content/computation-expressions.fsx
@@ -2,7 +2,7 @@
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
 
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 open FSharpPlus
 open FSharpPlus.Data
 

--- a/docsrc/content/extension-methods.fsx
+++ b/docsrc/content/extension-methods.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 open FSharpPlus
 
 (**

--- a/docsrc/content/extensions.fsx
+++ b/docsrc/content/extensions.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 
 (**
 Extensions

--- a/docsrc/content/generic-doc.fsx
+++ b/docsrc/content/generic-doc.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 open FSharpPlus
 
 (**

--- a/docsrc/content/index.fsx
+++ b/docsrc/content/index.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 
 (**
 FSharpPlus

--- a/docsrc/content/lens.fsx
+++ b/docsrc/content/lens.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 
 (**
 Lens

--- a/docsrc/content/numerics.fsx
+++ b/docsrc/content/numerics.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 open FSharpPlus
 
 (**

--- a/docsrc/content/operators-common.fsx
+++ b/docsrc/content/operators-common.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 open FSharpPlus
 
 (**

--- a/docsrc/content/parsing.fsx
+++ b/docsrc/content/parsing.fsx
@@ -2,7 +2,7 @@
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
 open System
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 open FSharpPlus
 (**
 # Parsing

--- a/docsrc/content/tutorial.fsx
+++ b/docsrc/content/tutorial.fsx
@@ -2,7 +2,7 @@
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
 
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 
 (**
 Introducing FSharpPlus

--- a/docsrc/content/type-all.fsx
+++ b/docsrc/content/type-all.fsx
@@ -2,7 +2,7 @@
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
 
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 
 (**
 All

--- a/docsrc/content/type-any.fsx
+++ b/docsrc/content/type-any.fsx
@@ -2,7 +2,7 @@
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
 
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 
 (**
 Any

--- a/docsrc/content/type-choicet.fsx
+++ b/docsrc/content/type-choicet.fsx
@@ -10,6 +10,6 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 
 open FSharpPlus

--- a/docsrc/content/type-compose.fsx
+++ b/docsrc/content/type-compose.fsx
@@ -2,7 +2,7 @@
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
 
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 
 (**
 Compose

--- a/docsrc/content/type-const.fsx
+++ b/docsrc/content/type-const.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 (**
 Const<'T,'U>
 ============

--- a/docsrc/content/type-cont.fsx
+++ b/docsrc/content/type-cont.fsx
@@ -2,7 +2,7 @@
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
 
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 
 (**
 Cont<'R,'U>

--- a/docsrc/content/type-contt.fsx
+++ b/docsrc/content/type-contt.fsx
@@ -2,7 +2,7 @@
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
 
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 
 (**
 TO-DO Add some docs here !

--- a/docsrc/content/type-coproduct.fsx
+++ b/docsrc/content/type-coproduct.fsx
@@ -2,7 +2,7 @@
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
 
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 
 (**
 TO-DO Add some docs here !

--- a/docsrc/content/type-dlist.fsx
+++ b/docsrc/content/type-dlist.fsx
@@ -2,7 +2,7 @@
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
 
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 
 (**
 DList

--- a/docsrc/content/type-dual.fsx
+++ b/docsrc/content/type-dual.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 (**
 TO-DO Add some docs here !
 =========================

--- a/docsrc/content/type-endo.fsx
+++ b/docsrc/content/type-endo.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 (**
 TO-DO Add some docs here !
 =========================

--- a/docsrc/content/type-first.fsx
+++ b/docsrc/content/type-first.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 (**
 TO-DO Add some docs here !
 =========================

--- a/docsrc/content/type-free.fsx
+++ b/docsrc/content/type-free.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 (**
 Free<'Functor<'T>, 'T>
 ======================

--- a/docsrc/content/type-identity.fsx
+++ b/docsrc/content/type-identity.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 (**
 TO-DO Add some docs here !
 =========================

--- a/docsrc/content/type-kleisli.fsx
+++ b/docsrc/content/type-kleisli.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 (**
 TO-DO Add some docs here !
 =========================

--- a/docsrc/content/type-last.fsx
+++ b/docsrc/content/type-last.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 (**
 TO-DO Add some docs here !
 =========================

--- a/docsrc/content/type-listt.fsx
+++ b/docsrc/content/type-listt.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 (**
 TO-DO Add some docs here !
 =========================

--- a/docsrc/content/type-matrix.fsx
+++ b/docsrc/content/type-matrix.fsx
@@ -1,8 +1,8 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
-#r @"../../src/FSharpPlus.TypeLevel/bin/Release/netstandard2.0/FSharpPlus.TypeLevel.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus.TypeLevel/bin/Release/net8.0/FSharpPlus.TypeLevel.dll"
 
 (**
 Matrix<'NumType,'Rows,'Cols>

--- a/docsrc/content/type-mult.fsx
+++ b/docsrc/content/type-mult.fsx
@@ -10,6 +10,6 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 
 open FSharpPlus

--- a/docsrc/content/type-nonempty-map.fsx
+++ b/docsrc/content/type-nonempty-map.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 (**
 NonEmptyMap<'Key, 'Value>
 ================

--- a/docsrc/content/type-nonempty-set.fsx
+++ b/docsrc/content/type-nonempty-set.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 (**
 NonEmptySet<'T>
 ================

--- a/docsrc/content/type-nonempty.fsx
+++ b/docsrc/content/type-nonempty.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 (**
 NonEmptyList<'T>
 ================

--- a/docsrc/content/type-optiont.fsx
+++ b/docsrc/content/type-optiont.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 (**
 TO-DO Add some docs here !
 =========================

--- a/docsrc/content/type-parallelarray.fsx
+++ b/docsrc/content/type-parallelarray.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 (**
 ParallelArray<'T>
 =================

--- a/docsrc/content/type-reader.fsx
+++ b/docsrc/content/type-reader.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 (**
 Reader<'R,'T>
 =============

--- a/docsrc/content/type-readert.fsx
+++ b/docsrc/content/type-readert.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 (**
 TO-DO Add some docs here !
 =========================

--- a/docsrc/content/type-resultt.fsx
+++ b/docsrc/content/type-resultt.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 (**
 TO-DO Add some docs here !
 =========================

--- a/docsrc/content/type-seqt.fsx
+++ b/docsrc/content/type-seqt.fsx
@@ -2,7 +2,7 @@
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
 
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 
 // For some reason AsyncDownloadString is not found during doc build. The following is a dumb implementation just to make the compiler happy.
 // TODO find out why.

--- a/docsrc/content/type-state.fsx
+++ b/docsrc/content/type-state.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 (**
 State<'S,'T>
 ============

--- a/docsrc/content/type-statet.fsx
+++ b/docsrc/content/type-statet.fsx
@@ -10,6 +10,6 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 
 open FSharpPlus

--- a/docsrc/content/type-validation.fsx
+++ b/docsrc/content/type-validation.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 (**
 Validation<'Error, 'T>
 ======================

--- a/docsrc/content/type-valueoptiont.fsx
+++ b/docsrc/content/type-valueoptiont.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 (**
 TO-DO Add some docs here !
 =========================

--- a/docsrc/content/type-vector.fsx
+++ b/docsrc/content/type-vector.fsx
@@ -1,8 +1,8 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
-#r @"../../src/FSharpPlus.TypeLevel/bin/Release/netstandard2.0/FSharpPlus.TypeLevel.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus.TypeLevel/bin/Release/net8.0/FSharpPlus.TypeLevel.dll"
 
 (**
 Vector<'NumType,'Dimension>

--- a/docsrc/content/type-writer.fsx
+++ b/docsrc/content/type-writer.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 (**
 Writer<'Monoid,'T>
 ==================

--- a/docsrc/content/type-writert.fsx
+++ b/docsrc/content/type-writert.fsx
@@ -10,6 +10,6 @@ Examples
 *)
 
 
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 
 open FSharpPlus

--- a/docsrc/content/type-ziplist.fsx
+++ b/docsrc/content/type-ziplist.fsx
@@ -1,7 +1,7 @@
 (*** hide ***)
 // This block of code is omitted in the generated HTML documentation. Use 
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 (**
 ZipList<'T>
 ===========

--- a/docsrc/tools/Program.fs
+++ b/docsrc/tools/Program.fs
@@ -61,7 +61,7 @@ Target.create "Build" (fun _ ->
             OutputDirectory = output
             ProjectParameters =  ("root", root)::info
             Projects = rootDir @@ "src/FSharpPlus/FSharpPlus.fsproj"
-            TargetPath = rootDir @@ "src/FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+            TargetPath = rootDir @@ "src/FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
             SourceRepository = githubLink @@ "tree/master" }
            )
 )

--- a/docsrc/tools/doclib.fs
+++ b/docsrc/tools/doclib.fs
@@ -1025,7 +1025,7 @@ module ProcessUtils =
 
 type ProcessResult = { ExitCode : int; stdout : string; stderr : string }
 
-let executeProcess (exe, cmdline, workingDir, (env:(string*string) list option)) =
+let executeProcess (exe:string, cmdline:string, workingDir, (env:(string*string) list option)) =
     let psi =
         System.Diagnostics.ProcessStartInfo (exe, cmdline,
             UseShellExecute = false,

--- a/docsrc/tools/docsTool.fsproj
+++ b/docsrc/tools/docsTool.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docsrc/tools/tools.fs
+++ b/docsrc/tools/tools.fs
@@ -5,7 +5,7 @@ let (</>) x y = IO.Path.Combine(x,y)
 
 module Path =
     // Paths with template/source/output locations
-    let bin        = __SOURCE_DIRECTORY__ </> "../../src/FSharpPlus/bin/Release/netstandard2.0/"
+    let bin        = __SOURCE_DIRECTORY__ </> "../../src/FSharpPlus/bin/Release/net8.0/"
     let content    = __SOURCE_DIRECTORY__ </> "../content"
     let output     = __SOURCE_DIRECTORY__ </> "../../docs"
     let templates      = __SOURCE_DIRECTORY__ </> "./templates"

--- a/src/FSharpPlus.Docs/FSharpPlus.Docs.fsproj
+++ b/src/FSharpPlus.Docs/FSharpPlus.Docs.fsproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <Configurations>Debug;Release;Fable</Configurations>
     <Platforms>AnyCPU</Platforms>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/FSharpPlus.Docs/Samples/Collections.fsx
+++ b/src/FSharpPlus.Docs/Samples/Collections.fsx
@@ -1,5 +1,5 @@
 #if INTERACTIVE
-#r @"../../FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 #else
 module Samples.Collections
 #endif

--- a/src/FSharpPlus.Docs/Samples/Conversions.fsx
+++ b/src/FSharpPlus.Docs/Samples/Conversions.fsx
@@ -1,5 +1,5 @@
 #if INTERACTIVE
-#r @"../../FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 #else
 module Samples.Conversions
 #endif

--- a/src/FSharpPlus.Docs/Samples/Learn You a Haskell.fsx
+++ b/src/FSharpPlus.Docs/Samples/Learn You a Haskell.fsx
@@ -1,5 +1,5 @@
 #if INTERACTIVE
-#r @"../../FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 #else
 module Samples.Learn_You_a_Haskell
 #endif

--- a/src/FSharpPlus.Docs/Samples/Split-Join.fsx
+++ b/src/FSharpPlus.Docs/Samples/Split-Join.fsx
@@ -1,5 +1,5 @@
 #if INTERACTIVE
-#r @"../../FSharpPlus/bin/Release/netstandard2.0/FSharpPlus.dll"
+#r @"../../FSharpPlus/bin/Release/net8.0/FSharpPlus.dll"
 #else
 module Samples.SplitJoin
 #endif

--- a/src/FSharpPlus.TypeLevel/FSharpPlus.TypeLevel.fsproj
+++ b/src/FSharpPlus.TypeLevel/FSharpPlus.TypeLevel.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);TYPELEVEL_DEBUG</DefineConstants>
     <Configurations>Debug;Release;Fable</Configurations>
     <Platforms>AnyCPU</Platforms>

--- a/src/FSharpPlus.TypeLevel/Providers/FSharpPlus.Providers.fsproj
+++ b/src/FSharpPlus.TypeLevel/Providers/FSharpPlus.Providers.fsproj
@@ -5,7 +5,7 @@
     <FscToolExe>$(FSC_ExePathCompilerBuild)</FscToolExe>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <Title>FSharpPlus.Providers</Title>
     <AssemblyName>FSharpPlus.Providers</AssemblyName>
     <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
@@ -19,6 +19,12 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+
+    <!--
+      https://github.com/fsprojects/FSharp.TypeProviders.SDK/issues/408#issuecomment-2200299743
+      Make the consuming project compile on .NET 8 or later
+    -->
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
 
     <BaseOutputPath>..\bin</BaseOutputPath>
 

--- a/src/FSharpPlus/Builders.fs
+++ b/src/FSharpPlus/Builders.fs
@@ -11,7 +11,7 @@ namespace FSharpPlus
 
 #nowarn "40"
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 /// Constructs to express generic computations
 [<AutoOpenAttribute>]

--- a/src/FSharpPlus/Control/Alternative.fs
+++ b/src/FSharpPlus/Control/Alternative.fs
@@ -6,7 +6,7 @@ namespace FSharpPlus.Control
 /// </summary>
 /// </namespacedoc>
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER && !FABLE_COMPILER_4
 
 open System.Runtime.InteropServices
 open FSharpPlus
@@ -85,7 +85,7 @@ type IsAltLeftZero =
 
 type Choice =
     inherit Default1
-    #if !FABLE_COMPILER || FABLE_COMPILER_3
+    #if !FABLE_COMPILER
     static member inline Choice (x: ref<'``Foldable<'Alternative<'T>>``>, _mthd: Default4) =
         use e = (ToSeq.Invoke x.Value).GetEnumerator ()
         let mutable res = Empty.Invoke ()

--- a/src/FSharpPlus/Control/Applicative.fs
+++ b/src/FSharpPlus/Control/Applicative.fs
@@ -14,7 +14,7 @@ open FSharpPlus.Data
 type Apply =
     inherit Default1
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
     static member        ``<*>`` (struct (f: Lazy<'T->'U>     , x: Lazy<'T>           )  , _output: Lazy<'U>             , [<Optional>]_mthd: Apply) = Lazy.apply f x                               : Lazy<'U>
     static member        ``<*>`` (struct (f: seq<_>           , x: seq<'T>            )  , _output: seq<'U>              , [<Optional>]_mthd: Apply) = Seq.apply  f x                               : seq<'U>
@@ -88,7 +88,7 @@ type Apply =
     static member inline InvokeOnInstance (f: '``Applicative<'T->'U>``) (x: '``Applicative<'T>``) : '``Applicative<'U>`` =
         ((^``Applicative<'T->'U>`` or ^``Applicative<'T>`` or ^``Applicative<'U>``) : (static member (<*>) : _*_ -> _) (f, x))
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 type Apply with
     static member inline ``<*>`` (struct (f: '``Monad<'T->'U>``      , x: '``Monad<'T>``     ) , _output: '``Monad<'U>``      , [<Optional>]_mthd:Default2) : '``Monad<'U>``       = Bind.InvokeOnInstance f (fun (x1: 'T->'U) -> Bind.InvokeOnInstance x (fun x2 -> Return.InvokeOnInstance (x1 x2)))

--- a/src/FSharpPlus/Control/Applicative.fs
+++ b/src/FSharpPlus/Control/Applicative.fs
@@ -28,7 +28,7 @@ type Apply =
     #if !FABLE_COMPILER
     static member        ``<*>`` (struct (f: Task<_>          , x: Task<'T>             ), _output: Task<'U>             , [<Optional>]_mthd: Apply) = Task.apply   f x : Task<'U>
     #endif
-    #if !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !FABLE_COMPILER
     static member        ``<*>`` (struct (f: ValueTask<_>     , x: ValueTask<'T>        ), _output: ValueTask<'U>        , [<Optional>]_mthd: Apply) : ValueTask<'U> = ValueTask.apply f x
     static member        ``<*>`` (struct (_: DmStruct1<_>     , _: DmStruct1<'T>        ), _output: DmStruct1<'U>        , [<Optional>]_mthd: Apply) : DmStruct1<'U> = Unchecked.defaultof<DmStruct1<'U>>
     #endif
@@ -112,7 +112,7 @@ type Lift2 =
     #if !FABLE_COMPILER
     static member        Lift2 (f, (x: Task<'T>           , y: Task<'U>           ), _mthd: Lift2) = Task.lift2  f x y
     #endif
-    #if !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !FABLE_COMPILER
     static member        Lift2 (f, (x: ValueTask<'T>      , y: ValueTask<'U>      ), _mthd: Lift2) = ValueTask.lift2  f x y
     #endif
     static member        Lift2 (f, (x                     , y                     ), _mthd: Lift2) = Async.lift2  f x y
@@ -161,7 +161,7 @@ type Lift3 =
     #if !FABLE_COMPILER
     static member        Lift3 (f, (x: Task<'T>           , y: Task<'U>           , z: Task<'V>            ), _mthd: Lift3) = Task.lift3  f x y z
     #endif
-    #if !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !FABLE_COMPILER
     static member        Lift3 (f, (x: ValueTask<'T>      , y: ValueTask<'U>      , z: ValueTask<'V>       ), _mthd: Lift3) = ValueTask.lift3  f x y z
     #endif
     static member        Lift3 (f, (x                     , y                     , z                      ), _mthd: Lift3) = Async.lift3  f x y z

--- a/src/FSharpPlus/Control/Applicative.fs
+++ b/src/FSharpPlus/Control/Applicative.fs
@@ -28,7 +28,7 @@ type Apply =
     #if !FABLE_COMPILER
     static member        ``<*>`` (struct (f: Task<_>          , x: Task<'T>             ), _output: Task<'U>             , [<Optional>]_mthd: Apply) = Task.apply   f x : Task<'U>
     #endif
-    #if !NET45 && !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !NETSTANDARD2_0 && !FABLE_COMPILER
     static member        ``<*>`` (struct (f: ValueTask<_>     , x: ValueTask<'T>        ), _output: ValueTask<'U>        , [<Optional>]_mthd: Apply) : ValueTask<'U> = ValueTask.apply f x
     static member        ``<*>`` (struct (_: DmStruct1<_>     , _: DmStruct1<'T>        ), _output: DmStruct1<'U>        , [<Optional>]_mthd: Apply) : DmStruct1<'U> = Unchecked.defaultof<DmStruct1<'U>>
     #endif
@@ -112,7 +112,7 @@ type Lift2 =
     #if !FABLE_COMPILER
     static member        Lift2 (f, (x: Task<'T>           , y: Task<'U>           ), _mthd: Lift2) = Task.lift2  f x y
     #endif
-    #if !NET45 && !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !NETSTANDARD2_0 && !FABLE_COMPILER
     static member        Lift2 (f, (x: ValueTask<'T>      , y: ValueTask<'U>      ), _mthd: Lift2) = ValueTask.lift2  f x y
     #endif
     static member        Lift2 (f, (x                     , y                     ), _mthd: Lift2) = Async.lift2  f x y
@@ -161,7 +161,7 @@ type Lift3 =
     #if !FABLE_COMPILER
     static member        Lift3 (f, (x: Task<'T>           , y: Task<'U>           , z: Task<'V>            ), _mthd: Lift3) = Task.lift3  f x y z
     #endif
-    #if !NET45 && !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !NETSTANDARD2_0 && !FABLE_COMPILER
     static member        Lift3 (f, (x: ValueTask<'T>      , y: ValueTask<'U>      , z: ValueTask<'V>       ), _mthd: Lift3) = ValueTask.lift3  f x y z
     #endif
     static member        Lift3 (f, (x                     , y                     , z                      ), _mthd: Lift3) = Async.lift3  f x y z

--- a/src/FSharpPlus/Control/Arrow.fs
+++ b/src/FSharpPlus/Control/Arrow.fs
@@ -1,7 +1,7 @@
 namespace FSharpPlus.Control
 
 #nowarn "0077"
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 open System
 open System.Runtime.InteropServices

--- a/src/FSharpPlus/Control/ArrowApply.fs
+++ b/src/FSharpPlus/Control/ArrowApply.fs
@@ -4,7 +4,7 @@ open System
 open System.Runtime.InteropServices
 open FSharpPlus.Internals
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 // ArrowApply class -------------------------------------------------------
 

--- a/src/FSharpPlus/Control/ArrowChoice.fs
+++ b/src/FSharpPlus/Control/ArrowChoice.fs
@@ -1,7 +1,7 @@
 namespace FSharpPlus.Control
 
 #nowarn "0077"
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 open System
 open System.Runtime.InteropServices

--- a/src/FSharpPlus/Control/Bifoldable.fs
+++ b/src/FSharpPlus/Control/Bifoldable.fs
@@ -1,6 +1,6 @@
 namespace FSharpPlus.Control
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 open System.Runtime.InteropServices
 open FSharpPlus.Internals

--- a/src/FSharpPlus/Control/Bitraversable.fs
+++ b/src/FSharpPlus/Control/Bitraversable.fs
@@ -1,6 +1,6 @@
 ﻿namespace FSharpPlus.Control
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 // open System.Runtime.InteropServices
 open FSharpPlus.Internals

--- a/src/FSharpPlus/Control/Category.fs
+++ b/src/FSharpPlus/Control/Category.fs
@@ -1,7 +1,7 @@
 namespace FSharpPlus.Control
 
 #nowarn "0077"
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 open System
 open System.Runtime.InteropServices

--- a/src/FSharpPlus/Control/Collection.fs
+++ b/src/FSharpPlus/Control/Collection.fs
@@ -8,7 +8,7 @@ open System.Runtime.InteropServices
 open FSharpPlus
 open FSharpPlus.Internals
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 type OfSeq =
     inherit Default1

--- a/src/FSharpPlus/Control/Comonad.fs
+++ b/src/FSharpPlus/Control/Comonad.fs
@@ -13,7 +13,7 @@ open FSharpPlus.Internals
 
 type Extract =
     static member        Extract (x: Async<'T>) =
-    #if FABLE_COMPILER_3 || FABLE_COMPILER_4
+    #if FABLE_COMPILER
         Async.RunSynchronously x
     #else
         Async.AsTask(x).Result
@@ -22,7 +22,7 @@ type Extract =
     static member        Extract ((_: 'W, a: 'T)  ) = a
     static member        Extract (struct (_: 'W, a: 'T)) = a
     static member        Extract (f: 'T Id        ) = f
-    #if !FABLE_COMPILER || FABLE_COMPILER_3
+    #if !FABLE_COMPILER
     static member inline Extract (f: 'Monoid -> 'T) = f (Zero.Invoke ())
     #else
     static member inline Extract (f: 'Monoid -> 'T) = f (LanguagePrimitives.GenericZero)
@@ -45,7 +45,7 @@ type Extend =
     static member        (=>>) ((w: 'W, a: 'T)  , f: _ -> 'U        ) = (w, f (w, a))
     static member        (=>>) (struct (w: 'W, a: 'T), f: _ -> 'U   ) = struct (w, f (struct (w, a)))
     static member        (=>>) (g: Id<'T>       , f: Id<'T> -> 'U   ) = f g
-    #if !FABLE_COMPILER || FABLE_COMPILER_3
+    #if !FABLE_COMPILER
     static member inline (=>>) (g: 'Monoid -> 'T, f: _ -> 'U        ) = fun a -> f (fun b -> g (Plus.Invoke a b))
     #else
     static member inline (=>>) (g: 'Monoid -> 'T, f: _ -> 'U        ) = fun a -> f (fun b -> g (a + b))
@@ -94,13 +94,13 @@ type Extend =
     static member        (=>>) (s: 'T []        , g) = Array.map g (s |> Array.toList |> List.tails |> List.toArray |> Array.map List.toArray) : 'U []
     static member        (=>>) (s: seq<'T>      , g) = Seq.map   g (s |> Seq.toList   |> List.tails |> List.toSeq   |> Seq.map   List.toSeq)   : 'U seq
 
-#if !FABLE_COMPILER || FABLE_COMPILER_3
+#if !FABLE_COMPILER
     static member inline Invoke (g: '``Comonad<'T>``->'U) (s: '``Comonad<'T>``) : '``Comonad<'U>`` =
         let inline call (_mthd: 'M, source: 'I, _output: 'R) = ((^M or ^I or ^R) : (static member (=>>) : _*_ -> _) source, g)
         call (Unchecked.defaultof<Extend>, s, Unchecked.defaultof<'``Comonad<'U>``>)
 #endif
 
-#if !FABLE_COMPILER || FABLE_COMPILER_3
+#if !FABLE_COMPILER
 
 type Duplicate =
     inherit Default1

--- a/src/FSharpPlus/Control/Comonad.fs
+++ b/src/FSharpPlus/Control/Comonad.fs
@@ -30,7 +30,7 @@ type Extract =
     #if !FABLE_COMPILER
     static member        Extract (f: Task<'T>     ) = f.Result
     #endif
-    #if !NET45 && !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !NETSTANDARD2_0 && !FABLE_COMPILER
     static member        Extract (f: ValueTask<'T>     ) = f.Result
     #endif
     static member inline Invoke (x: '``Comonad<'T>``) : 'T =
@@ -67,7 +67,7 @@ type Extend =
                 tcs.Task
     #endif
 
-    #if !NET45 && !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !NETSTANDARD2_0 && !FABLE_COMPILER
     static member        (=>>) (g: ValueTask<'T>     , f: ValueTask<'T> -> 'U ) : ValueTask<'U> =
         if g.IsCompletedSuccessfully then
             try

--- a/src/FSharpPlus/Control/Comonad.fs
+++ b/src/FSharpPlus/Control/Comonad.fs
@@ -30,7 +30,7 @@ type Extract =
     #if !FABLE_COMPILER
     static member        Extract (f: Task<'T>     ) = f.Result
     #endif
-    #if !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !FABLE_COMPILER
     static member        Extract (f: ValueTask<'T>     ) = f.Result
     #endif
     static member inline Invoke (x: '``Comonad<'T>``) : 'T =
@@ -67,7 +67,7 @@ type Extend =
                 tcs.Task
     #endif
 
-    #if !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !FABLE_COMPILER
     static member        (=>>) (g: ValueTask<'T>     , f: ValueTask<'T> -> 'U ) : ValueTask<'U> =
         if g.IsCompletedSuccessfully then
             try

--- a/src/FSharpPlus/Control/Converter.fs
+++ b/src/FSharpPlus/Control/Converter.fs
@@ -142,7 +142,7 @@ type TryParse =
         let mutable r = Unchecked.defaultof< ^R>
         if (^R: (static member TryParse : _ * _ -> _) (value, &r)) then Some r else None
 
-    #if NET7_0
+    #if NET7_0_OR_GREATER
     /// IParsable<'T>
     static member InvokeOnInterface<'T when 'T :> IParsable<'T>> (value: string) =
         let mutable r = Unchecked.defaultof<'T>
@@ -199,7 +199,7 @@ type Parse with
     
     static member inline Parse (_: ^R                  , _: Default2) : string -> ^R  = Parse.InvokeOnInstance
 
-    #if NET7_0
+    #if NET7_0_OR_GREATER
     static member Parse<'T when 'T :> IParsable<'T>> (_: 'T, _: Default1) = fun (x: string) -> 'T.Parse (x, CultureInfo.InvariantCulture)
     static member inline Parse (_: ^t when ^t: null and ^t: struct, _: Default1) = id
     #else
@@ -217,7 +217,7 @@ type TryParse with
 
     static member inline TryParse (_: 'R, _: Default2) : string -> 'R option = TryParse.InvokeOnInstance
 
-    #if NET7_0
+    #if NET7_0_OR_GREATER
     static member inline TryParse (_: 'R, _: Default1) : string -> 'R option = TryParse.InvokeOnInterface
     static member inline TryParse (_: ^t when ^t: null and ^t: struct, _: Default1) = id
     #else

--- a/src/FSharpPlus/Control/Converter.fs
+++ b/src/FSharpPlus/Control/Converter.fs
@@ -10,7 +10,7 @@ open System.Text
 open FSharpPlus.Internals
 open FSharpPlus.Internals.Prelude
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 type Explicit =
     inherit Default1
@@ -26,10 +26,8 @@ type Explicit =
     static member inline Explicit (_: uint32    , _: Explicit) = fun x -> uint32          x
     static member inline Explicit (_: int64     , _: Explicit) = fun x -> int64           x
     static member inline Explicit (_: uint64    , _: Explicit) = fun x -> uint64          x
-#if !FABLE_COMPILER_3
     static member inline Explicit (_: nativeint , _: Explicit) = fun x -> nativeint  (int x)
     static member inline Explicit (_: unativeint, _: Explicit) = fun x -> unativeint (uint32 x)
-#endif    
     static member inline Explicit (_: float     , _: Explicit) = fun x -> float           x
     static member inline Explicit (_: float32   , _: Explicit) = fun x -> float32         x    
     static member inline Explicit (_: decimal   , _: Explicit) = fun x -> decimal         x
@@ -38,7 +36,7 @@ type Explicit =
         let inline call_2 (a: ^a, b: ^r) = ((^a or ^r or ^t) : (static member Explicit : _*_ -> ('t  -> ^r)) b, a)
         let inline call (a: 'a) = fun (x: 'x) -> call_2 (a, Unchecked.defaultof<'r>) x : 'r
         call Unchecked.defaultof<Explicit> value
-#if !FABLE_COMPILER_3
+
 type OfBytes =
     static member OfBytes (_: bool   , _: OfBytes) = fun (x, i, _) -> BitConverter.ToBoolean(x, i)
 
@@ -81,12 +79,10 @@ type ToBytes =
         let inline call (a: 'a, b: 'b, e) = call_2 (a, b, e)
         call (Unchecked.defaultof<ToBytes>, value, isLittleEndian)
 
-#endif
 open System.Globalization
 
 type TryParse =
     inherit Default1
-#if !FABLE_COMPILER_3
     static member TryParse (_: decimal       , _: TryParse) = fun (x:string) -> Decimal.TryParse (x, NumberStyles.Any, CultureInfo.InvariantCulture) |> tupleToOption : option<decimal>
     static member TryParse (_: float32       , _: TryParse) = fun (x:string) -> Single.TryParse  (x, NumberStyles.Any, CultureInfo.InvariantCulture) |> tupleToOption : option<float32>
     static member TryParse (_: float         , _: TryParse) = fun (x:string) -> Double.TryParse  (x, NumberStyles.Any, CultureInfo.InvariantCulture) |> tupleToOption : option<float>
@@ -96,18 +92,6 @@ type TryParse =
     static member TryParse (_: int16         , _: TryParse) = fun (x:string) -> Int16.TryParse   (x, NumberStyles.Any, CultureInfo.InvariantCulture) |> tupleToOption : option<int16>
     static member TryParse (_: int           , _: TryParse) = fun (x:string) -> Int32.TryParse   (x, NumberStyles.Any, CultureInfo.InvariantCulture) |> tupleToOption : option<int>
     static member TryParse (_: int64         , _: TryParse) = fun (x:string) -> Int64.TryParse   (x, NumberStyles.Any, CultureInfo.InvariantCulture) |> tupleToOption : option<int64>
-#else
-    static member TryParse (_: decimal       , _: TryParse) = fun (x:string) -> Decimal.TryParse (x) |> tupleToOption : option<decimal>
-    static member TryParse (_: float32       , _: TryParse) = fun (x:string) -> Single.TryParse  (x) |> tupleToOption : option<float32>
-    static member TryParse (_: float         , _: TryParse) = fun (x:string) -> Double.TryParse  (x) |> tupleToOption : option<float>
-    static member TryParse (_: uint16        , _: TryParse) = fun (x:string) -> UInt16.TryParse  (x) |> tupleToOption : option<uint16>
-    static member TryParse (_: uint32        , _: TryParse) = fun (x:string) -> UInt32.TryParse  (x) |> tupleToOption : option<uint32>
-    static member TryParse (_: uint64        , _: TryParse) = fun (x:string) -> UInt64.TryParse  (x) |> tupleToOption : option<uint64>
-    static member TryParse (_: int16         , _: TryParse) = fun (x:string) -> Int16.TryParse   (x) |> tupleToOption : option<int16>
-    static member TryParse (_: int           , _: TryParse) = fun (x:string) -> Int32.TryParse   (x) |> tupleToOption : option<int>
-    static member TryParse (_: int64         , _: TryParse) = fun (x:string) -> Int64.TryParse   (x) |> tupleToOption : option<int64>
-#endif
-
     static member TryParse (_: string        , _: TryParse) = fun x -> Some x                               : option<string>
     static member TryParse (_: StringBuilder , _: TryParse) = fun x -> Some (new StringBuilder (x: string)) : option<StringBuilder>
     #if !FABLE_COMPILER

--- a/src/FSharpPlus/Control/Foldable.fs
+++ b/src/FSharpPlus/Control/Foldable.fs
@@ -4,7 +4,7 @@
 // Warn FS0077 -> Member constraints with the name 'get_Item' are given special status by the F# compiler as certain .NET types are implicitly augmented with this member. This may result in runtime failures if you attempt to invoke the member constraint from your own code.
 // Those .NET types are string and array. String is explicitely handled here and array through the seq overload.
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 open FSharpPlus.Control
 

--- a/src/FSharpPlus/Control/Functor.fs
+++ b/src/FSharpPlus/Control/Functor.fs
@@ -14,7 +14,7 @@ open FSharpPlus
 open FSharpPlus.Extensions
 open FSharpPlus.Data
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && ! FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 // Functor class ----------------------------------------------------------
 
@@ -62,7 +62,7 @@ type Iterate =
 type Map =
     inherit Default1
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
     static member Map ((x: Lazy<_>             , f: 'T->'U), _mthd: Map) = Lazy.map f x
     #if !FABLE_COMPILER
@@ -115,7 +115,7 @@ type Map =
     static member inline InvokeOnInstance (mapping: 'T->'U) (source: '``Functor<'T>``) : '``Functor<'U>`` = 
         (^``Functor<'T>`` : (static member Map : _ * _ -> _) source, mapping)
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 
 type Map with
@@ -141,7 +141,7 @@ type Map with
     static member inline Map ((_: ^t when ^t: null and ^t: struct, _ ), _mthd: Default1) = ()
 
 #endif
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 type Unzip =
     inherit Default1
@@ -201,7 +201,7 @@ type Unzip =
         call (Unchecked.defaultof<Unzip>, source) : '``Functor<'T1>`` * '``Functor<'T2>``
 
 #endif
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 type Zip =
     inherit Default1
@@ -242,7 +242,7 @@ type Zip with
     static member inline Zip ((x: '``ZipFunctor<'T1>``            , y: '``ZipFunctor<'T2>``            , _output: '``ZipFunctor<'T1 * 'T2>``      ), _mthd: Default1) = Zip.InvokeOnInstance x y : '``ZipFunctor<'T1 * 'T2>``
 
 #endif
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 // Bifunctor class --------------------------------------------------------
 
@@ -263,7 +263,7 @@ type Bimap =
         (^``Bifunctor<'T,'V>``: (static member Bimap : _*_*_ -> _) source, f, g)
 
 #endif
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 type MapFirst =
     inherit Default1
@@ -315,7 +315,7 @@ type Dimap =
         (^``Profunctor<'B,'C>`` : (static member Dimap : _*_*_ -> _) source, ab, cd)
 
 #endif
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 // Contravariant class ----------------------------------------------------
 
@@ -341,7 +341,7 @@ type Contramap =
     #endif
 #endif
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
     
 type Contramap with
     static member inline Contramap (x: '``Profunctor<'B,'C>``, f: 'A->'B, [<Optional>]_mthd: Default2) = Dimap.InvokeOnInstance f id x : '``Profunctor<'A,'C>``
@@ -349,13 +349,13 @@ type Contramap with
     static member inline Contramap (_: ^t when ^t: null and ^t: struct  , _: 'A->'B,  _mthd: Default1) = ()
 
 #endif
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 type Map with
     static member inline Map ((x: '``Profunctor<'B,'C>``, cd: 'C->'D), [<Optional>]_mthd: Default5) = Dimap.InvokeOnInstance id cd x : '``Profunctor<'B,'D>``
 
 #endif
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 type Dimap with
     static member inline Dimap (x: '``Profunctor<'B,'C>``, ab: 'A->'B, cd: 'C->'D, [<Optional>]_mthd: Default2) = x |> Map.InvokeOnInstance cd |> Contramap.InvokeOnInstance ab : '``Profunctor<'A,'D>``

--- a/src/FSharpPlus/Control/Functor.fs
+++ b/src/FSharpPlus/Control/Functor.fs
@@ -68,7 +68,7 @@ type Map =
     #if !FABLE_COMPILER
     static member Map ((x: Task<'T>            , f: 'T->'U), _mthd: Map) = Task.map f x : Task<'U>
     #endif
-    #if !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !FABLE_COMPILER
     static member Map ((x: ValueTask<'T>       , f: 'T->'U), _mthd: Map) = ValueTask.map f x : ValueTask<'U>
     #endif
     static member Map ((x: option<_>           , f: 'T->'U), _mthd: Map) = Option.map  f x
@@ -154,7 +154,7 @@ type Unzip =
     #if !FABLE_COMPILER
     static member        Unzip ((source: Task<'T * 'U>                     , _output: Task<'T> * Task<'U>                                  ) , _mthd: Unzip   ) = Map.Invoke fst source, Map.Invoke snd source
     #endif
-    #if !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !FABLE_COMPILER
     static member        Unzip ((source: ValueTask<'T * 'U>                , _output: ValueTask<'T> * ValueTask<'U>                        ) , _mthd: Unzip   ) = Map.Invoke fst source, Map.Invoke snd source
     #endif
     static member        Unzip ((source: option<'T * 'U>                   , _output: option<'T> * option<'U>                              ) , _mthd: Unzip   ) = Option.unzip source
@@ -225,7 +225,7 @@ type Zip =
     #if !FABLE_COMPILER
     static member Zip ((x: Task<'T>                   , y: Task<'U>                  , _output: Task<'T*'U>                  ), _mthd: Zip) = Task.zip                x y
     #endif
-    #if !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !FABLE_COMPILER
     static member Zip ((x: ValueTask<'T>              , y: ValueTask<'U>             , _output: ValueTask<'T*'U>             ), _mthd: Zip) = ValueTask.zip           x y
     #endif
 

--- a/src/FSharpPlus/Control/Functor.fs
+++ b/src/FSharpPlus/Control/Functor.fs
@@ -68,7 +68,7 @@ type Map =
     #if !FABLE_COMPILER
     static member Map ((x: Task<'T>            , f: 'T->'U), _mthd: Map) = Task.map f x : Task<'U>
     #endif
-    #if !NET45 && !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !NETSTANDARD2_0 && !FABLE_COMPILER
     static member Map ((x: ValueTask<'T>       , f: 'T->'U), _mthd: Map) = ValueTask.map f x : ValueTask<'U>
     #endif
     static member Map ((x: option<_>           , f: 'T->'U), _mthd: Map) = Option.map  f x
@@ -154,7 +154,7 @@ type Unzip =
     #if !FABLE_COMPILER
     static member        Unzip ((source: Task<'T * 'U>                     , _output: Task<'T> * Task<'U>                                  ) , _mthd: Unzip   ) = Map.Invoke fst source, Map.Invoke snd source
     #endif
-    #if !NET45 && !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !NETSTANDARD2_0 && !FABLE_COMPILER
     static member        Unzip ((source: ValueTask<'T * 'U>                , _output: ValueTask<'T> * ValueTask<'U>                        ) , _mthd: Unzip   ) = Map.Invoke fst source, Map.Invoke snd source
     #endif
     static member        Unzip ((source: option<'T * 'U>                   , _output: option<'T> * option<'U>                              ) , _mthd: Unzip   ) = Option.unzip source
@@ -225,7 +225,7 @@ type Zip =
     #if !FABLE_COMPILER
     static member Zip ((x: Task<'T>                   , y: Task<'U>                  , _output: Task<'T*'U>                  ), _mthd: Zip) = Task.zip                x y
     #endif
-    #if !NET45 && !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !NETSTANDARD2_0 && !FABLE_COMPILER
     static member Zip ((x: ValueTask<'T>              , y: ValueTask<'U>             , _output: ValueTask<'T*'U>             ), _mthd: Zip) = ValueTask.zip           x y
     #endif
 

--- a/src/FSharpPlus/Control/Indexable.fs
+++ b/src/FSharpPlus/Control/Indexable.fs
@@ -4,7 +4,7 @@
 // Warn FS0077 -> Member constraints with the name 'get_Item' are given special status by the F# compiler as certain .NET types are implicitly augmented with this member. This may result in runtime failures if you attempt to invoke the member constraint from your own code.
 // Those .NET types are string and array but they are explicitely handled here.
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 open System
 open System.Runtime.InteropServices
@@ -220,7 +220,7 @@ type TryFindIndex =
 type FindSliceIndex =
     inherit Default1
     static member        FindSliceIndex (x: string           , e                   , [<Optional>]_impl: FindSliceIndex) = String.findSliceIndex e x
-    #if !FABLE_COMPILER || FABLE_COMPILER_3
+    #if !FABLE_COMPILER
     static member        FindSliceIndex (x: 'a ResizeArray   , e: 'a ResizeArray   , [<Optional>]_impl: FindSliceIndex) = Seq.findSliceIndex e x
     static member        FindSliceIndex (x: 'a []            , e                   , [<Optional>]_impl: FindSliceIndex) = Array.findSliceIndex e x
     static member        FindSliceIndex (x: list<'a>         , e                   , [<Optional>]_impl: FindSliceIndex) = List.findSliceIndex e x
@@ -260,7 +260,7 @@ type TryFindSliceIndex =
 type FindLastSliceIndex =
     inherit Default1
     static member        FindLastSliceIndex (x: string           , e                   , [<Optional>]_impl: FindLastSliceIndex) = String.findLastSliceIndex e x
-    #if !FABLE_COMPILER || FABLE_COMPILER_3
+    #if !FABLE_COMPILER
     static member        FindLastSliceIndex (x: 'a ResizeArray   , e: 'a ResizeArray   , [<Optional>]_impl: FindLastSliceIndex) = Seq.findLastSliceIndex e x
     static member        FindLastSliceIndex (x: 'a []            , e                   , [<Optional>]_impl: FindLastSliceIndex) = Array.findLastSliceIndex e x
     static member        FindLastSliceIndex (x: list<'a>         , e                   , [<Optional>]_impl: FindLastSliceIndex) = List.findLastSliceIndex e x

--- a/src/FSharpPlus/Control/Invokable.fs
+++ b/src/FSharpPlus/Control/Invokable.fs
@@ -1,6 +1,6 @@
 namespace FSharpPlus.Control
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 open System
 open FSharpPlus.Internals

--- a/src/FSharpPlus/Control/Monad.fs
+++ b/src/FSharpPlus/Control/Monad.fs
@@ -62,7 +62,7 @@ type Bind =
 
     static member (>>=) (source: NonEmptySeq<'T>, f: 'T -> NonEmptySeq<'U>) = NonEmptySeq.collect f source : NonEmptySeq<'U>
 
-#if !FABLE_COMPILER || FABLE_COMPILER_3
+#if !FABLE_COMPILER
     static member inline Invoke (source: '``Monad<'T>``) (binder: 'T -> '``Monad<'U>``) : '``Monad<'U>`` =
         let inline call (_mthd: 'M, input: 'I, _output: 'R, f) = ((^M or ^I or ^R) : (static member (>>=) : _*_ -> _) input, f)
         call (Unchecked.defaultof<Bind>, source, Unchecked.defaultof<'``Monad<'U>``>, binder)
@@ -71,7 +71,7 @@ type Bind =
     static member inline InvokeOnInstance (source: '``Monad<'T>``) (binder: 'T -> '``Monad<'U>``) : '``Monad<'U>`` =
         ((^``Monad<'T>`` or ^``Monad<'U>``) : (static member (>>=) : _*_ -> _) source, binder)
 
-#if !FABLE_COMPILER || FABLE_COMPILER_3
+#if !FABLE_COMPILER
 
 type Join =
     inherit Default1
@@ -128,7 +128,7 @@ type Return =
     inherit Default1
     static member inline InvokeOnInstance (x: 'T) = (^``Applicative<'T>`` : (static member Return : ^T -> ^``Applicative<'T>``) x)
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
     static member inline Invoke (x: 'T) : '``Applicative<'T>`` =
         let inline call (mthd: ^M, output: ^R) = ((^M or ^R) : (static member Return : _*_ -> _) output, mthd)

--- a/src/FSharpPlus/Control/Monad.fs
+++ b/src/FSharpPlus/Control/Monad.fs
@@ -22,7 +22,7 @@ type Bind =
     static member        (>>=) (source: Task<'T>        , f: 'T -> Task<'U>    ) = Task.bind f source                      : Task<'U>
     static member        (>>=) (source                  , f: 'T -> _           ) = Nullable.bind f source                  : Nullable<'U>
     #endif
-    #if !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !FABLE_COMPILER
     static member        (>>=) (source: ValueTask<'T>   , f: 'T -> ValueTask<'U>    ) = ValueTask.bind f source            : ValueTask<'U>
     #endif
 
@@ -83,7 +83,7 @@ type Join =
     #if !FABLE_COMPILER  
     static member        Join (x: Task<Task<_>>           , [<Optional>]_output: Task<'T>        , [<Optional>]_mthd: Join    ) = Task.join x                : Task<'T>
     #endif
-    #if !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !FABLE_COMPILER
     static member        Join (x: ValueTask<ValueTask<_>> , [<Optional>]_output: ValueTask<'T>   , [<Optional>]_mthd: Join    ) = ValueTask.join x           : ValueTask<'T>
     #endif
     static member        Join (x                        , [<Optional>]_output: option<'T>      , [<Optional>]_mthd: Join    ) = Option.flatten x           : option<'T>
@@ -144,7 +144,7 @@ type Return =
     #if !FABLE_COMPILER
     static member        Return (_: 'T Task        , _: Return  ) = fun x -> Task.FromResult x                    : 'T Task
     #endif
-    #if !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !FABLE_COMPILER
     static member        Return (_: 'T ValueTask   , _: Return  ) = fun (x: 'T) -> ValueTask<'T> x                : 'T ValueTask
     static member        Return (_: 'T DmStruct1   , _: Return  ) = fun (_: 'T) -> Unchecked.defaultof<_>         : 'T DmStruct1
     #endif
@@ -196,7 +196,7 @@ type Delay =
     
     #endif
     
-    #if !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !FABLE_COMPILER
     static member        Delay (_mthd: Delay   , x: unit-> ValueTask<_>                                   , _          ) = x () : ValueTask<'T>
     #endif
 

--- a/src/FSharpPlus/Control/Monad.fs
+++ b/src/FSharpPlus/Control/Monad.fs
@@ -22,7 +22,7 @@ type Bind =
     static member        (>>=) (source: Task<'T>        , f: 'T -> Task<'U>    ) = Task.bind f source                      : Task<'U>
     static member        (>>=) (source                  , f: 'T -> _           ) = Nullable.bind f source                  : Nullable<'U>
     #endif
-    #if !NET45 && !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !NETSTANDARD2_0 && !FABLE_COMPILER
     static member        (>>=) (source: ValueTask<'T>   , f: 'T -> ValueTask<'U>    ) = ValueTask.bind f source            : ValueTask<'U>
     #endif
 
@@ -83,7 +83,7 @@ type Join =
     #if !FABLE_COMPILER  
     static member        Join (x: Task<Task<_>>           , [<Optional>]_output: Task<'T>        , [<Optional>]_mthd: Join    ) = Task.join x                : Task<'T>
     #endif
-    #if !NET45 && !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !NETSTANDARD2_0 && !FABLE_COMPILER
     static member        Join (x: ValueTask<ValueTask<_>> , [<Optional>]_output: ValueTask<'T>   , [<Optional>]_mthd: Join    ) = ValueTask.join x           : ValueTask<'T>
     #endif
     static member        Join (x                        , [<Optional>]_output: option<'T>      , [<Optional>]_mthd: Join    ) = Option.flatten x           : option<'T>
@@ -144,7 +144,7 @@ type Return =
     #if !FABLE_COMPILER
     static member        Return (_: 'T Task        , _: Return  ) = fun x -> Task.FromResult x                    : 'T Task
     #endif
-    #if !NET45 && !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !NETSTANDARD2_0 && !FABLE_COMPILER
     static member        Return (_: 'T ValueTask   , _: Return  ) = fun (x: 'T) -> ValueTask<'T> x                : 'T ValueTask
     static member        Return (_: 'T DmStruct1   , _: Return  ) = fun (_: 'T) -> Unchecked.defaultof<_>         : 'T DmStruct1
     #endif
@@ -196,7 +196,7 @@ type Delay =
     
     #endif
     
-    #if !NET45 && !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !NETSTANDARD2_0 && !FABLE_COMPILER
     static member        Delay (_mthd: Delay   , x: unit-> ValueTask<_>                                   , _          ) = x () : ValueTask<'T>
     #endif
 

--- a/src/FSharpPlus/Control/MonadOps.fs
+++ b/src/FSharpPlus/Control/MonadOps.fs
@@ -1,6 +1,6 @@
 namespace FSharpPlus.Internals
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 module internal MonadOps =
     open FSharpPlus.Control

--- a/src/FSharpPlus/Control/MonadTrans.fs
+++ b/src/FSharpPlus/Control/MonadTrans.fs
@@ -1,6 +1,6 @@
 ﻿namespace FSharpPlus.Control
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 open FSharpPlus
 

--- a/src/FSharpPlus/Control/Monoid.fs
+++ b/src/FSharpPlus/Control/Monoid.fs
@@ -118,7 +118,7 @@ type Plus with
     static member inline ``+`` (x: 'a Task, y: 'a Task, [<Optional>]_mthd: Plus) = Task.lift2 Plus.Invoke x y
 #endif
 
-#if !NET45 && !NETSTANDARD2_0 && !FABLE_COMPILER
+#if !NETSTANDARD2_0 && !FABLE_COMPILER
 type Plus with    
     
     static member inline ``+`` (x: 'a ValueTask, y: 'a ValueTask, [<Optional>]_mthd: Plus) = ValueTask.lift2 Plus.Invoke x y

--- a/src/FSharpPlus/Control/Monoid.fs
+++ b/src/FSharpPlus/Control/Monoid.fs
@@ -12,7 +12,7 @@ open FSharpPlus.Data
 open FSharpPlus.Internals
 open FSharpPlus.Internals.Prelude
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 [<Extension; Sealed>]
 type Plus =

--- a/src/FSharpPlus/Control/Monoid.fs
+++ b/src/FSharpPlus/Control/Monoid.fs
@@ -118,7 +118,7 @@ type Plus with
     static member inline ``+`` (x: 'a Task, y: 'a Task, [<Optional>]_mthd: Plus) = Task.lift2 Plus.Invoke x y
 #endif
 
-#if !NETSTANDARD2_0 && !FABLE_COMPILER
+#if !FABLE_COMPILER
 type Plus with    
     
     static member inline ``+`` (x: 'a ValueTask, y: 'a ValueTask, [<Optional>]_mthd: Plus) = ValueTask.lift2 Plus.Invoke x y

--- a/src/FSharpPlus/Control/Numeric.fs
+++ b/src/FSharpPlus/Control/Numeric.fs
@@ -193,7 +193,7 @@ type Zero with
         s.SetResult v
         s.Task
     #endif
-    #if !NET45 && !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !NETSTANDARD2_0 && !FABLE_COMPILER
     static member inline Zero (_: ValueTask<'a>, _: Zero) : ValueTask<'a> =
         let (v: 'a) = Zero.Invoke ()
         ValueTask<'a>(v)

--- a/src/FSharpPlus/Control/Numeric.fs
+++ b/src/FSharpPlus/Control/Numeric.fs
@@ -193,7 +193,7 @@ type Zero with
         s.SetResult v
         s.Task
     #endif
-    #if !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !FABLE_COMPILER
     static member inline Zero (_: ValueTask<'a>, _: Zero) : ValueTask<'a> =
         let (v: 'a) = Zero.Invoke ()
         ValueTask<'a>(v)

--- a/src/FSharpPlus/Control/Numeric.fs
+++ b/src/FSharpPlus/Control/Numeric.fs
@@ -42,7 +42,7 @@ type FromBigInt =
         call Unchecked.defaultof<FromBigInt> x
 #endif
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 type FromInt64 =
     inherit Default1

--- a/src/FSharpPlus/Control/Traversable.fs
+++ b/src/FSharpPlus/Control/Traversable.fs
@@ -1,6 +1,6 @@
 ﻿namespace FSharpPlus.Control
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 open System.Runtime.InteropServices
 open System.ComponentModel

--- a/src/FSharpPlus/Control/Tuple.fs
+++ b/src/FSharpPlus/Control/Tuple.fs
@@ -161,7 +161,7 @@ type MapItem5 =
         call (Unchecked.defaultof<MapItem5>, value)
 
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 type Curry =
     static member inline Invoke f =

--- a/src/FSharpPlus/Control/ZipApplicative.fs
+++ b/src/FSharpPlus/Control/ZipApplicative.fs
@@ -24,7 +24,7 @@ type Pure =
     inherit Default1
     static member inline InvokeOnInstance (x: 'T) = (^``ZipApplicative<'T>`` : (static member Pure : ^T -> ^``ZipApplicative<'T>``) x)
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
     static member inline Invoke (x: 'T) : '``ZipApplicative<'T>`` =
         let inline call (mthd: ^M, output: ^R) = ((^M or ^R) : (static member Pure : _*_ -> _) output, mthd)
@@ -75,7 +75,7 @@ type Pure =
 type ZipApply =
     inherit Default1
  
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
     static member        ``<.>`` (struct (f: Lazy<'T->'U>        , x: Lazy<'T>             ), [<Optional>]_output: Lazy<'U>             , [<Optional>]_mthd: ZipApply) = Apply.``<*>`` (struct (f, x), _output, Unchecked.defaultof<Apply>)
     static member        ``<.>`` (struct (f: seq<_>              , x: seq<'T>              ), [<Optional>]_output: seq<'U>              , [<Optional>]_mthd: ZipApply) = Seq.map2 (<|) f x
@@ -124,7 +124,7 @@ type ZipApply =
     static member inline InvokeOnInstance (f: '``ZipApplicative<'T->'U>``) (x: '``ZipApplicative<'T>``) : '``ZipApplicative<'U>`` =
         ((^``ZipApplicative<'T->'U>`` or ^``ZipApplicative<'T>`` or ^``ZipApplicative<'U>``) : (static member (<.>) : _*_ -> _) (f, x))
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 type ZipApply with
     static member inline ``<.>`` (struct (_: ^t when ^t : null and ^t: struct, _: ^u when ^u : null and ^u: struct), _output: ^r when ^r : null and ^r: struct, _mthd: Default1) = id

--- a/src/FSharpPlus/Control/ZipApplicative.fs
+++ b/src/FSharpPlus/Control/ZipApplicative.fs
@@ -38,7 +38,7 @@ type Pure =
     #if !FABLE_COMPILER
     static member        Pure (_: 'T Task         , _: Pure) = fun x -> Task.FromResult x                     : 'T Task
     #endif
-    #if !NET45 && !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !NETSTANDARD2_0 && !FABLE_COMPILER
     static member        Pure (_: 'T ValueTask    , _: Pure) = fun (x: 'T) -> ValueTask<'T> x                 : 'T ValueTask
     #endif
     static member        Pure (x: option<'a>      , _: Pure) = Return.Return (x, Unchecked.defaultof<Return>)
@@ -89,7 +89,7 @@ type ZipApply =
     #if !FABLE_COMPILER
     static member        ``<.>`` (struct (f: Task<_>             , x: Task<'T>             ), [<Optional>]_output: Task<'U>             , [<Optional>]_mthd: ZipApply) = Task.map2 (<|) f x
     #endif
-    #if !NET45 && !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !NETSTANDARD2_0 && !FABLE_COMPILER
     static member        ``<.>`` (struct (f: ValueTask<_>        , x: ValueTask<'T>        ), [<Optional>]_output: ValueTask<'U>        , [<Optional>]_mthd: ZipApply) = ValueTask.map2 (<|) f x
     #endif
     static member        ``<.>`` (struct (f: Async<_>            , x: Async<'T>            ), [<Optional>]_output: Async<'U>            , [<Optional>]_mthd: ZipApply) : Async<'U>            = Async.map2 (<|) f x
@@ -147,7 +147,7 @@ type Map2 =
     #if !FABLE_COMPILER
     static member        Map2 (f, (x: Task<'T>           , y: Task<'U>           ), _mthd: Map2) = Task.map2 f x y
     #endif
-    #if !NET45 && !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !NETSTANDARD2_0 && !FABLE_COMPILER
     static member        Map2 (f, (x: ValueTask<'T>      , y: ValueTask<'U>      ), _mthd: Map2) = ValueTask.map2 f x y
     #endif
     static member        Map2 (f, (x                     , y                     ), _mthd: Map2) = Async.map2 f x y
@@ -194,7 +194,7 @@ type Map3 =
     #if !FABLE_COMPILER
     static member        Map3 (f, (x: Task<'T>           , y: Task<'U>           , z: Task<'V>            ), _mthd: Map3) = Task.map3 f x y z
     #endif
-    #if !NET45 && !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !NETSTANDARD2_0 && !FABLE_COMPILER
     static member        Map3 (f, (x: ValueTask<'T>      , y: ValueTask<'U>      , z: ValueTask<'V>       ), _mthd: Map3) = ValueTask.map3 f x y z
     #endif
     static member        Map3 (f, (x                     , y                     , z                      ), _mthd: Map3) = Async.map3  f x y z

--- a/src/FSharpPlus/Control/ZipApplicative.fs
+++ b/src/FSharpPlus/Control/ZipApplicative.fs
@@ -38,7 +38,7 @@ type Pure =
     #if !FABLE_COMPILER
     static member        Pure (_: 'T Task         , _: Pure) = fun x -> Task.FromResult x                     : 'T Task
     #endif
-    #if !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !FABLE_COMPILER
     static member        Pure (_: 'T ValueTask    , _: Pure) = fun (x: 'T) -> ValueTask<'T> x                 : 'T ValueTask
     #endif
     static member        Pure (x: option<'a>      , _: Pure) = Return.Return (x, Unchecked.defaultof<Return>)
@@ -89,7 +89,7 @@ type ZipApply =
     #if !FABLE_COMPILER
     static member        ``<.>`` (struct (f: Task<_>             , x: Task<'T>             ), [<Optional>]_output: Task<'U>             , [<Optional>]_mthd: ZipApply) = Task.map2 (<|) f x
     #endif
-    #if !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !FABLE_COMPILER
     static member        ``<.>`` (struct (f: ValueTask<_>        , x: ValueTask<'T>        ), [<Optional>]_output: ValueTask<'U>        , [<Optional>]_mthd: ZipApply) = ValueTask.map2 (<|) f x
     #endif
     static member        ``<.>`` (struct (f: Async<_>            , x: Async<'T>            ), [<Optional>]_output: Async<'U>            , [<Optional>]_mthd: ZipApply) : Async<'U>            = Async.map2 (<|) f x
@@ -147,7 +147,7 @@ type Map2 =
     #if !FABLE_COMPILER
     static member        Map2 (f, (x: Task<'T>           , y: Task<'U>           ), _mthd: Map2) = Task.map2 f x y
     #endif
-    #if !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !FABLE_COMPILER
     static member        Map2 (f, (x: ValueTask<'T>      , y: ValueTask<'U>      ), _mthd: Map2) = ValueTask.map2 f x y
     #endif
     static member        Map2 (f, (x                     , y                     ), _mthd: Map2) = Async.map2 f x y
@@ -194,7 +194,7 @@ type Map3 =
     #if !FABLE_COMPILER
     static member        Map3 (f, (x: Task<'T>           , y: Task<'U>           , z: Task<'V>            ), _mthd: Map3) = Task.map3 f x y z
     #endif
-    #if !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !FABLE_COMPILER
     static member        Map3 (f, (x: ValueTask<'T>      , y: ValueTask<'U>      , z: ValueTask<'V>       ), _mthd: Map3) = ValueTask.map3 f x y z
     #endif
     static member        Map3 (f, (x                     , y                     , z                      ), _mthd: Map3) = Async.map3  f x y z

--- a/src/FSharpPlus/Data/Compose.fs
+++ b/src/FSharpPlus/Data/Compose.fs
@@ -4,7 +4,7 @@ open FSharpPlus
 open FSharpPlus.Control
 
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 /// Right-to-left composition of functors. The composition of applicative functors is always applicative, but the composition of monads is not always a monad.
 [<Struct>]

--- a/src/FSharpPlus/Data/Const.fs
+++ b/src/FSharpPlus/Data/Const.fs
@@ -3,7 +3,7 @@
 open FSharpPlus
 open FSharpPlus.Internals.Prelude
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 /// <summary> The Const functor, defined as Const&lt;&#39;T, &#39;U&gt; where &#39;U is a phantom type. Useful for: Lens getters Its applicative instance plays a fundamental role in Lens.
 /// <para/>   Useful for: Lens getters.

--- a/src/FSharpPlus/Data/Cont.fs
+++ b/src/FSharpPlus/Data/Cont.fs
@@ -90,7 +90,7 @@ type Cont<'r,'t> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member CallCC (f: ('T -> Cont<'R,'U>) -> _) = Cont.callCC f : Cont<'R,'T>
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
     static member inline Lift (m: '``Monad<'T>``) = Cont ((>>=) m) : ContT<'``Monad<'R>``,'T>
 

--- a/src/FSharpPlus/Data/Coproduct.fs
+++ b/src/FSharpPlus/Data/Coproduct.fs
@@ -1,6 +1,6 @@
 ﻿namespace FSharpPlus.Data
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 open FSharpPlus
 open FSharpPlus.Control

--- a/src/FSharpPlus/Data/Error.fs
+++ b/src/FSharpPlus/Data/Error.fs
@@ -7,7 +7,7 @@ open FSharpPlus.Internals.Prelude
 open FSharpPlus.Control
 
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 /// Additional operations on Result
 [<RequireQualifiedAccess>]
 module Result =
@@ -30,7 +30,7 @@ module ResultOrException =
     let Exception : Result<_,exn>   -> _ = function Error e -> e | _ -> exn ()
 
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 /// Monad Transformer for Result<'T, 'E>
 [<Struct>]

--- a/src/FSharpPlus/Data/Kleisli.fs
+++ b/src/FSharpPlus/Data/Kleisli.fs
@@ -1,6 +1,6 @@
 ﻿namespace FSharpPlus.Data
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 open FSharpPlus
 open FSharpPlus.Control

--- a/src/FSharpPlus/Data/List.fs
+++ b/src/FSharpPlus/Data/List.fs
@@ -1,6 +1,6 @@
 ﻿namespace FSharpPlus.Data
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 open FSharpPlus
 open System.ComponentModel

--- a/src/FSharpPlus/Data/Monoids.fs
+++ b/src/FSharpPlus/Data/Monoids.fs
@@ -2,7 +2,7 @@
 
 open FSharpPlus
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 /// The dual of a monoid, obtained by swapping the arguments of append.
 [<Struct>]
 type Dual<'t> = Dual of 't with
@@ -54,7 +54,7 @@ type Last<'t> = Last of Option<'t> with
     static member run (Last a) = a                                            : 't option
 
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 /// Numeric wrapper for multiplication monoid (*, 1)
 [<Struct>]

--- a/src/FSharpPlus/Data/NonEmptyList.fs
+++ b/src/FSharpPlus/Data/NonEmptyList.fs
@@ -134,7 +134,7 @@ module NonEmptyList =
         | []   -> {Head = s; Tail = []}
         | h::t -> cons s (tails {Head = h; Tail = t})
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
     /// <summary>
     /// Maps each element of the list to an action, evaluates these actions from left to right and collect the results.
@@ -224,7 +224,7 @@ module NonEmptyList =
     /// Equivalent to [start..stop] on regular lists.
     let inline range (start: 'T) stop = create start (List.drop 1 [start..stop])
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
     /// Reduces using alternative operator `<|>`.
     let inline choice (list: NonEmptyList<'``Alt<'T>``>) = reduce (<|>) list : '``Alt<'T>``
 #endif
@@ -277,7 +277,7 @@ type NonEmptyList<'t> with
 
     static member Extract   {Head = h; Tail = _} = h : 't
 
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     static member Duplicate (s: NonEmptyList<'a>, [<Optional>]_impl: Duplicate) = NonEmptyList.tails s
     #endif
 
@@ -290,7 +290,7 @@ type NonEmptyList<'t> with
     static member FoldBack ({Head = x; Tail = xs}, f, z) = List.foldBack f (x::xs) z
     static member Sum (source: seq<NonEmptyList<'T>>) = source |> Seq.map NonEmptyList.toList |> List.concat |> NonEmptyList.ofList
 
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member ToList (s: NonEmptyList<'a>, [<Optional>]_impl: ToList) = NonEmptyList.toList s    
 

--- a/src/FSharpPlus/Data/NonEmptyMap.fs
+++ b/src/FSharpPlus/Data/NonEmptyMap.fs
@@ -246,7 +246,7 @@ module NonEmptyMap =
     /// Returns the union of two maps, preferring values from the first in case of duplicate keys.
     let union (source: NonEmptyMap<'Key, 'T>) (altSource: NonEmptyMap<'Key, 'T>) = unionWith (fun x _ -> x) source altSource
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
     let inline traverse (f: 'T->'``Functor<'U>``) (m: NonEmptyMap<'K, 'T>) : '``Functor<NonEmptyMap<'K, 'U>>`` =
         let m' = traverse f (toMap m) : '``Functor<Map<'K, 'U>>``
         ofMap <!> m' : '``Functor<NonEmptyMap<'K, 'U>>``
@@ -266,7 +266,7 @@ type NonEmptyMap<[<EqualityConditionalOn>]'Key,[<EqualityConditionalOn;Compariso
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Unzip (x: NonEmptyMap<'K, ('T * 'U)>) = NonEmptyMap.unzip x : NonEmptyMap<'K, 'T> * NonEmptyMap<'K, 'U>
 
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Traverse (x: NonEmptyMap<'K, 'T>, f: 'T->'``Functor<'U>``) : '``Functor<NonEmptyMap<'K, 'U>>`` = NonEmptyMap.traverse f x
 

--- a/src/FSharpPlus/Data/NonEmptySet.fs
+++ b/src/FSharpPlus/Data/NonEmptySet.fs
@@ -235,7 +235,7 @@ type NonEmptySet<[<EqualityConditionalOn>]'a when 'a: comparison> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member FoldBack (set: NonEmptySet<'a>, f, z) = Set.foldBack f set.Value z
 
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member ToList (s: NonEmptySet<'a>, [<Optional>]_impl: ToList) = NonEmptySet.toList s
 

--- a/src/FSharpPlus/Data/Option.fs
+++ b/src/FSharpPlus/Data/Option.fs
@@ -6,7 +6,7 @@ open FSharpPlus.Internals.Prelude
 open FSharpPlus.Control
 
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 /// Additional operations on Option
 [<RequireQualifiedAccess>]

--- a/src/FSharpPlus/Data/Reader.fs
+++ b/src/FSharpPlus/Data/Reader.fs
@@ -76,7 +76,7 @@ type Reader<'r,'t> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Local (m, f: 'R1->'R2) = Reader.local f m      : Reader<'R1,'T>
 
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Zip (x, y) = Reader.zip x y
 
@@ -91,7 +91,7 @@ type Reader<'r,'t> with
     static member Delay (body: unit->Reader<'R,'T>)  = Reader (fun s -> Reader.run (body ()) s) : Reader<'R,'T>
 
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 /// Monad Transformer for Reader<'R, 'T>
 [<Struct>]

--- a/src/FSharpPlus/Data/Seq.fs
+++ b/src/FSharpPlus/Data/Seq.fs
@@ -1,6 +1,6 @@
 ﻿namespace FSharpPlus.Data
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 open System.ComponentModel
 open FSharpPlus

--- a/src/FSharpPlus/Data/State.fs
+++ b/src/FSharpPlus/Data/State.fs
@@ -94,7 +94,7 @@ type State<'s,'t> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Put x     = State.put x                      : State<'S,unit>
 
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Zip (x, y) = State.zip x y
     #endif
@@ -105,7 +105,7 @@ type State<'s,'t> with
     static member Delay (body: unit->State<'S,'T>)  = State (fun s -> State.run (body ()) s) : State<'S,'T>
 
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 open FSharpPlus.Control
 open FSharpPlus.Internals.Prelude

--- a/src/FSharpPlus/Data/Validation.fs
+++ b/src/FSharpPlus/Data/Validation.fs
@@ -5,7 +5,7 @@ namespace FSharpPlus.Data
 open System.ComponentModel
 open FSharpPlus
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 open FSharpPlus.Lens
 #endif
 
@@ -100,7 +100,7 @@ module Validation =
         | Success a -> folder a state
         | Failure _ -> state
 
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
 
     /// Traverse the Success case with the supplied function.
     let inline traverse (f: 'T -> '``Functor<'U>``) (source: Validation<'Error, 'T>) : '``Functor<Validation<'Error, 'U>>`` =
@@ -219,7 +219,7 @@ module Validation =
     [<System.Obsolete("This function will not be supported in future versions.")>]
     let validate (e: 'e) (p: 'a -> bool) (a: 'a) : Validation<'e,'a> = if p a then Success a else Failure e
 
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     /// validationNel : Result<'a,'e> -> Validation (NonEmptyList<'e>) a
     /// This is 'liftError' specialized to 'NonEmptyList', since
     /// they are a common semigroup to use.
@@ -241,7 +241,7 @@ module Validation =
     let inline _Success x = (prism Success <| either Ok (Error << Failure)) x
     let inline _Failure x = (prism Failure <| either (Error << Failure) Ok) x
     #endif
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     let inline isoValidationResult x = x |> iso toResult ofResult
     #endif
     
@@ -308,7 +308,7 @@ type Validation<'error, 't> with
     static member inline Map3 (f, x: Validation<'Error, 'T>, y: Validation<_, 'U>, z: Validation<_, 'V>) : Validation<_, 'W> = Validation.map3 f x y z
 
     // as Alternative (inherits from Applicative)
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     static member inline get_Empty () = Failure (getEmpty ())
     static member inline (<|>) (x: Validation<'Error, 'T>, y: Validation<_,_>) = Validation.appValidation Control.Append.Invoke x y
     #endif
@@ -327,7 +327,7 @@ type Validation<'error, 't> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Bimap (x: Validation<'T, 'V>, f: 'T -> 'U, g: 'V -> 'W) : Validation<'U, 'W> = Validation.bimap f g x
 
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
 
     // as Traversable
     [<EditorBrowsable(EditorBrowsableState.Never)>]

--- a/src/FSharpPlus/Data/ValueOption.fs
+++ b/src/FSharpPlus/Data/ValueOption.fs
@@ -6,7 +6,7 @@ open FSharpPlus.Internals.Prelude
 open FSharpPlus.Control
 
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 /// Additional operations on ValueOption
 [<RequireQualifiedAccess>]

--- a/src/FSharpPlus/Data/Writer.fs
+++ b/src/FSharpPlus/Data/Writer.fs
@@ -22,7 +22,7 @@ module Writer =
     let map f (Writer (a: 'T, w)) = Writer (f a, w)                                            : Writer<'Monoid,'U>
 
 
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
 
     /// Combines two Writers into one by applying a mapping function.
     let inline map2 f (Writer (a: 'T, w1)) (Writer (b: 'U, w2)) = Writer (f a b, w1 ++ w2) : Writer<'Monoid,'V>
@@ -106,7 +106,7 @@ type Writer<'monoid,'t> with
     static member        Extract (Writer (_: 'W, a: 'T)) = a
     static member        (=>>)   (Writer (w: 'W, _: 'T) as g, f : Writer<_,_> -> 'U) = Writer (w, f g)
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 
 /// Monad Transformer for Writer<'Monoid, 'T>

--- a/src/FSharpPlus/Data/ZipList.fs
+++ b/src/FSharpPlus/Data/ZipList.fs
@@ -53,7 +53,7 @@ type ZipList<'s> with
 
     static member ToSeq (ZipList x) = x
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
     static member inline get_Zero () = result (getZero ()) : ZipList<'a>
     static member inline (+) (x: ZipList<'a>, y: ZipList<'a>) = lift2 plus x y : ZipList<'a>

--- a/src/FSharpPlus/Extensions/Array.fs
+++ b/src/FSharpPlus/Extensions/Array.fs
@@ -150,7 +150,7 @@ module Array =
     /// <returns>
     /// The index of the slice.
     /// </returns>
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
 
     /// <summary>
     /// Returns the index of the first occurrence of the specified slice in the source.

--- a/src/FSharpPlus/Extensions/AsyncEnumerable.fs
+++ b/src/FSharpPlus/Extensions/AsyncEnumerable.fs
@@ -1,6 +1,6 @@
 ﻿namespace FSharpPlus
 
-#if !FABLE_COMPILER && (NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER)
+#if !FABLE_COMPILER
 
 open System
 open System.Threading

--- a/src/FSharpPlus/Extensions/Enumerator.fs
+++ b/src/FSharpPlus/Extensions/Enumerator.fs
@@ -1,6 +1,6 @@
 namespace FSharpPlus
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 /// Additional operations on IEnumerator
 [<RequireQualifiedAccess>]

--- a/src/FSharpPlus/Extensions/Extensions.fs
+++ b/src/FSharpPlus/Extensions/Extensions.fs
@@ -70,7 +70,7 @@ module Extensions =
 
     #endif
 
-    #if !NET45 && !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !NETSTANDARD2_0 && !FABLE_COMPILER
 
     type ValueTask<'t> with
 

--- a/src/FSharpPlus/Extensions/Extensions.fs
+++ b/src/FSharpPlus/Extensions/Extensions.fs
@@ -70,7 +70,7 @@ module Extensions =
 
     #endif
 
-    #if !NETSTANDARD2_0 && !FABLE_COMPILER
+    #if !FABLE_COMPILER
 
     type ValueTask<'t> with
 

--- a/src/FSharpPlus/Extensions/List.fs
+++ b/src/FSharpPlus/Extensions/List.fs
@@ -243,7 +243,7 @@ module List =
             member _.GetEnumerator () = (source :> _ seq).GetEnumerator ()
             member _.GetEnumerator () = (source :> System.Collections.IEnumerable).GetEnumerator () }
 
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
 
     /// <summary>
     /// Gets the index of the first occurrence of the specified slice in the source.

--- a/src/FSharpPlus/Extensions/Seq.fs
+++ b/src/FSharpPlus/Extensions/Seq.fs
@@ -203,7 +203,7 @@ module Seq =
     /// <returns>The seq converted to a System.Collections.Generic.IReadOnlyList</returns>
     let toIReadOnlyList (source: seq<_>) = source |> ResizeArray |> ReadOnlyCollection :> IReadOnlyList<_>
     #endif
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     /// <summary>
     /// Gets the index of the first occurrence of the specified slice in the source.
     /// </summary>

--- a/src/FSharpPlus/Extensions/ValueTask.fs
+++ b/src/FSharpPlus/Extensions/ValueTask.fs
@@ -1,6 +1,6 @@
 namespace FSharpPlus
 
-#if !NET45 && !NETSTANDARD2_0 && !FABLE_COMPILER
+#if !NETSTANDARD2_0 && !FABLE_COMPILER
 
 /// Additional operations on ValueTask<'T>
 [<RequireQualifiedAccess>]

--- a/src/FSharpPlus/Extensions/ValueTask.fs
+++ b/src/FSharpPlus/Extensions/ValueTask.fs
@@ -1,6 +1,6 @@
 namespace FSharpPlus
 
-#if !NETSTANDARD2_0 && !FABLE_COMPILER
+#if !FABLE_COMPILER
 
 /// Additional operations on ValueTask<'T>
 [<RequireQualifiedAccess>]

--- a/src/FSharpPlus/FSharpPlus.fsproj
+++ b/src/FSharpPlus/FSharpPlus.fsproj
@@ -27,7 +27,7 @@
     <DefineConstants Condition=" '$(Configuration)' == 'Test'">$(DefineConstants);TEST_TRACE</DefineConstants>
     <DefineConstants Condition=" '$(Configuration)' == 'Fable'">$(DefineConstants);FABLE_COMPILER</DefineConstants>
     <DefineConstants Condition=" '$(Configuration)' == 'Fable4'">$(DefineConstants);FABLE_COMPILER;FABLE_COMPILER_4</DefineConstants>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <!--<OutputPath>..\..\bin</OutputPath>-->
   </PropertyGroup>
   <ItemGroup>

--- a/src/FSharpPlus/FSharpPlus.fsproj
+++ b/src/FSharpPlus/FSharpPlus.fsproj
@@ -19,14 +19,13 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Configurations>Debug;Release;Fable;Fable3;Test</Configurations>
+    <Configurations>Debug;Release;Fable;Test</Configurations>
     <Platforms>AnyCPU</Platforms>
     <LangVersion>8.0</LangVersion>
-    <LangVersion Condition=" '$(Configuration)' == 'Fable' OR '$(Configuration)' == 'Fable3' ">6.0</LangVersion>
+    <LangVersion Condition=" '$(Configuration)' == 'Fable' ">6.0</LangVersion>
 
     <DefineConstants Condition=" '$(Configuration)' == 'Test'">$(DefineConstants);TEST_TRACE</DefineConstants>
     <DefineConstants Condition=" '$(Configuration)' == 'Fable'">$(DefineConstants);FABLE_COMPILER</DefineConstants>
-    <DefineConstants Condition=" '$(Configuration)' == 'Fable3'">$(DefineConstants);FABLE_COMPILER;FABLE_COMPILER_3</DefineConstants>
     <DefineConstants Condition=" '$(Configuration)' == 'Fable4'">$(DefineConstants);FABLE_COMPILER;FABLE_COMPILER_4</DefineConstants>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
     <!--<OutputPath>..\..\bin</OutputPath>-->

--- a/src/FSharpPlus/Internals.fs
+++ b/src/FSharpPlus/Internals.fs
@@ -327,7 +327,7 @@ type BitConverter =
         if isNull value then nullArg "value"
         BitConverter.ToString (value, startIndex, value.Length - startIndex)
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 // findSliceIndex
 module FindSliceIndex =
     open System.Collections.Generic

--- a/src/FSharpPlus/Lens.fs
+++ b/src/FSharpPlus/Lens.fs
@@ -1,6 +1,6 @@
 ﻿namespace FSharpPlus
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 open FSharpPlus.Operators
 open FSharpPlus.Data

--- a/src/FSharpPlus/Operators.fs
+++ b/src/FSharpPlus/Operators.fs
@@ -29,7 +29,7 @@ module Operators =
     /// <category index="0">Common Combinators</category>
     let inline uncurry f (x: 'T1, y: 'T2) : 'Result = f x y
     
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     /// <summary>
     /// Takes a function expecting a tuple of any N number of elements and returns a function expecting N curried arguments.
     /// </summary>
@@ -122,7 +122,7 @@ module Operators =
     /// <category index="0">Common Combinators</category>
     let inline tuple8<'T1, 'T2, 'T3, 'T4, 'T5, 'T6, 'T7, 'T8> (t1: 'T1) (t2: 'T2) (t3: 'T3) (t4: 'T4) (t5: 'T5) (t6: 'T6) (t7: 'T7) (t8: 'T8) = t1, t2, t3, t4, t5, t6, t7, t8
          
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
 
     // Functor ----------------------------------------------------------------
 
@@ -431,7 +431,7 @@ module Operators =
     let inline invmap (f: 'T -> 'U) (g: 'U -> 'T) (source: '``InvariantFunctor<'T>``) = Invmap.Invoke f g source : '``InvariantFunctor<'U>``
 
 
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
 
     // Category ---------------------------------------------------------------
 
@@ -1399,7 +1399,7 @@ module Operators =
     let inline mapItem5 (mapping: 'T -> 'U) (tuple: '``('A * 'B * 'C * 'D * 'T * ..)``) = MapItem5.Invoke mapping tuple : '``('A * 'B * 'C * 'D * 'U * ..)``
     
     
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     
     // Converter
 
@@ -1445,7 +1445,7 @@ module Operators =
 
     #endif
 
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
 
     /// <summary>
     /// Converts to a value from its string representation.
@@ -1594,7 +1594,7 @@ module Operators =
 
 #endif
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
     // Additional functions
 
@@ -1643,7 +1643,7 @@ module Operators =
     let dispose (resource: System.IDisposable) = match resource with null -> () | x -> x.Dispose ()
 
     
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
 
     /// <summary>Additional operators for Arrows related functions which shadows some F# operators for bitwise functions.</summary>
     module Arrows =

--- a/src/FSharpPlus/Parsing.fs
+++ b/src/FSharpPlus/Parsing.fs
@@ -1,6 +1,6 @@
 ﻿namespace FSharpPlus
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 
 [<AutoOpen>]
 module Parsing =

--- a/tests/CSharpLib/CSharpLib.csproj
+++ b/tests/CSharpLib/CSharpLib.csproj
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <Configurations>Debug;Release;Fable</Configurations>
     <Platforms>AnyCPU</Platforms>
-    <TargetFrameworks>netstandard2.1</TargetFrameworks>
-    <LangVersion Condition=" '$(TargetFramework)' == 'netstandard2.1'">8.0</LangVersion>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/tests/CSharpLib/CustomerId.cs
+++ b/tests/CSharpLib/CustomerId.cs
@@ -2,10 +2,7 @@
 
 namespace CSharpLib
 {
-    public struct CustomerId : IEquatable<CustomerId>
-#if NETSTANDARD2_1
-    ,ICustomerId
-#endif
+    public struct CustomerId : IEquatable<CustomerId>, ICustomerId
     {
         public long Value { get; }
         public CustomerId(long value) => this.Value = value;
@@ -26,7 +23,6 @@ namespace CSharpLib
             return false;
         }
     }
-#if NETSTANDARD2_1 
     public interface ICustomerId
     {
         long Value { get; }
@@ -41,5 +37,4 @@ namespace CSharpLib
             return false;
         }
     }
-#endif
 }

--- a/tests/FSharpPlus.Tests/Asyncs.fs
+++ b/tests/FSharpPlus.Tests/Asyncs.fs
@@ -1,7 +1,5 @@
 ﻿namespace FSharpPlus.Tests
 
-#if !NET462 && !NETSTANDARD2_0
-
 module Async =
 
     open System
@@ -109,4 +107,3 @@ module Async =
             CollectionAssert.AreEquivalent ((Async.AsTaskAndWait t123).Exception.InnerExceptions, (Async.AsTaskAndWait t123').Exception.InnerExceptions, "Async.map3 (fun x y z -> [x; y; z]) t1 t2 t3 is the same as transpose [t1; t2; t3]")
             CollectionAssert.AreNotEquivalent ((Async.AsTaskAndWait t123).Exception.InnerExceptions, (Async.AsTaskAndWait t123'').Exception.InnerExceptions, "Async.map3 (fun x y z -> [x; y; z]) t1 t2 t3 is not the same as sequence [t1; t2; t3]")
 
-#endif

--- a/tests/FSharpPlus.Tests/FSharpPlus.Tests.fsproj
+++ b/tests/FSharpPlus.Tests/FSharpPlus.Tests.fsproj
@@ -12,7 +12,7 @@
     <Platforms>AnyCPU</Platforms>
     <DefineConstants Condition=" '$(Configuration)' == 'Test'">$(DefineConstants);TEST_TRACE</DefineConstants>
     <DefineConstants Condition=" '$(Configuration)' == 'Fable'">$(DefineConstants);FABLE_COMPILER</DefineConstants>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Helpers.fs" />

--- a/tests/FSharpPlus.Tests/FSharpPlus.Tests.fsproj
+++ b/tests/FSharpPlus.Tests/FSharpPlus.Tests.fsproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <LangVersion Condition=" '$(Configuration)' == 'Fable' OR '$(Configuration)' == 'Fable3' ">6.0</LangVersion>
+    <LangVersion Condition=" '$(Configuration)' == 'Fable' ">6.0</LangVersion>
     <IsPackable>false</IsPackable>
     <Configurations>Debug;Release;Fable;Test</Configurations>
     <Platforms>AnyCPU</Platforms>

--- a/tests/FSharpPlus.Tests/Parsing.fs
+++ b/tests/FSharpPlus.Tests/Parsing.fs
@@ -77,12 +77,10 @@ module Parsing =
         Assert.IsTrue((v3.Value.Value = 1))
         let v4 : ProductId option = tryParse "P_X"
         Assert.IsTrue(Option.isNone v4)
-#if NETSTANDARD3_0
         let v5 : ICustomerId option = tryParse "C_1"
         Assert.IsTrue((v5.Value.Value = 1L))
         let v6 : ICustomerId option = tryParse "C_X"
         Assert.IsTrue(Option.isNone v6)
-#endif
 
     [<Test>]
     let scanfParsing () =

--- a/tests/FSharpPlus.Tests/ValueTask.fs
+++ b/tests/FSharpPlus.Tests/ValueTask.fs
@@ -1,7 +1,5 @@
 ﻿namespace FSharpPlus.Tests
 
-#if !NET462 && !NETSTANDARD2_0
-
 module ValueTask =
 
     open System
@@ -199,4 +197,3 @@ module ValueTask =
             let t123'' = sequence [t1; t2; t3]
             CollectionAssert.AreEquivalent (t123.AsTask().Exception.InnerExceptions, t123'.AsTask().Exception.InnerExceptions, "ValueTask.map3 (fun x y z -> [x; y; z]) t1 t2 t3 is the same as transpose [t1; t2; t3]")
             CollectionAssert.AreNotEquivalent (t123.AsTask().Exception.InnerExceptions, t123''.AsTask().Exception.InnerExceptions, "ValueTask.map3 (fun x y z -> [x; y; z]) t1 t2 t3 is not the same as sequence [t1; t2; t3]")
-#endif

--- a/tests/FSharpPlusFable.Tests/FSharpPlusFable.Tests.fsproj
+++ b/tests/FSharpPlusFable.Tests/FSharpPlusFable.Tests.fsproj
@@ -4,10 +4,9 @@
     <OutputType>Exe</OutputType>
     <Configurations>Debug;Release;Fable</Configurations>
     <Platforms>AnyCPU</Platforms>
-    <LangVersion Condition=" '$(Configuration)' == 'Fable' ">6.0</LangVersion>
     <DefineConstants Condition=" '$(Configuration)' == 'Fable'">$(DefineConstants);FABLE_COMPILER;FABLE_COMPILER_FAKE</DefineConstants>
     <DefineConstants Condition=" '$(Configuration)' == 'Fable4'">$(DefineConstants);FABLE_COMPILER;FABLE_COMPILER_4;FABLE_COMPILER_FAKE</DefineConstants>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
 

--- a/tests/FSharpPlusFable.Tests/FSharpPlusFable.Tests.fsproj
+++ b/tests/FSharpPlusFable.Tests/FSharpPlusFable.Tests.fsproj
@@ -2,11 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <Configurations>Debug;Release;Fable;Fable3</Configurations>
+    <Configurations>Debug;Release;Fable</Configurations>
     <Platforms>AnyCPU</Platforms>
-    <LangVersion Condition=" '$(Configuration)' == 'Fable' OR '$(Configuration)' == 'Fable3' ">6.0</LangVersion>
+    <LangVersion Condition=" '$(Configuration)' == 'Fable' ">6.0</LangVersion>
     <DefineConstants Condition=" '$(Configuration)' == 'Fable'">$(DefineConstants);FABLE_COMPILER;FABLE_COMPILER_FAKE</DefineConstants>
-    <DefineConstants Condition=" '$(Configuration)' == 'Fable3'">$(DefineConstants);FABLE_COMPILER;FABLE_COMPILER_3;FABLE_COMPILER_FAKE</DefineConstants>
     <DefineConstants Condition=" '$(Configuration)' == 'Fable4'">$(DefineConstants);FABLE_COMPILER;FABLE_COMPILER_4;FABLE_COMPILER_FAKE</DefineConstants>
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>

--- a/tests/FSharpPlusFable.Tests/FSharpTests/Extensions.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/Extensions.fs
@@ -46,7 +46,7 @@ let ExtensionsTest =
                    let r2 = m1 |> Map.unionWith konst m2
                    equalMap r1 r2)
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
       testCase "Bind" 
         (fun () ->  let x = [1;2] >>= fun x -> [string x ; string (x + 1000) ]
                     let y = { Head = 1; Tail = [2] } >>= fun x -> { Head = string x ; Tail = [string (x + 1000)] }

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General.fs
@@ -158,7 +158,7 @@ let monadTransformers = testList "MonadTransformers" [
     #endif
     ]
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 module ProfunctorDefaults =
     type Fun<'T,'U> = Fun of ('T -> 'U) with
         static member Dimap ((Fun f): Fun<'B,'C>, g: 'A->'B, h:'C->'D) = Fun (g >> f >> h)
@@ -169,7 +169,7 @@ module ProfunctorDefaults =
     ()
 #endif
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 module BifunctorDefaults =
     type Tup<'a,'b> = Tup of ('a * 'b) with
         static member Bimap (Tup (a, b), f, g) = Tup (f a, g b)
@@ -180,7 +180,7 @@ module BifunctorDefaults =
     ()
 #endif
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 type StringCodec<'t> = StringCodec of ReaderT<string, Result<'t,string>> * ('t -> Const<string, unit>) with
     static member Invmap (StringCodec (d, e), f: 'T -> 'U, g: 'U -> 'T) = StringCodec (map f d, contramap g e)
 module StringCodec =
@@ -189,7 +189,7 @@ module StringCodec =
 #endif
 
 let invariant = testList "Invariant" [
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
     testCase "testStringToIntDerivedFromFloat" (fun () ->
         let floatCodec = StringCodec (ReaderT (tryParse >> Option.toResultWith "Parse error"), string<float> >> Const)
         let floatParsed  = StringCodec.decode floatCodec "1.8"
@@ -234,7 +234,7 @@ let bitConverter = testList "BitConverter" [
 
 let curry = testList "Curry" [
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
     testCase "curryTest" (fun () ->
     
         #if !FABLE_COMPILER
@@ -270,7 +270,7 @@ let curry = testList "Curry" [
         ())
 #endif
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
     testCase "uncurryTest" (fun () ->
         let g2  x y   = [x + y]
         let g3  x y z = [x + y + z]

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General.fs
@@ -122,7 +122,7 @@ let monadTransformers = testList "MonadTransformers" [
         let _ = put initialState : ChoiceT<State<int, Choice<unit,string>>>
 
         ())
-    #if !NETSTANDARD3_0
+
     testCase "testStateT" (fun () ->
         let lst1: StateT<string,_> = StateT.lift [1;2]
         let lst2: StateT<string,_> = StateT.lift [4;5]
@@ -154,7 +154,6 @@ let monadTransformers = testList "MonadTransformers" [
         equal (Ok 11) x
         let y = (fn |> ResultT.run |> Reader.run) -1
         equal (Error NegativeValue) y)
-    #endif
     #endif
     ]
 

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/Alternative.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/Alternative.fs
@@ -8,7 +8,7 @@ open FSharpPlus.Data
 
 
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 let testEmpty () =
     let _: WrappedListE<int> = empty
     let _: list<int>         = empty
@@ -21,7 +21,7 @@ let testEmpty () =
     ()
 #endif
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 let testAppend () =
     let _ = WrappedListE [1;2] <|> WrappedListE [3;4]
     let _ = [1;2] <|> [3;4]
@@ -35,7 +35,7 @@ let testAppend () =
     ()
 #endif
 let alternative = testList "Alternative" [
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
     testCase "testEmptyAndAppendForCustomType" (fun () ->
         let u = WrappedListE [1;2]
         let v = WrappedListG [1;2]
@@ -61,7 +61,7 @@ let alternative = testList "Alternative" [
         Assert.AreEqual (Some 1, z))
 #endif
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
     testCase "testChoice" (fun () ->
         let s = seq { 
             yield (SideEffects.add "a"; None)

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/Applicative.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/Applicative.fs
@@ -70,7 +70,7 @@ let applicative = testList "Applicative" [
         Assert.IsInstanceOf<Option<bool>> testGTE4)
     #endif
 
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     testCase "applicatives" (fun () -> 
 
         let run (ZipList x) = x

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/Collections.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/Collections.fs
@@ -14,7 +14,7 @@ module Collections =
 
     open System.Collections.Concurrent
 
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     let testCollections =
         let bigSeq = seq {1..10000000}
         let bigLst = [ 1..10000000 ]
@@ -39,7 +39,7 @@ module Collections =
         ()
     #endif
 
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     let testSeqConversions =
         #if !FABLE_COMPILER
         let sk: Generic.Stack<_>          = ofSeq { 1 .. 3 }
@@ -125,7 +125,7 @@ module Collections =
         ()
     #endif
 
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     let testListConversions =
 
         // From sequence

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/Foldable.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/Foldable.fs
@@ -9,7 +9,7 @@ open FSharpPlus.Data
 open System
 open System.Collections.ObjectModel
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 let foldables =
     let _10  = foldBack (+) (seq [1;2;3;4]) 0
     let _323 = toList (seq [3;2;3])
@@ -34,7 +34,7 @@ let foldable = testList "Foldable" [
         SideEffects.are [])
 #endif
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
     testList "filterDefaultCustom" [
         #if !FABLE_COMPILER
         testCase "WrappedListA" (fun () ->
@@ -57,7 +57,7 @@ let foldable = testList "Foldable" [
     ]
 #endif
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
     testList "foldAternatives" [
         testCase "Option list" (fun () ->
             let x = choice [None; Some 3; Some 4; None]
@@ -70,7 +70,7 @@ let foldable = testList "Foldable" [
     ]
 #endif
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
     testList "fromToSeq" [
         #if !FABLE_COMPILER
         testCase "dictionary" (fun () ->
@@ -120,13 +120,13 @@ let foldable = testList "Foldable" [
         Assert.IsInstanceOf<Option<seq<int>>> (Some sortedSeq))
 #endif
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
     testCase "intersperse" (fun () ->
         equal "a,b,c,d,e" (intersperse ',' "abcde")
         equal ["a";",";"b";",";"c";",";"d";",";"e"] (intersperse "," ["a";"b";"c";"d";"e"]))
 #endif
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
     testCase "intercalate" (fun () ->
         equal "Lorem, ipsum, dolor" (intercalate ", " ["Lorem"; "ipsum"; "dolor"]))
 #endif
@@ -163,7 +163,7 @@ let foldable = testList "Foldable" [
         equal 50 (foldMap ((+) 10) iReadOnlyList))
 #endif
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
     testCase "exists" (fun () ->
         SideEffects.reset ()
         let _ = exists ((=) 2) [1..3]
@@ -175,7 +175,7 @@ let foldable = testList "Foldable" [
         ())
 #endif
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
     testList "pick" [
         #if !FABLE_COMPILER
         testCase "StringBuilder" (fun () ->
@@ -201,7 +201,7 @@ let foldable = testList "Foldable" [
     ]
 #endif
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
     testList "minimum" [
         testCase "list" (fun () ->
             let _ = minimum [1..3]
@@ -225,7 +225,7 @@ let foldable = testList "Foldable" [
     ]
 #endif
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
     testList "maxBy" [
         testCase "list" (fun () ->
             let _ = maxBy id [1..3]
@@ -249,7 +249,7 @@ let foldable = testList "Foldable" [
     ]
 #endif
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
     testList "length" [
         testCase "list" (fun () ->
             let _ = length [1..3]
@@ -273,7 +273,7 @@ let foldable = testList "Foldable" [
     ]
 #endif
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
     testList "tryHead" [
         testCase "seq" (fun () ->
             let s                = tryHead <| seq [1;2]
@@ -306,7 +306,7 @@ let foldable = testList "Foldable" [
     ]
 #endif
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
     testCase "tryLast" (fun () ->
         let s                = tryLast <| seq [1;2]
         let s': int option   = tryLast <| seq []

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/Functor.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/Functor.fs
@@ -34,7 +34,7 @@ let functor = testList "Functor" [
         let tenEncoded = StringCodec.encode intCodec 10
         equal oneParsed (Result<int, string>.Ok 1)
         equal tenEncoded "10" )
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     testList "mapDefaultCustom" [
         testCase "nelist" (fun () -> 
 
@@ -140,7 +140,7 @@ let functor = testList "Functor" [
     ]
     #endif
 
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     testCase "unzip" (fun () -> 
         let testVal = unzip {Head = (1, 'a'); Tail = [(2, 'b');(3, 'b')]}
         #if !FABLE_COMPILER
@@ -154,7 +154,7 @@ let functor = testList "Functor" [
         Assert.AreEqual((NonEmptyMap.Create((1,(true)), (2, (false))),NonEmptyMap.Create((1,('a')), (2, ( 'b')))),testVal2))
     #endif
 
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     testCase "zipTest" (fun () ->
 
         SideEffects.reset ()
@@ -239,7 +239,7 @@ let functor = testList "Functor" [
         ())
     #endif
 
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     testCase "genericZipShortest" (fun () ->
         let a = zip [|1; 2; 3|]  [|"a"; "b"|]
         equalSeq [|1,"a"; 2,"b"|] a

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/Indexable.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/Indexable.fs
@@ -11,7 +11,7 @@ open System.Collections.ObjectModel
 open FSharpPlus.Control
 
 let indexable = testList "Indexable" [
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     testList "testCompileAndExecuteItem" [
         testCase "map" (fun () ->
             let a = Map.ofSeq [1, "one"; 2, "two"]
@@ -68,7 +68,7 @@ let indexable = testList "Indexable" [
     ]
     #endif
 
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     testList "testCompileAndExecuteTryItem" [
         testCase "map" (fun () ->
             let a = Map.ofSeq [1, "one"; 2, "two"]
@@ -228,7 +228,7 @@ let indexable = testList "Indexable" [
         equalSeq ["Using WrappedMapA's TraverseIndexed"] (SideEffects.get ()))
     #endif
 
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     testCase "findIndexUsage" (fun () ->
         let m1 = WrappedListD [0..4]
         SideEffects.reset ()
@@ -237,7 +237,7 @@ let indexable = testList "Indexable" [
         equal i1 2)
     #endif
 
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     testCase "findSliceIndexUsage" (fun () ->
         let m1 = WrappedListD [0..4]
         let m2 = WrappedListD [1..3]

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/Lensing.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/Lensing.fs
@@ -5,7 +5,7 @@ open Testing
 open FSharpPlus
 open FSharpPlus.Data
 open System
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 open FSharpPlus.Lens
 type Person = { Name: string; DateOfBirth: DateTime }
 module Person =
@@ -20,7 +20,7 @@ let rayuela =
                  DateOfBirth = DateTime (1914, 8, 26) } }
 #endif
 let lensing = testList "Lensing" [
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
     testCase "Lens" (fun () ->
                equal (view Book._authorName rayuela) "Julio Cortázar")
     testCase "Lens view 1, 2" (fun () ->

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/Monad.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/Monad.fs
@@ -5,13 +5,13 @@ open FSharpPlus
 open FSharpPlus.Data
 #nowarn "686"
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 let option<'t> = monad<Option<'t>>
 let list<'t>   = monad'<list<'t>>
 #endif
 
 let monad = testList "Monad" [
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     testCase "joinDefaultCustom" (fun () -> 
         let x = join [[1];[2]]
         equal [1;2] x
@@ -23,7 +23,7 @@ let monad = testList "Monad" [
         equal ["Join"] (SideEffects.get ()))
     #endif
 
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     testCase "workFlow" (fun () ->       
         let testVal = 
             monad {

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/Monoid.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/Monoid.fs
@@ -10,7 +10,7 @@ open FSharpPlus.Data
 open System.Threading.Tasks
 #endif
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 type ZipList<'s> = ZipList of 's seq with
     static member Return (x:'a)                               = ZipList (Seq.initInfinite (konst x))
     static member Map   (ZipList x, f: 'a->'b)                = ZipList (Seq.map f x)
@@ -44,7 +44,7 @@ let monoid = testList "Monoid" [
         #if !FABLE_COMPILER
         let (WrappedListB x) = Seq.sum [WrappedListB [10]; WrappedListB [15]]
         #endif
-        #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+        #if !FABLE_COMPILER
         //equalSeq [10;15] x // fails to infer type?
         let (WrappedListC y) = Seq.sum [WrappedListC [10]; WrappedListC [15]]
         equalSeq [10] y
@@ -71,7 +71,7 @@ let monoid = testList "Monoid" [
         equal ["Using optimized Sum"] (SideEffects.get ())
         #endif
 
-        #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+        #if !FABLE_COMPILER
         let _wl = WrappedListB  [2..10]
 
         let _arrayGroup = groupBy ((%)/> 2) [|11;2;3;9;5;6;7;8;9;10|]

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/MonoidCompile.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/MonoidCompile.fs
@@ -10,7 +10,7 @@ open FSharpPlus.Data
 open System.Threading.Tasks
 #endif
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 type ZipList<'s> = ZipList of 's seq with
     static member Return (x:'a)                               = ZipList (Seq.initInfinite (konst x))
     static member Map   (ZipList x, f: 'a->'b)                = ZipList (Seq.map f x)
@@ -49,13 +49,13 @@ let testCompile =
     let _quot23      = plus       (zero)         <@ ResizeArray ([2;3])   @>
     let _quot13      = plus       (zero)         <@ ("1","3") @>
     #endif
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     let lzy1 = plus (lazy [1]) (lazy [2;3])
     #endif
     #if !FABLE_COMPILER
     let _lzy = plus (zero) lzy1
     #endif
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     let asy1 = plus (async.Return [1]) (async.Return [2;3])
     #endif
     #if !FABLE_COMPILER
@@ -64,7 +64,7 @@ let testCompile =
     let _bigNestedTuple2 = (1, System.Tuple (8, "ff",3,4,5,6,7,8,9,10,11,12,(),14,15,16,17,18,19,20)) ++ (zero, System.Tuple (8, "ff",3,4,5,6,7,8,9,10,11,12,(),14,15,16,17,18,19,20)) ++ zero
     #endif
 
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     let _nes : NonEmptySeq<_> = plus (NonEmptySeq.singleton 1) (NonEmptySeq.singleton 2)
     #endif
 

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/Numeric.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/Numeric.fs
@@ -7,7 +7,7 @@ open System.Collections.Generic
 open FSharpPlus.Data
 
 let numeric = testList "Numeric" [
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     testCase "Zero First" (fun () -> let z : First<int> = getZero() in equal None (First.run z))
     #endif
     ]

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/Parsing.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/Parsing.fs
@@ -6,7 +6,7 @@ open FSharpPlus.Data
 #nowarn "686"
 open System
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 let (|Int32|_|) : _-> Int32 option = tryParse
 type ProductId = { Value:int }
 with
@@ -17,7 +17,7 @@ with
 #endif
 
 let parsing = testList "Parsing" [
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     testCase "parse" (fun () -> 
 
         let v2 : DateTimeOffset = parse "2011-03-04T15:42:19+03:00"

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/Splits.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/Splits.fs
@@ -17,7 +17,7 @@ type Sum<'a> = Sum of 'a with
 
 let splits = testList "Splits" [
 
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     testCase "splitArraysAndStrings" (fun () ->
         let a1 = "this.isABa.tABCest"  |> split [|"AT" ; "ABC" |]
         let a2 = "this.isABa.tABCest"B |> split [|"AT"B; "ABC"B|]

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/Traversable.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/Traversable.fs
@@ -7,7 +7,7 @@ open FSharpPlus.Data
 open System.Threading.Tasks
 
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 type Either<'l,'r> = Left of 'l | Right of 'r with
     static member Return x = Right x
     static member inline get_Empty () = Left empty
@@ -26,7 +26,7 @@ let traverseTest =
 let toOptions x = if x <> 4 then Some x       else None
 let toChoices x = if x <> 4 then Choice1Of2 x else Choice2Of2 "This is a failure"
 let toLists   x = if x <> 4 then [x; x]       else []
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 let toEithers x = if x <> 4 then Right x else Left ["This is a failure"]
 #endif
 
@@ -85,7 +85,7 @@ let traversable = testList "Traversable" [
         ())
     #endif
 
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     testList "traverse_Order" [
         testCase "nelist" (fun () ->
             SideEffects.reset()
@@ -191,7 +191,7 @@ let traversable = testList "Traversable" [
         Assert.AreEqual (Either<string list,NonEmptySeq<int>>.Left ["This is a failure"], e))
     #endif
 
-    #if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+    #if !FABLE_COMPILER
     testList "traverseFiniteApplicatives" [ // TODO -> implement short-circuit without breaking anything else
 
         #if !FABLE_COMPILER

--- a/tests/FSharpPlusFable.Tests/FSharpTests/General/Util.fs
+++ b/tests/FSharpPlusFable.Tests/FSharpTests/General/Util.fs
@@ -4,7 +4,7 @@ open FSharpPlus
 open FSharpPlus.Data
 open FSharpPlus.Control
 open Testing
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 type WrappedMapA<'K,'V when 'K : comparison> = WrappedMapA of Map<'K,'V> with
     static member ToMap (WrappedMapA m) = m
     static member inline TraverseIndexed (WrappedMapA m, f) =
@@ -42,7 +42,7 @@ type WrappedListA<'s> = WrappedListA of 's list with
         List.length lst
 #endif
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 type WrappedListB<'s> = WrappedListB of 's list with
     static member Return x = WrappedListB [x]
     static member (+) (WrappedListB l, WrappedListB x) = WrappedListB (l @ x)
@@ -63,7 +63,7 @@ type WrappedListC<'s> = WrappedListC of 's list with
     static member Zero = WrappedListC List.empty
     static member Sum (lst: seq<WrappedListC<_>>) = Seq.head lst
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 type WrappedListD<'s> = WrappedListD of 's list with
     interface Collections.Generic.IEnumerable<'s> with member x.GetEnumerator () = (let (WrappedListD x) = x in x :> _ seq).GetEnumerator ()
     interface Collections.IEnumerable             with member x.GetEnumerator () = (let (WrappedListD x) = x in x :> _ seq).GetEnumerator () :> Collections.IEnumerator
@@ -140,7 +140,7 @@ type WrappedListG<'s> = WrappedListG of 's list with
     static member Delay (f: unit -> WrappedListG<_>) = SideEffects.add "Using WrappedListG's Delay"; f ()
     static member Using (resource, body)             = SideEffects.add "Using WrappedListG's Using"; using resource body
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 type WrappedListH<'s> = WrappedListH of 's list with
     static member Map (WrappedListH lst, f) = WrappedListH (List.map f lst)
     static member inline Sequence (x: WrappedListH<'``Functor<'T>``>) =
@@ -201,7 +201,7 @@ type WrappedSeqC<'s> = WrappedSeqC of 's seq with
                     SideEffects.add "Using WrappedSeqC's TryFinally"
                     try computation finally compensation ()
 
-#if (!FABLE_COMPILER || FABLE_COMPILER_3) && !FABLE_COMPILER_4
+#if !FABLE_COMPILER
 type WrappedSeqD<'s> = WrappedSeqD of 's seq with
     static member Return x = SideEffects.add "Using WrappedSeqD's Return"; WrappedSeqD (Seq.singleton x)
     static member (<*>)  (WrappedSeqD f, WrappedSeqD x) = SideEffects.add "Using WrappedSeqD's Apply"; WrappedSeqD (f <*> x)

--- a/tests/FSharpPlusFable.Tests/fable3-global.json
+++ b/tests/FSharpPlusFable.Tests/fable3-global.json
@@ -1,1 +1,0 @@
-{ "sdk": { "version": "6.0.201", "rollForward": "latestFeature" } }

--- a/tests/benchmarks/Benchmarks.fsproj
+++ b/tests/benchmarks/Benchmarks.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <Optimize>true</Optimize>


### PR DESCRIPTION
Drop net45 and bump to net8. Note that in the v1 branches net45 is still one of the target framework.

This is related to #578 and #577