### PR TITLE
+ Missing dictionary utility functions

### DIFF
--- a/src/FSharpPlus/Control/Applicative.fs
+++ b/src/FSharpPlus/Control/Applicative.fs
@@ -42,40 +42,15 @@ type Apply =
         let f, x = f.Value, x.Value
         KeyValuePair2 (Plus.Invoke a b, f x)
 
-    static member        ``<*>`` (struct (f: Map<'Key,_>      , x: Map<'Key,'T>        ) , _output: Map<'Key,'U>         , [<Optional>]_mthd: Apply) : Map<'Key,'U> = Map (seq {
-       for KeyValue(k, vf) in f do
-           match Map.tryFind k x with
-           | Some vx -> yield k, vf vx
-           | _       -> () })
-
-    static member        ``<*>`` (struct (f: Dictionary<'Key,_>, x: Dictionary<'Key,'T>) , _output: Dictionary<'Key,'U>  , [<Optional>]_mthd: Apply) : Dictionary<'Key,'U> =
-       let dct = Dictionary ()
-       for KeyValue(k, vf) in f do
-           match x.TryGetValue k with
-           | true, vx -> dct.Add (k, vf vx)
-           | _        -> ()
-       dct
-
-    static member        ``<*>`` (struct (f: IDictionary<'Key,_>, x: IDictionary<'Key,'T>) , _output: IDictionary<'Key,'U>  , [<Optional>]_mthd: Apply) : IDictionary<'Key,'U> =
-       let dct = Dictionary ()
-       for KeyValue(k, vf) in f do
-           match x.TryGetValue k with
-           | true, vx -> dct.Add (k, vf vx)
-           | _        -> ()
-       dct :> IDictionary<'Key,'U>
-
-    static member        ``<*>`` (struct (f: IReadOnlyDictionary<'Key,_>, x: IReadOnlyDictionary<'Key,'T>) , _output: IReadOnlyDictionary<'Key,'U>  , [<Optional>]_mthd: Apply) : IReadOnlyDictionary<'Key,'U> =
-       let dct = Dictionary ()
-       for KeyValue(k, vf) in f do
-           match x.TryGetValue k with
-           | true, vx -> dct.Add (k, vf vx)
-           | _        -> ()
-       dct :> IReadOnlyDictionary<'Key,'U>
+    static member ``<*>`` (struct (f: Map<'Key,_>                , x: Map<'Key,'T>                ) , _output: Map<'Key,'U>                , [<Optional>]_mthd: Apply) : Map<'Key,'U>                 = Map.apply f x
+    static member ``<*>`` (struct (f: Dictionary<'Key,_>         , x: Dictionary<'Key,'T>         ) , _output: Dictionary<'Key,'U>         , [<Optional>]_mthd: Apply) : Dictionary<'Key,'U>          = Dictionary.apply f x
+    static member ``<*>`` (struct (f: IDictionary<'Key,_>        , x: IDictionary<'Key,'T>        ) , _output: IDictionary<'Key,'U>        , [<Optional>]_mthd: Apply) : IDictionary<'Key,'U>         = Dict.apply f x
+    static member ``<*>`` (struct (f: IReadOnlyDictionary<'Key,_>, x: IReadOnlyDictionary<'Key,'T>) , _output: IReadOnlyDictionary<'Key,'U>, [<Optional>]_mthd: Apply) : IReadOnlyDictionary<'Key,'U> = IReadOnlyDictionary.apply f x
 
     #if !FABLE_COMPILER
-    static member        ``<*>`` (struct (f: Expr<'T->'U>, x: Expr<'T>), _output: Expr<'U>, [<Optional>]_mthd: Apply) = Expr.Cast<'U> (Expr.Application (f, x))
+    static member ``<*>`` (struct (f: Expr<'T->'U>, x: Expr<'T>), _output: Expr<'U>, [<Optional>]_mthd: Apply) = Expr.Cast<'U> (Expr.Application (f, x))
     #endif
-    static member        ``<*>`` (struct (f: ('T->'U) ResizeArray, x: 'T ResizeArray), _output: 'U ResizeArray, [<Optional>]_mthd: Apply) = ResizeArray.apply f x : 'U ResizeArray
+    static member ``<*>`` (struct (f: ('T->'U) ResizeArray, x: 'T ResizeArray), _output: 'U ResizeArray, [<Optional>]_mthd: Apply) = ResizeArray.apply f x : 'U ResizeArray
 
     static member inline Invoke (f: '``Applicative<'T -> 'U>``) (x: '``Applicative<'T>``) : '``Applicative<'U>`` =
         let inline call (mthd : ^M, input1: ^I1, input2: ^I2, output: ^R) =

--- a/src/FSharpPlus/Control/Foldable.fs
+++ b/src/FSharpPlus/Control/Foldable.fs
@@ -148,7 +148,6 @@ type FoldMap =
     static member inline FoldMap (x: _ []        , f, [<Optional>]_impl: FoldMap) = Array.fold (fun x y -> Plus.Invoke x (f y)) (Zero.Invoke ()) x
 
     static member inline FoldMap (x: Map<_, _>                , f, [<Optional>]_impl: FoldMap) = Map.fold                 (fun x _ y -> Plus.Invoke x (f y)) (Zero.Invoke ()) x
-    static member inline FoldMap (x: Dictionary<_, _>         , f, [<Optional>]_impl: FoldMap) = Dictionary.fold          (fun x _ y -> Plus.Invoke x (f y)) (Zero.Invoke ()) x
     static member inline FoldMap (x: IDictionary<_, _>        , f, [<Optional>]_impl: FoldMap) = Dict.fold                (fun x _ y -> Plus.Invoke x (f y)) (Zero.Invoke ()) x
     static member inline FoldMap (x: IReadOnlyDictionary<_, _>, f, [<Optional>]_impl: FoldMap) = IReadOnlyDictionary.fold (fun x _ y -> Plus.Invoke x (f y)) (Zero.Invoke ()) x
 
@@ -191,7 +190,6 @@ type Fold =
     static member        Fold (x: Set<_>      , f,             z    , [<Optional>]_impl: Fold    ) = Set.fold               f z x
     static member        Fold (x:  _ []       , f,             z    , [<Optional>]_impl: Fold    ) = Array.fold             f z x
     static member        Fold (x: Map<_,_>    , f,             z    , [<Optional>]_impl: Fold    ) = Map.fold                 (fun s _ -> f s) z x
-    static member        Fold (x: Dictionary<_,_>         , f, z    , [<Optional>]_impl: Fold    ) = Dictionary.fold          (fun s _ -> f s) z x
     static member        Fold (x: IDictionary<_,_>        , f, z    , [<Optional>]_impl: Fold    ) = Dict.fold                (fun s _ -> f s) z x
     static member        Fold (x: IReadOnlyDictionary<_,_>, f, z    , [<Optional>]_impl: Fold    ) = IReadOnlyDictionary.fold (fun s _ -> f s) z x
 

--- a/src/FSharpPlus/Control/Foldable.fs
+++ b/src/FSharpPlus/Control/Foldable.fs
@@ -147,6 +147,11 @@ type FoldMap =
     static member inline FoldMap (x: Set<_>      , f, [<Optional>]_impl: FoldMap) = Seq.fold   (fun x y -> Plus.Invoke x (f y)) (Zero.Invoke ()) x
     static member inline FoldMap (x: _ []        , f, [<Optional>]_impl: FoldMap) = Array.fold (fun x y -> Plus.Invoke x (f y)) (Zero.Invoke ()) x
 
+    static member inline FoldMap (x: Map<_, _>                , f, [<Optional>]_impl: FoldMap) = Map.fold                 (fun x _ y -> Plus.Invoke x (f y)) (Zero.Invoke ()) x
+    static member inline FoldMap (x: Dictionary<_, _>         , f, [<Optional>]_impl: FoldMap) = Dictionary.fold          (fun x _ y -> Plus.Invoke x (f y)) (Zero.Invoke ()) x
+    static member inline FoldMap (x: IDictionary<_, _>        , f, [<Optional>]_impl: FoldMap) = Dict.fold                (fun x _ y -> Plus.Invoke x (f y)) (Zero.Invoke ()) x
+    static member inline FoldMap (x: IReadOnlyDictionary<_, _>, f, [<Optional>]_impl: FoldMap) = IReadOnlyDictionary.fold (fun x _ y -> Plus.Invoke x (f y)) (Zero.Invoke ()) x
+
     static member inline Invoke (f: 'T->'Monoid) (x: '``Foldable'<T>``) : 'Monoid =
         let inline call_2 (a: ^a, b: ^b, f) = ((^a or ^b) : (static member FoldMap : _*_*_ -> _) b, f, a)
         let inline call (a: 'a, b: 'b, f) = call_2 (a, b, f)
@@ -185,6 +190,10 @@ type Fold =
     static member        Fold (x: list<_>     , f,             z    , [<Optional>]_impl: Fold    ) = List.fold              f z x
     static member        Fold (x: Set<_>      , f,             z    , [<Optional>]_impl: Fold    ) = Set.fold               f z x
     static member        Fold (x:  _ []       , f,             z    , [<Optional>]_impl: Fold    ) = Array.fold             f z x
+    static member        Fold (x: Map<_,_>    , f,             z    , [<Optional>]_impl: Fold    ) = Map.fold                 (fun s _ -> f s) z x
+    static member        Fold (x: Dictionary<_,_>         , f, z    , [<Optional>]_impl: Fold    ) = Dictionary.fold          (fun s _ -> f s) z x
+    static member        Fold (x: IDictionary<_,_>        , f, z    , [<Optional>]_impl: Fold    ) = Dict.fold                (fun s _ -> f s) z x
+    static member        Fold (x: IReadOnlyDictionary<_,_>, f, z    , [<Optional>]_impl: Fold    ) = IReadOnlyDictionary.fold (fun s _ -> f s) z x
 
     static member inline Invoke (folder: 'State->'T->'State) (state: 'State) (foldable: '``Foldable'<T>``) : 'State =
         let inline call_2 (a: ^a, b: ^b, f, z) = ((^a or ^b) : (static member Fold : _*_*_*_ -> _) b, f, z, a)

--- a/src/FSharpPlus/Control/Functor.fs
+++ b/src/FSharpPlus/Control/Functor.fs
@@ -149,13 +149,13 @@ type Unzip =
     static member inline Unzip ((source: '``Functor<'T * 'U>``             , _output: '``Functor<'T>`` * '``Functor<'U>``                  ) , _mthd: Default1) = (^``Functor<'T * 'U>``: (static member Unzip : _->_) source) : '``Functor<'T>`` * '``Functor<'U>``
     static member inline Unzip (( _    : ^t when ^t: null and ^t: struct   , _                                                             ) , _              ) = ()
     
-    static member        Unzip ((source: Lazy<'T * 'U>                     , _output: Lazy<'T> * Lazy<'U>                                  ) , _mthd: Unzip   ) = Map.Invoke fst source, Map.Invoke snd source
+    static member        Unzip ((source: Lazy<'T * 'U>                     , _output: Lazy<'T> * Lazy<'U>                                  ) , _mthd: Unzip   ) = Lazy.map fst source, Lazy.map snd source
 
     #if !FABLE_COMPILER
-    static member        Unzip ((source: Task<'T * 'U>                     , _output: Task<'T> * Task<'U>                                  ) , _mthd: Unzip   ) = Map.Invoke fst source, Map.Invoke snd source
+    static member        Unzip ((source: Task<'T * 'U>                     , _output: Task<'T> * Task<'U>                                  ) , _mthd: Unzip   ) = Task.map fst source, Task.map snd source
     #endif
     #if !FABLE_COMPILER
-    static member        Unzip ((source: ValueTask<'T * 'U>                , _output: ValueTask<'T> * ValueTask<'U>                        ) , _mthd: Unzip   ) = Map.Invoke fst source, Map.Invoke snd source
+    static member        Unzip ((source: ValueTask<'T * 'U>                , _output: ValueTask<'T> * ValueTask<'U>                        ) , _mthd: Unzip   ) = ValueTask.map fst source, ValueTask.map snd source
     #endif
     static member        Unzip ((source: option<'T * 'U>                   , _output: option<'T> * option<'U>                              ) , _mthd: Unzip   ) = Option.unzip source
     static member        Unzip ((source: voption<'T * 'U>                  , _output: voption<'T> * voption<'U>                            ) , _mthd: Unzip   ) = ValueOption.unzip source
@@ -167,17 +167,17 @@ type Unzip =
     static member        Unzip ((struct (m: 'Monoid, t: ('T * 'U))         , _output: struct ('Monoid * 'T) * struct ('Monoid * 'U)        ) , _mthd: Unzip   ) = struct (m, fst t), struct (m, snd t)
     static member        Unzip ((source: ('T * 'U) []                      , _output: 'T []    * 'U []                                     ) , _mthd: Unzip   ) = Array.unzip  source
     #if !FABLE_COMPILER
-    static member        Unzip ((source: ('T * 'U) [,]                     , _output: 'T [,]   * 'U [,]                                    ) , _mthd: Unzip   ) = Map.Invoke fst source, Map.Invoke snd source
-    static member        Unzip ((source: ('T * 'U) [,,]                    , _output: 'T [,,]  * 'U [,,]                                   ) , _mthd: Unzip   ) = Map.Invoke fst source, Map.Invoke snd source
-    static member        Unzip ((source: ('T * 'U) [,,,]                   , _output: 'T [,,,] * 'U [,,,]                                  ) , _mthd: Unzip   ) = Map.Invoke fst source, Map.Invoke snd source
+    static member        Unzip ((source: ('T * 'U) [,]                     , _output: 'T [,]   * 'U [,]                                    ) , _mthd: Unzip   ) = Array2D.map fst source, Array2D.map snd source
+    static member        Unzip ((source: ('T * 'U) [,,]                    , _output: 'T [,,]  * 'U [,,]                                   ) , _mthd: Unzip   ) = Array3D.map fst source, Array3D.map snd source
+    static member        Unzip ((source: ('T * 'U) [,,,]                   , _output: 'T [,,,] * 'U [,,,]                                  ) , _mthd: Unzip   ) = Map.Invoke  fst source, Map.Invoke  snd source
     #endif
 
-    static member        Unzip ((source: Async<'T * 'U>                    , _output: Async<'T> * Async<'U>                                ) , _mthd: Unzip   ) = Map.Invoke fst source, Map.Invoke snd source
+    static member        Unzip ((source: Async<'T * 'U>                    , _output: Async<'T> * Async<'U>                                ) , _mthd: Unzip   ) = Async.map fst source, Async.map snd source
     static member        Unzip ((source: Result<'T * 'U, 'E>               , _output: Result<'T,'E> * Result<'U,'E>                        ) , _mthd: Unzip   ) = Result.unzip source
-    static member        Unzip ((source: Choice<'T * 'U, 'E>               , _output: Choice<'T,'E> * Choice<'U,'E>                        ) , _mthd: Unzip   ) = Map.Invoke fst source, Map.Invoke snd source
+    static member        Unzip ((source: Choice<'T * 'U, 'E>               , _output: Choice<'T,'E> * Choice<'U,'E>                        ) , _mthd: Unzip   ) = Choice.map fst source, Choice.map snd source
     static member        Unzip ((source: KeyValuePair<'Key, 'T * 'U>       , _output: KeyValuePair<_, 'T> * KeyValuePair<_, 'U>            ) , _mthd: Unzip   ) = Map.Invoke fst source, Map.Invoke snd source
-    static member        Unzip ((source: Map<'Key, 'T * 'U>                , _output: Map<_, 'T> * Map<_, 'U>                              ) , _mthd: Unzip   ) = Map.unzip    source
-    static member        Unzip ((source: Dictionary<'Key, 'T * 'U>         , _output: Dictionary<_, 'T> * Dictionary<_, 'U>                ) , _mthd: Unzip   ) = Map.Invoke fst source, Map.Invoke snd source
+    static member        Unzip ((source: Map<'Key, 'T * 'U>                , _output: Map<_, 'T> * Map<_, 'U>                              ) , _mthd: Unzip   ) = Map.unzip        source
+    static member        Unzip ((source: Dictionary<'Key, 'T * 'U>         , _output: Dictionary<_, 'T> * Dictionary<_, 'U>                ) , _mthd: Unzip   ) = Dictionary.unzip source
 
     #if !FABLE_COMPILER
     static member        Unzip ((source: Expr<'T * 'U>                     , _output: Expr<'T> * Expr<'U>                                  ) , _mthd: Unzip   ) = Map.Invoke fst source, Map.Invoke snd source
@@ -187,10 +187,10 @@ type Unzip =
     
     static member        Unzip ((source: seq<'T * 'U>                      , _output: seq<'T> * seq<'U>                                    ) , _mthd: Unzip   ) = Map.Invoke fst source, Map.Invoke snd source    
 
-    static member        Unzip ((source: IEnumerator<'T * 'U>              , _output: IEnumerator<'T> * ResizeArray<'U>                    ) , _mthd: Unzip   ) = Map.Invoke fst source, Map.Invoke snd source
+    static member        Unzip ((source: IEnumerator<'T * 'U>              , _output: IEnumerator<'T> * ResizeArray<'U>                    ) , _mthd: Unzip   ) = Enumerator.map fst source, Enumerator.map snd source
     static member        Unzip ((source: IDictionary<'Key, 'T * 'U>        , _output: IDictionary<_,'T> * IDictionary<_,'U>                ) , _mthd: Unzip   ) = Dict.unzip source
     static member        Unzip ((source: IReadOnlyDictionary<'Key,'T * 'U> , _output: IReadOnlyDictionary<_,'T> * IReadOnlyDictionary<_,'U>) , _mthd: Unzip   ) = IReadOnlyDictionary.unzip source
-    static member        Unzip ((source: IObservable<'T * 'U>              , _output: IObservable<'T> * ResizeArray<'U>                    ) , _mthd: Unzip   ) = Map.Invoke fst source, Map.Invoke snd source
+    static member        Unzip ((source: IObservable<'T * 'U>              , _output: IObservable<'T> * ResizeArray<'U>                    ) , _mthd: Unzip   ) = Observable.map fst source, Observable.map snd source
 
 
 
@@ -208,7 +208,7 @@ type Zip =
     static member Zip ((x: seq<'T>                    , y: seq<'U>                   , _output: seq<'T*'U>                   ), _mthd: Zip) = Seq.zip                 x y    
     static member Zip ((x: IDictionary<'K, 'T>        , y: IDictionary<'K,'U>        , _output: IDictionary<'K,'T*'U>        ), _mthd: Zip) = Dict.zip                x y
     static member Zip ((x: IReadOnlyDictionary<'K, 'T>, y: IReadOnlyDictionary<'K,'U>, _output: IReadOnlyDictionary<'K,'T*'U>), _mthd: Zip) = IReadOnlyDictionary.zip x y
-    static member Zip ((x: Dictionary<'K, 'T>         , y: Dictionary<'K,'U>         , _output: Dictionary<'K,'T*'U>         ), _mthd: Zip) = Dict.zip       x y :?> Dictionary<'K,'T*'U>
+    static member Zip ((x: Dictionary<'K, 'T>         , y: Dictionary<'K,'U>         , _output: Dictionary<'K,'T*'U>         ), _mthd: Zip) = Dictionary.zip          x y
     static member Zip ((x: Map<'K, 'T>                , y: Map<'K,'U>                , _output: Map<'K,'T*'U>                ), _mthd: Zip) = Map.zip        x y
     static member Zip ((f: 'R -> 'T                   , g: 'R -> 'U                  , _output: 'R -> 'T * 'U                ), _mthd: Zip) = fun x -> (f x, g x)
     static member Zip ((f: Func<'R, 'T>               , g: Func<'R, 'U>              , _output: Func<'R, 'T * 'U>            ), _mthd: Zip) = Func<_,_> (fun x -> (f.Invoke x, g.Invoke x))

--- a/src/FSharpPlus/Extensions/Dict.fs
+++ b/src/FSharpPlus/Extensions/Dict.fs
@@ -127,6 +127,21 @@ module Dict =
             | None    -> ()
         dct :> IDictionary<'Key, 'T1 * 'T2>
 
+    /// <summary>Tuples values of three dictionaries.</summary>
+    /// <remarks>Keys that are not present on all three dictionaries are dropped.</remarks>
+    /// <param name="source1">The first input dictionary.</param>
+    /// <param name="source2">The second input dictionary.</param>
+    /// <param name="source3">The third input dictionary.</param>
+    ///
+    /// <returns>The tupled dictionary.</returns>
+    let zip3 (source1: IDictionary<'Key, 'T1>) (source2: IDictionary<'Key, 'T2>) (source3: IDictionary<'Key, 'T3>) =
+        let dct = Dictionary<'Key, 'T1 * 'T2 * 'T3> ()
+        for KeyValue(k, vx) in source1 do
+            match tryGetValue k source2, tryGetValue k source3 with
+            | Some vy, Some vz -> dct.Add (k, (vx, vy, vz))
+            | _                -> ()
+        dct :> IDictionary<'Key, 'T1 * 'T2 * 'T3>
+
     /// <summary>Splits a dictionary with tuple pair values to two separate dictionaries.</summary>
     /// <param name="source">The source dictionary.</param>
     ///
@@ -138,6 +153,46 @@ module Dict =
             dct1.Add (k, vx)
             dct2.Add (k, vy)
         dct1 :> IDictionary<'Key, 'T1>, dct2 :> IDictionary<'Key, 'T2>
+
+    /// <summary>Splits a dictionary with tuple of 3 values to three separate dictionaries.</summary>
+    /// <param name="source">The source dictionary.</param>
+    ///
+    /// <returns>A tuple of each untupled dictionary.</returns>
+    let unzip3 (source: IDictionary<'Key, 'T1 * 'T2 * 'T3>) =
+        let dct1 = Dictionary<'Key, 'T1> ()
+        let dct2 = Dictionary<'Key, 'T2> ()
+        let dct3 = Dictionary<'Key, 'T3> ()
+        for KeyValue(k, (vx, vy, vz)) in source do
+            dct1.Add (k, vx)
+            dct2.Add (k, vy)
+            dct3.Add (k, vz)
+        dct1 :> IDictionary<'Key, 'T1>, dct2 :> IDictionary<'Key, 'T2>, dct3 :> IDictionary<'Key, 'T3>
+
+
+    /// <summary>Flattens a dictionary of dictionaries into a single dictionary on matching keys.</summary>
+    /// <remarks>Keys that are not present in the inner dictionaries are dropped.</remarks>
+    /// <param name="source">The source IDictionary of IDictionaries.</param>
+    /// <returns>A flattened IDictionary.</returns>
+    let flatten (source: IDictionary<_, IDictionary<_, _>>) : IDictionary<'Key, 'Value> =
+        let dct = Dictionary ()
+        for KeyValue (k, v) in source do
+            match v.TryGetValue k  with
+            | true, v -> dct.Add (k, v)
+            | _       -> ()
+        dct :> IDictionary<'Key, 'Value>
+    
+    /// <summary>Applies a function to each value in a dictionary and then flattens the result on matching keys into a new dictionary.</summary>
+    /// <remarks>Keys that are not present in the inner dictionaries are dropped.</remarks>
+    /// <param name="mapper">The function to be applied to each value in the dictionary.</param>
+    /// <param name="source">The input dictionary.</param>
+    /// <returns>A flattened IDictionary.</returns>
+    let bind (mapper: 'T -> IDictionary<'Key, 'U>) (source: IDictionary<'Key, 'T>) =
+        let dct = Dictionary ()
+        for KeyValue (k, v) in source do
+            match (mapper v).TryGetValue k with
+            | true, v -> dct.Add (k, v)
+            | _       -> ()
+        dct :> IDictionary<'Key, 'U>
 
     /// Returns the union of two dictionaries, using the combiner function for duplicate keys.
     let unionWith combiner (source1: IDictionary<'Key, 'Value>) (source2: IDictionary<'Key, 'Value>) =

--- a/src/FSharpPlus/Extensions/Dict.fs
+++ b/src/FSharpPlus/Extensions/Dict.fs
@@ -268,3 +268,42 @@ module Dict =
             | Some v -> dct.Add (k, v)
             | None   -> ()
         dct :> IDictionary<'Key, 'U>
+
+    /// <summary>Creates an empty dictionary.</summary>
+    [<GeneralizableValue>]
+    let empty<'Key, 'U when 'Key : equality> = Dictionary<'Key, 'U> () :> IDictionary<_,_>
+
+    /// <summary>Converts a dictionary to a ResizeArray.</summary>
+    /// <param name="source">The source dictionary.</param>
+    ///
+    /// <returns>A ResizeArray containing the Key and Value of the original dictionary.</returns>
+    let toResizeArray (source: IDictionary<'Key, 'T>) =
+        let arr = ResizeArray<KeyValuePair<'Key, 'T>> ()
+        for KeyValue (k, x) in source do
+            arr.Add (KeyValuePair (k, x))
+        arr
+
+    /// <summary>Converts a dictionary to a sequence.</summary>
+    /// <param name="source">The source dictionary.</param>
+    ///
+    /// <returns>A sequence containing the Key and Value of the original dictionary.</returns>
+    let toSeq (source: IDictionary<'Key, 'T>) = toResizeArray source :> seq<_>
+
+    /// <summary>Folds over the bindings in the dictionary.</summary>
+    /// <remarks>
+    /// This function takes a folder function, an initial state, and a source dictionary.
+    /// The folder function is applied to each key-value pair in the source, accumulating a state.
+    /// The initial state is provided as the first argument to the folder function.
+    /// The function returns the final accumulated state after processing all key-value pairs.
+    /// </remarks>
+    /// <param name="folder">The folder function that takes the current state, a key, and a value, and returns the new state.</param>
+    /// <param name="state">The initial state to start the folding process.</param>
+    /// <param name="source">The source dictionary to fold over.</param>
+    /// <typeparam name="'State">The type of the state being accumulated.</typeparam>
+    /// <typeparam name="'Key">The type of the keys in the dictionary.</typeparam>
+    /// <typeparam name="'T">The type of the values in the dictionary.</typeparam>
+    ///
+    /// <returns>The final accumulated state after folding over all key-value pairs in the source.</returns>
+    let fold (folder: 'State -> 'Key -> 'T -> 'State) (state: 'State) (source: IDictionary<'Key, 'T>) =
+        let unzip source = Seq.map fst source, Seq.map snd source
+        source |> toSeq |> Seq.map (|KeyValue|) |> unzip ||> Seq.fold2 folder state

--- a/src/FSharpPlus/Extensions/Dict.fs
+++ b/src/FSharpPlus/Extensions/Dict.fs
@@ -67,6 +67,31 @@ module Dict =
             dct.Add (k, mapper v)
         dct :> IDictionary<'Key, 'U>
 
+    /// <summary>Applies each function in the dictionary of functions to the corresponding value in the dictionary of values,
+    /// producing a new dictionary of values.</summary>
+    /// <remarks>
+    /// If a key is present in the function dictionary but not in the value dictionary, that key is simply ignored.
+    /// If a key is present in the value dictionary but not in the function dictionary, that key is also ignored.
+    /// </remarks>
+    /// <param name="f">The dictionary of functions.</param>
+    /// <param name="x">The dictionary of values.</param>
+    /// <returns>The resulting dictionary of values.</returns>
+    /// <typeparam name="'Key">The type of the keys in the dictionaries.</typeparam>
+    /// <typeparam name="'T">The type of the values in the dictionary of values.</typeparam>
+    /// <typeparam name="'U">The type of the values in the resulting dictionary.</typeparam>    
+    /// <returns>A dictionary of values.</returns>
+    /// <remarks>
+    /// This function is useful for applying a set of transformations to a dictionary of values,
+    /// where each transformation is defined by a function in a dictionary of functions.
+    /// </remarks>
+    let apply (f: IDictionary<'Key, _>) (x: IDictionary<'Key, 'T>) : IDictionary<'Key, 'U> =
+        let dct = Dictionary ()
+        for KeyValue (k, vf) in f do
+            match x.TryGetValue k with
+            | true, vx -> dct.Add (k, vf vx)
+            | _        -> ()
+        dct :> IDictionary<'Key, 'U>
+
     /// <summary>Creates a Dictionary value from a pair of Dictionaries, using a function to combine them.</summary>
     /// <remarks>Keys that are not present on both dictionaries are dropped.</remarks>
     /// <param name="mapper">The mapping function.</param>

--- a/src/FSharpPlus/Extensions/Dict.fs
+++ b/src/FSharpPlus/Extensions/Dict.fs
@@ -7,11 +7,15 @@ module Dict =
     open System.Collections.ObjectModel
 
     #if !FABLE_COMPILER
-    open System.Linq
+    open System.Linq      
 
     /// Converts an IDictionary to an IReadOnlyDictionary.
     let toIReadOnlyDictionary source = ReadOnlyDictionary source :> IReadOnlyDictionary<_,_>
     #endif
+
+    /// <summary>Creates an empty dictionary.</summary>
+    [<GeneralizableValue>]
+    let empty<'Key, 'U when 'Key : equality> = printfn "creating"; Dictionary<'Key, 'U> () :> IDictionary<_,_>
 
     /// <summary>Tries to get the value of the given key.</summary>
     /// <remarks>This is a function wrapper for the IDictionary.TryGetValue method,
@@ -268,10 +272,6 @@ module Dict =
             | Some v -> dct.Add (k, v)
             | None   -> ()
         dct :> IDictionary<'Key, 'U>
-
-    /// <summary>Creates an empty dictionary.</summary>
-    [<GeneralizableValue>]
-    let empty<'Key, 'U when 'Key : equality> = Dictionary<'Key, 'U> () :> IDictionary<_,_>
 
     /// <summary>Converts a dictionary to a ResizeArray.</summary>
     /// <param name="source">The source dictionary.</param>

--- a/src/FSharpPlus/Extensions/Dictionary.fs
+++ b/src/FSharpPlus/Extensions/Dictionary.fs
@@ -69,6 +69,31 @@ module Dictionary =
             dct.Add (k, mapping v)
         dct
 
+    /// <summary>Applies each function in the dictionary of functions to the corresponding value in the dictionary of values,
+    /// producing a new dictionary of values.</summary>
+    /// <remarks>
+    /// If a key is present in the function dictionary but not in the value dictionary, that key is simply ignored.
+    /// If a key is present in the value dictionary but not in the function dictionary, that key is also ignored.
+    /// </remarks>
+    /// <param name="f">The dictionary of functions.</param>
+    /// <param name="x">The dictionary of values.</param>
+    /// <returns>The resulting dictionary of values.</returns>
+    /// <typeparam name="'Key">The type of the keys in the dictionaries.</typeparam>
+    /// <typeparam name="'T">The type of the values in the dictionary of values.</typeparam>
+    /// <typeparam name="'U">The type of the values in the resulting dictionary.</typeparam>    
+    /// <returns>A dictionary of values.</returns>
+    /// <remarks>
+    /// This function is useful for applying a set of transformations to a dictionary of values,
+    /// where each transformation is defined by a function in a dictionary of functions.
+    /// </remarks>
+    let apply (f: Dictionary<'Key, _>) (x: Dictionary<'Key, 'T>) : Dictionary<'Key, 'U> =
+        let dct = Dictionary ()
+        for KeyValue (k, vf) in f do
+            match x.TryGetValue k with
+            | true, vx -> dct.Add (k, vf vx)
+            | _        -> ()
+        dct
+
     /// <summary>Creates a Dictionary value from a pair of Dictionaries, using a function to combine them.</summary>
     /// <remarks>Keys that are not present on both dictionaries are dropped.</remarks>
     /// <param name="mapping">The mapping function.</param>

--- a/src/FSharpPlus/Extensions/Dictionary.fs
+++ b/src/FSharpPlus/Extensions/Dictionary.fs
@@ -269,3 +269,42 @@ module Dictionary =
             | Some v -> dct.Add (k, v)
             | None   -> ()
         dct
+
+    /// <summary>Creates an empty dictionary.</summary>
+    [<GeneralizableValue>]
+    let empty<'Key, 'U when 'Key : equality> = Dictionary<'Key, 'U> ()
+
+    /// <summary>Converts a dictionary to a ResizeArray.</summary>
+    /// <param name="source">The source dictionary.</param>
+    ///
+    /// <returns>A ResizeArray containing the Key and Value of the original dictionary.</returns>
+    let toResizeArray (source: Dictionary<'Key, 'T>) =
+        let arr = ResizeArray<KeyValuePair<'Key, 'T>> ()
+        for KeyValue (k, x) in source do
+            arr.Add (KeyValuePair (k, x))
+        arr
+
+    /// <summary>Converts a dictionary to a sequence.</summary>
+    /// <param name="source">The source dictionary.</param>
+    ///
+    /// <returns>A sequence containing the Key and Value of the original dictionary.</returns>
+    let toSeq (source: Dictionary<'Key, 'T>) = toResizeArray source :> seq<_>
+
+    /// <summary>Folds over the bindings in the dictionary.</summary>
+    /// <remarks>
+    /// This function takes a folder function, an initial state, and a source dictionary.
+    /// The folder function is applied to each key-value pair in the source, accumulating a state.
+    /// The initial state is provided as the first argument to the folder function.
+    /// The function returns the final accumulated state after processing all key-value pairs.
+    /// </remarks>
+    /// <param name="folder">The folder function that takes the current state, a key, and a value, and returns the new state.</param>
+    /// <param name="state">The initial state to start the folding process.</param>
+    /// <param name="source">The source dictionary to fold over.</param>
+    /// <typeparam name="'State">The type of the state being accumulated.</typeparam>
+    /// <typeparam name="'Key">The type of the keys in the dictionary.</typeparam>
+    /// <typeparam name="'T">The type of the values in the dictionary.</typeparam>
+    ///
+    /// <returns>The final accumulated state after folding over all key-value pairs in the source.</returns>
+    let fold (folder: 'State -> 'Key -> 'T -> 'State) (state: 'State) (source: Dictionary<'Key, 'T>) =
+        let unzip source = Seq.map fst source, Seq.map snd source
+        source |> toSeq |> Seq.map (|KeyValue|) |> unzip ||> Seq.fold2 folder state

--- a/src/FSharpPlus/Extensions/Dictionary.fs
+++ b/src/FSharpPlus/Extensions/Dictionary.fs
@@ -4,7 +4,7 @@
 [<RequireQualifiedAccess>]
 module Dictionary =
     open System.Collections.Generic
-    open System.Collections.ObjectModel
+    open System.Collections.ObjectModel    
 
     #if !FABLE_COMPILER
     open System.Linq
@@ -13,6 +13,10 @@ module Dictionary =
     let toIReadOnlyDictionary (source: Dictionary<'Key, 'Value>) = ReadOnlyDictionary source :> IReadOnlyDictionary<_,_>
     
     #endif
+
+    /// <summary>Creates an empty dictionary.</summary>
+    [<GeneralizableValue>]
+    let empty<'Key, 'U when 'Key : equality> = Dictionary<'Key, 'U> ()
 
     /// <summary>Tries to get the value of the given key.</summary>
     /// <remarks>Note: this is a function wrapper for the Dictionary.TryGetValue method,
@@ -269,10 +273,6 @@ module Dictionary =
             | Some v -> dct.Add (k, v)
             | None   -> ()
         dct
-
-    /// <summary>Creates an empty dictionary.</summary>
-    [<GeneralizableValue>]
-    let empty<'Key, 'U when 'Key : equality> = Dictionary<'Key, 'U> ()
 
     /// <summary>Converts a dictionary to a ResizeArray.</summary>
     /// <param name="source">The source dictionary.</param>

--- a/src/FSharpPlus/Extensions/IReadOnlyDictionary.fs
+++ b/src/FSharpPlus/Extensions/IReadOnlyDictionary.fs
@@ -299,6 +299,8 @@ module IReadOnlyDictionary =
 
     #endif
 
+    /// <summary>Creates an empty read-only dictionary.</summary>
+    [<GeneralizableValue>]
     let empty<'Key, 'U when 'Key : equality> = Dictionary<'Key, 'U> () :> IReadOnlyDictionary<_,_>
 
     /// <summary>Converts a read-only dictionary to a ResizeArray.</summary>
@@ -317,12 +319,40 @@ module IReadOnlyDictionary =
     /// <returns>A sequence containing the Key and Value of the original IReadOnlyDictionary.</returns>
     let toSeq (source: IReadOnlyDictionary<'Key, 'T>) = toResizeArray source :> seq<_>
 
-    /// Folds over the bindings in the Dictionary
+    /// <summary>Folds over the bindings in the Dictionary.</summary>
+    /// <remarks>
+    /// This function takes a folder function, an initial state, and a source read-only dictionary.
+    /// The folder function is applied to each key-value pair in the source, accumulating a state.
+    /// The initial state is provided as the first argument to the folder function.
+    /// The function returns the final accumulated state after processing all key-value pairs.
+    /// </remarks>
+    /// <param name="folder">The folder function that takes the current state, a key, and a value, and returns the new state.</param>
+    /// <param name="state">The initial state to start the folding process.</param>
+    /// <param name="source">The source read-only dictionary to fold over.</param>
+    /// <typeparam name="'State">The type of the state being accumulated.</typeparam>
+    /// <typeparam name="'Key">The type of the keys in the read-only dictionary.</typeparam>
+    /// <typeparam name="'T">The type of the values in the read-only dictionary.</typeparam>
+    ///
+    /// <returns>The final accumulated state after folding over all key-value pairs in the source.</returns>
     let fold     (folder: 'State -> 'Key -> 'T -> 'State) (state: 'State) (source: IReadOnlyDictionary<'Key, 'T>) =
         let unzip source = Seq.map fst source, Seq.map snd source
         source |> toSeq |> Seq.map (|KeyValue|) |> unzip ||> Seq.fold2 folder state
 
-    /// Folds over the bindings in the Dictionary
+    /// <summary>Folds over the bindings in the Dictionary in reverse order.</summary>
+    /// <remarks>
+    /// This function takes a folder function, a source read-only dictionary, and an initial state.
+    /// The folder function is applied to each key-value pair in the source, accumulating a state.
+    /// The initial state is provided as the last argument to the folder function.
+    /// The function returns the final accumulated state after processing all key-value pairs.
+    /// </remarks>
+    /// <param name="folder">The folder function that takes a key, a value, and the current state, and returns the new state.</param>
+    /// <param name="source">The source read-only dictionary to fold over.</param>
+    /// <param name="state">The initial state to start the folding process.</param>
+    /// <typeparam name="'State">The type of the state being accumulated.</typeparam>
+    /// <typeparam name="'Key">The type of the keys in the read-only dictionary.</typeparam>
+    /// <typeparam name="'T">The type of the values in the read-only dictionary.</typeparam>
+    ///
+    /// <returns>The final accumulated state after folding over all key-value pairs in the source.</returns>
     let foldBack (folder: 'Key -> 'T -> 'State -> 'State) (source: IReadOnlyDictionary<'Key, 'T>) state =
         let unzip source = Seq.map fst source, Seq.map snd source
         source |> toSeq |> Seq.map (|KeyValue|) |> unzip ||> Seq.foldBack2 folder <| state

--- a/src/FSharpPlus/Extensions/IReadOnlyDictionary.fs
+++ b/src/FSharpPlus/Extensions/IReadOnlyDictionary.fs
@@ -10,6 +10,10 @@ module IReadOnlyDictionary =
 
     open System.Collections.Generic
 
+    /// <summary>Creates an empty read-only dictionary.</summary>
+    [<GeneralizableValue>]
+    let empty<'Key, 'U when 'Key : equality> = Dictionary<'Key, 'U> () :> IReadOnlyDictionary<_,_>
+
     /// Replaces or sets the item associated with a specified key with the specified value.
     let add key value (source: IReadOnlyDictionary<'Key, 'Value>) = source |> Seq.map (|KeyValue|) |> Map |> Map.add key value :> IReadOnlyDictionary<_,_>
 
@@ -298,10 +302,6 @@ module IReadOnlyDictionary =
         intersectWith (fun a _ -> a) source1 source2
 
     #endif
-
-    /// <summary>Creates an empty read-only dictionary.</summary>
-    [<GeneralizableValue>]
-    let empty<'Key, 'U when 'Key : equality> = Dictionary<'Key, 'U> () :> IReadOnlyDictionary<_,_>
 
     /// <summary>Converts a read-only dictionary to a ResizeArray.</summary>
     /// <param name="source">The source IReadOnlyDictionary.</param>

--- a/src/FSharpPlus/Extensions/IReadOnlyDictionary.fs
+++ b/src/FSharpPlus/Extensions/IReadOnlyDictionary.fs
@@ -70,6 +70,31 @@ module IReadOnlyDictionary =
             dct.Add (k, mapper v)
         dct :> IReadOnlyDictionary<'Key, 'U>
 
+    /// <summary>Applies each function in the read-only dictionary of functions to the corresponding value in the read-only dictionary of values,
+    /// producing a new read-only dictionary of values.</summary>
+    /// <remarks>
+    /// If a key is present in the function dictionary but not in the value dictionary, that key is simply ignored.
+    /// If a key is present in the value dictionary but not in the function dictionary, that key is also ignored.
+    /// </remarks>
+    /// <param name="f">The read-only dictionary of functions.</param>
+    /// <param name="x">The read-only dictionary of values.</param>
+    /// <returns>The resulting read-only dictionary of values.</returns>
+    /// <typeparam name="'Key">The type of the keys in the read-only dictionaries.</typeparam>
+    /// <typeparam name="'T">The type of the values in the read-only dictionary of values.</typeparam>
+    /// <typeparam name="'U">The type of the values in the resulting read-only dictionary.</typeparam>    
+    /// <returns>A read-only dictionary of values.</returns>
+    /// <remarks>
+    /// This function is useful for applying a set of transformations to a read-only dictionary of values,
+    /// where each transformation is defined by a function in a read-only dictionary of functions.
+    /// </remarks>
+    let apply (f: IReadOnlyDictionary<'Key, _>) (x: IReadOnlyDictionary<'Key, 'T>) : IReadOnlyDictionary<'Key, 'U> =
+        let dct = Dictionary ()
+        for KeyValue (k, vf) in f do
+            match x.TryGetValue k with
+            | true, vx -> dct.Add (k, vf vx)
+            | _        -> ()
+        dct :> IReadOnlyDictionary<'Key, 'U>
+    
     /// <summary>Creates a read-only dictionary value from a pair of read-only dictionaries,
     /// using a function to combine them.</summary>
     /// <remarks>Keys that are not present on both read-only dictionaries are dropped.</remarks>

--- a/src/FSharpPlus/Extensions/Map.fs
+++ b/src/FSharpPlus/Extensions/Map.fs
@@ -49,6 +49,29 @@ module Map =
     /// <returns>The mapped Map.</returns>
     let mapValues f (x: Map<'Key, 'T>) = Map.map (fun _ -> f) x
 
+    /// <summary>Applies each function in the Map of functions to the corresponding value in the Map of values,
+    /// producing a new Map of values.</summary>
+    /// <remarks>
+    /// If a key is present in the function Map but not in the value Map, that key is simply ignored.
+    /// If a key is present in the value Map but not in the function Map, that key is also ignored.
+    /// </remarks>
+    /// <param name="f">The Map of functions.</param>
+    /// <param name="x">The Map of values.</param>
+    /// <returns>The resulting Map of values.</returns>
+    /// <typeparam name="'Key">The type of the keys in the dictionaries.</typeparam>
+    /// <typeparam name="'T">The type of the values in the Map of values.</typeparam>
+    /// <typeparam name="'U">The type of the values in the resulting Map.</typeparam>    
+    /// <returns>A Map of values.</returns>
+    /// <remarks>
+    /// This function is useful for applying a set of transformations to a Map of values,
+    /// where each transformation is defined by a function in a Map of functions.
+    /// </remarks>
+    let apply (f: Map<'Key, _>) (x: Map<'Key, 'T>) : Map<'Key, 'U> = Map (seq {
+       for KeyValue (k, vf) in f do
+           match Map.tryFind k x with
+           | Some vx -> yield k, vf vx
+           | _       -> () })
+
     /// <summary>Maps values of two Maps.</summary>
     /// <remarks>Keys that are not present on both Maps are dropped.</remarks>
     /// <param name="f">The mapping function.</param>

--- a/src/FSharpPlus/Extensions/Map.fs
+++ b/src/FSharpPlus/Extensions/Map.fs
@@ -91,21 +91,72 @@ module Map =
 
     /// <summary>Tuples values of two Maps.</summary>
     /// <remarks>Keys that are not present on both Maps are dropped.</remarks>
-    /// <param name="x">The first input Map.</param>
-    /// <param name="y">The second input Map.</param>
+    /// <param name="source1">The first input Map.</param>
+    /// <param name="source2">The second input Map.</param>
     ///
     /// <returns>The tupled Map.</returns>
-    let zip (x: Map<'Key, 'T1>) (y: Map<'Key, 'T2>) = Map <| seq {
-        for KeyValue(k, vx) in x do
-            match Map.tryFind k y with
-            | Some vy -> yield (k, (vx, vy))
+    let zip (source1: Map<'Key, 'T1>) (source2: Map<'Key, 'T2>) = Map <| seq {
+        for KeyValue(k, v1) in source1 do
+            match Map.tryFind k source2 with
+            | Some v2 -> yield (k, (v1, v2))
             | None    -> () }
+
+    /// <summary>Tuples values of three Maps.</summary>
+    /// <remarks>Keys that are not present on all three Maps are dropped.</remarks>
+    /// <param name="source1">The first input Map.</param>
+    /// <param name="source2">The second input Map.</param>
+    /// <param name="source3">The third input Map.</param>
+    ///
+    /// <returns>The tupled Map.</returns>
+    let zip3 (source1: Map<'Key, 'T1>) (source2: Map<'Key, 'T2>) (source3: Map<'Key, 'T3>) = Map <| seq {
+        for KeyValue(k, v1) in source1 do
+            match Map.tryFind k source2, Map.tryFind k source3 with
+            | Some v2, Some v3 -> yield (k, (v1, v2, v3))
+            | _    -> () }
 
     /// <summary>Splits a Map with tuple pair values to two separate Maps.</summary>
     /// <param name="source">The source Map.</param>
     ///
     /// <returns>A tuple of each untupled Map.</returns>
     let unzip (source: Map<'Key, 'T1 * 'T2>) = mapValues fst source, mapValues snd source
+
+    /// <summary>Splits a Map with tuple of 3 values to three separate Maps.</summary>
+    /// <param name="source">The source Map.</param>
+    ///
+    /// <returns>A tuple of each untupled Map.</returns>
+    let unzip3 (source: Map<'Key, 'T1 * 'T2 * 'T3>) =
+        mapValues (fun (x, _, _) -> x) source, mapValues (fun (_, x, _) -> x) source, mapValues (fun (_, _, x) -> x) source
+
+    /// <summary>Flattens a Map of Maps to a single Map.</summary>
+    /// <remarks>
+    /// This function takes a Map where each value is another Map, and combines them into a single Map.
+    /// If a key appears in multiple inner Maps, the value from the last Map is used.
+    /// </remarks>
+    /// <param name="source">The source Map of Maps.</param>
+    ///
+    /// <returns>A single Map with all keys and values from the inner Maps.</returns>
+    let flatten (source: Map<_, _>) : Map<'Key, 'Value> =
+        Map (seq {
+            for KeyValue (k, v) in source do
+                match Map.tryFind k v with
+                | Some v -> yield k, v
+                | _      -> () })
+
+    /// <summary>Maps the values of the original Map using a function that returns a Map.</summary>
+    /// <remarks>
+    /// This function applies a mapping function to each value of the Map, where the mapping function returns a Map.
+    /// The resulting Maps are then combined into a single Map.
+    /// If a key appears in multiple Maps, the value from the last Map is used.
+    /// </remarks>
+    /// <param name="mapper">The mapping function that takes a value and returns a Map.</param>
+    /// <param name="source">The input Map.</param>
+    ///
+    /// <returns>A single Map with all keys and values from the mapped Maps.</returns>
+    let bind (mapper: 'T -> Map<'Key, 'U>) (source: Map<'Key, 'T>) = Map (seq {
+        for KeyValue(k, v) in source do
+            match Map.tryFind k (mapper v) with
+            | Some v -> yield k, v
+            | _      -> () })
 
     /// Returns the union of two maps, using the combiner function for duplicate keys.
     let unionWith combiner (source1: Map<'Key, 'Value>) (source2: Map<'Key, 'Value>) =

--- a/tests/FSharpPlus.Tests/Folds.fs
+++ b/tests/FSharpPlus.Tests/Folds.fs
@@ -36,3 +36,20 @@ module Folds =
         #if TEST_TRACE
         CollectionAssert.AreEqual (["ToSeq seq"], Traces.get())
         #endif
+
+    [<Test>]
+    let dictFolds () =
+        let r1 = dict         [1, 2; 3, 4] |> fold (fun acc v -> acc + v) 0
+        let r2 = readOnlyDict [1, 2; 3, 4] |> fold (fun acc v -> acc + v) 0
+        let r3 = Map.ofSeq    [1, 2; 3, 4] |> fold (fun acc v -> acc + v) 0
+        let r4 = dict         [1, 2; 3, 4] |> foldMap ((+) 10)
+        let r5 = readOnlyDict [1, 2; 3, 4] |> foldMap ((+) 10)
+        let r6 = Map.ofSeq    [1, 2; 3, 4] |> foldMap ((+) 10)
+        Assert.AreEqual (6, r1)
+        Assert.AreEqual (6, r2)
+        Assert.AreEqual (6, r3)
+        Assert.AreEqual (26, r4)
+        Assert.AreEqual (26, r5)
+        Assert.AreEqual (26, r6)
+
+        


### PR DESCRIPTION
There were several missing utility functions for dictionary-like data structures. This PR includes:

 - Additional helper functions for types that implement dictionary-like interfaces (IDictionary, Map, etc.)
 - Enhanced support for common dictionary operations that were previously missing from the library
 - Improved consistency in the API surface area for dict-like types
 - Internal re-use of such helper functions, improving readability of existing code

This PR fills gaps in the dictionary/map function coverage, making the library more complete and consistent for developers working with key-value data structures.