### PR TITLE
+ Zero for Result and Choice

### DIFF
--- a/src/FSharpPlus/Control/Numeric.fs
+++ b/src/FSharpPlus/Control/Numeric.fs
@@ -201,6 +201,8 @@ type Zero with
     #endif
     static member inline Zero (_: 'T->'Monoid               , _: Zero) = (fun _ -> Zero.Invoke ()) : 'T->'Monoid
     static member inline Zero (_: Async<'a>                 , _: Zero) = let (v: 'a) = Zero.Invoke () in async.Return v
+    static member inline Zero (_: Result<'T, 'Error>        , _: Zero) = let (v: 'Error) = Zero.Invoke () in Error v
+    static member inline Zero (_: Choice<'T1, 'T2>          , _: Zero) = let (v: 'T2) = Zero.Invoke () in Choice2Of2 v
     #if !FABLE_COMPILER
     static member inline Zero (_: Expr<'a>                  , _: Zero) = let (v: 'a) = Zero.Invoke () in Expr.Cast<'a>(Expr.Value (v))
     #endif

--- a/tests/FSharpPlus.Tests/Monoid.fs
+++ b/tests/FSharpPlus.Tests/Monoid.fs
@@ -78,9 +78,9 @@ module Monoid =
 
     [<Test>]
     let resultAndChoice () =
-        let r1 = sum [Ok 1; Error (); Ok 3]
-        let r2 = sum [Choice1Of2 1; Choice2Of2 (); Choice1Of2 3]
-        Assert.IsInstanceOf<Option<Result<int, unit>>> (Some r1)
-        Assert.IsInstanceOf<Option<Choice<int, unit>>> (Some r2)
+        let r1 = sum [Ok 1; Error "This is an error"; Ok 3]
+        let r2 = sum [Choice1Of2 1; Choice2Of2 "This is an error"; Choice1Of2 3]
+        Assert.IsInstanceOf<Option<Result<int, string>>> (Some r1)
+        Assert.IsInstanceOf<Option<Choice<int, string>>> (Some r2)
         Assert.AreEqual (Ok 4, r1)
         Assert.AreEqual (Choice1Of2 4, r2)

--- a/tests/FSharpPlus.Tests/Monoid.fs
+++ b/tests/FSharpPlus.Tests/Monoid.fs
@@ -82,5 +82,5 @@ module Monoid =
         let r2 = sum [Choice1Of2 1; Choice2Of2 "This is an error"; Choice1Of2 3]
         Assert.IsInstanceOf<Option<Result<int, string>>> (Some r1)
         Assert.IsInstanceOf<Option<Choice<int, string>>> (Some r2)
-        Assert.AreEqual (Ok 4, r1)
-        Assert.AreEqual (Choice1Of2 4, r2)
+        Assert.AreEqual (Result<int, string>.Ok 4, r1)
+        Assert.AreEqual (Choice<int, string>.Choice1Of2 4, r2)

--- a/tests/FSharpPlus.Tests/Monoid.fs
+++ b/tests/FSharpPlus.Tests/Monoid.fs
@@ -75,3 +75,12 @@ module Monoid =
             return y - x }
         Assert.AreEqual (str, "FourTen")
         Assert.AreEqual (num, 6)
+
+    [<Test>]
+    let resultAndChoice () =
+        let r1 = sum [Ok 1; Error (); Ok 3]
+        let r2 = sum [Choice1Of2 1; Choice2Of2 (); Choice1Of2 3]
+        Assert.IsInstanceOf<Option<Result<int, unit>>> (Some r1)
+        Assert.IsInstanceOf<Option<Choice<int, unit>>> (Some r2)
+        Assert.AreEqual (Ok 4, r1)
+        Assert.AreEqual (Choice1Of2 4, r2)


### PR DESCRIPTION
### Description

The current Semigroup implementation for `Result` supports a neutral element `Error e` as long as `e` has a neutral element, effectively making it a Monoid.

Before this PR, the following line **doesn't compile**:

```fsharp
sum [Ok 1; Error (); Ok 3] ;;
-----------------^^

stdin(13,18): error FS0001: The type 'bigint' does not support a conversion to the type 'Result<int,unit>'
```

However, it **does compile and work as expected** when using the binary Semigroup operator (`++`), because the `zero` is never involved:

```fsharp
Ok 1 ++ Error () ++ Ok 3
// val it: Result<int,unit> = Ok 4
```

This PR makes the Monoid instance consistent by providing a `zero` operation for `Result`, allowing `sum` and similar generic functions to work correctly. A similar addition for `Choice<'t1, 't2>` will be added.

---

### Isomorphism with Option

- For `Option`, the zero is `None`.
- For `Result`, with this change, `Error ()` (if the error type has a zero) will act as the identity element.
- This makes `Result<'T, unit>` isomorphic to `Option<'T>`, aligning with intuitive semantics for error accumulation.

---

### Discussion

I fail to see a drawback in providing a `zero` instance for `Result`, as long as both `Ok` and `Error` paths behave consistently.

If you see any caveats or edge cases this might introduce, please share your input.






