### PR TITLE
Removed String.startsWith !FABLE_COMPILER condition

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fable": {
-      "version": "4.5.0",
+      "version": "4.23.0",
       "commands": [
         "fable"
       ]

--- a/src/FSharpPlus/Extensions/String.fs
+++ b/src/FSharpPlus/Extensions/String.fs
@@ -42,15 +42,12 @@ module String =
         
         source.Contains subString
 
-    #if !FABLE_COMPILER
-    
     /// Does the source string start with the given subString? -- function wrapper for String.StartsWith method using InvariantCulture.
     let startsWith (subString: string) (source: string) =
         raiseIfNull (nameof subString) subString
         raiseIfNull (nameof source) source
         
         source.StartsWith (subString, false, CultureInfo.InvariantCulture)
-    #endif
 
     /// Does the source string end with the given subString? -- function wrapper for String.EndsWith method using InvariantCulture.
     let endsWith subString (source: string) =


### PR DESCRIPTION
Hi, I had an error with `String.endsWith` when compiling a project using FSharpPlus with Fable. `String.endsWith` was not surrounded by a `!FABLE_COMPILER` symbol condition.
A Fable maintainer [fixed my issue by making `String.endsWith` work with Fable, _as well as `String.startsWith`_](https://github.com/fable-compiler/Fable/issues/3934#issuecomment-2429149490).

This PR simply removes the `!FABLE_COMPILER` symbol condition around `String.startsWith` that is not needed anymore.